### PR TITLE
fix(backend): ZEAL_FAIL default False em desenvolvimento

### DIFF
--- a/backend/config/settings/development.py
+++ b/backend/config/settings/development.py
@@ -13,7 +13,7 @@ ENABLE_ZEAL = env.bool("ENABLE_ZEAL", default=True)
 if ENABLE_ZEAL:
     INSTALLED_APPS += ["zeal"]
     MIDDLEWARE = ["zeal.middleware.ZealotMiddleware", *MIDDLEWARE]
-    ZEAL_FAIL = True
+    ZEAL_FAIL = env.bool("ZEAL_FAIL", default=False)
     ZEAL_LOG = True
 
 DATABASES = {


### PR DESCRIPTION
Django-zeal estava com ZEAL_FAIL=True, quebrando o fluxo em dev ao lançar exceção em qualquer N+1 query. Agora:

- ZEAL_FAIL default False (não quebra, só loga)
- Configurável via env var ZEAL_FAIL para CI/QA
- ZEAL_LOG continua True para visibilidade

Closes #92