### PR TITLE
docs: document Astro landing page separation across all docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ Nossa documentação segue o princípio Diátaxis. Escolha sua rota de leitura c
 ## 🛠 Tech Stack (Resumo)
 
 - **Backend:** Django 5.2 + Django Ninja (API-First).
-- **Frontend:** React 19 + TypeScript + Tailwind CSS + shadcn/ui.
+- **Frontend (App):** React 19 + TypeScript + Tailwind CSS + shadcn/ui.
+- **Landing Page:** Astro 5 + React + Tailwind CSS (SEO-first).
 - **Database:** PostgreSQL (Neon).
-- **Infra:** Docker, Cloud Run, Cloudflare R2.
+- **Infra:** Docker, Cloud Run, Vercel, Cloudflare R2.
 
 > 📖 **Detalhes completos da Stack:** [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
 
@@ -63,7 +64,8 @@ make superuser        # Crie seu acesso admin
 ```
 wedding_management/
 ├── backend/                  # Django Ninja API
-├── frontend/                # React SPA
+├── frontend/                # React SPA (App principal)
+├── landing/                 # Landing page institucional (Astro + SEO)
 ├── docs/                    # Documentação técnica (Princípio Diátaxis)
 ├── .env                     # Variáveis de ambiente
 ├── Makefile                 # Automação de comandos

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Nossa documentação segue o princípio Diátaxis. Escolha sua rota de leitura c
 
 - **Backend:** Django 5.2 + Django Ninja (API-First).
 - **Frontend (App):** React 19 + TypeScript + Tailwind CSS + shadcn/ui.
-- **Landing Page:** Astro 5 + React + Tailwind CSS (SEO-first).
+- **Landing Page:** Astro 6 + React + Tailwind CSS (SEO-first).
 - **Database:** PostgreSQL (Neon).
 - **Infra:** Docker, Cloud Run, Vercel, Cloudflare R2.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,14 +13,15 @@
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │                      FRONTEND LAYER                          │
-│  ┌──────────────────────────────────────────────────────┐   │
-│  │  React 19 + Vite 7 + TypeScript 5                    │   │
-│  │  - Tailwind CSS v4 (styling)                         │   │
-│  │  - Zustand 5 (state management)                      │   │
-│  │  - TanStack Query 5 (data fetching)                  │   │
-│  │  - Axios (HTTP transport — gerenciado pelo Orval, não usar diretamente)                               │   │
-│  └──────────────────────────────────────────────────────┘   │
-│                           ↕ HTTPS (JWT)                      │
+│  ┌──────────────────────────┐  ┌──────────────────────────┐ │
+│  │  React SPA (App)        │  │  Astro Landing Page      │ │
+│  │  React 19 + Vite 7      │  │  Astro 5 + React        │ │
+│  │  - Tailwind CSS v4      │  │  - Tailwind CSS v4      │ │
+│  │  - Zustand 5            │  │  - shadcn/ui            │ │
+│  │  - TanStack Query 5     │  │  - SEO-first SSR        │ │
+│  │  - Orval hooks          │  │  - simaceito.site       │ │
+│  └──────────────────────────┘  └──────────────────────────┘ │
+│                          ↕ HTTPS (JWT ou público)           │
 │  ┌──────────────────────────────────────────────────────┐   │
 │  │  Vercel Edge Network (CDN Global)                    │   │
 │  └──────────────────────────────────────────────────────┘   │
@@ -160,6 +161,39 @@ frontend/src/
 ├── stores/           # Zustand stores
 └── types/            # TypeScript definitions
 ```
+
+---
+
+### 2.2.1 Landing Page (Astro)
+
+A landing page institucional foi separada do SPA principal para garantir **SEO otimizado** e independência de deploy:
+
+**Framework:**
+
+```json
+{
+  "astro": "^5.x",
+  "react": "^19.x",
+  "tailwindcss": "^4.x"
+}
+```
+
+**Estrutura:**
+
+```
+landing/
+├── src/
+│   ├── components/      # Componentes Astro/React
+│   ├── layouts/         # Layouts Astro
+│   ├── pages/           # Rotas SSR/SSG
+│   ├── styles/          # Estilos globais
+│   └── lib/             # Utilitários
+├── public/              # Assets estáticos
+├── astro.config.mjs     # Configuração Astro
+└── components.json      # shadcn/ui config
+```
+
+**Deploy:** Vercel (projeto separado do SPA), domínio `simaceito.site`.
 
 ---
 
@@ -502,7 +536,13 @@ Ver [ADR-001](ADR/001-why-cloud-run.md).
 
 ---
 
-### 4.2 Vercel (Frontend)
+### 4.2 Vercel (Frontend — App + Landing)
+
+O frontend está dividido em **dois projetos Vercel independentes**:
+
+#### 4.2.1 React SPA (App)
+
+**Domínio:** `app.simaceito.site`
 
 **Configuração:**
 
@@ -546,11 +586,34 @@ export default defineConfig({
 });
 ```
 
-**Custos do Hobby Tier:**
+#### 4.2.2 Astro Landing Page
+
+**Domínio:** `simaceito.site`
+
+**Configuração:**
+
+```json
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "framework": "astro",
+  "env": {
+    "PUBLIC_API_URL": "https://api.simaceito.site"
+  }
+}
+```
+
+**Benefícios da separação:**
+- SEO nativo (SSR/SSG via Astro sem cliente React pesado)
+- Deploy independente — landing não quebra em deploy do app
+- Bundle pequeno — sem TanStack Query, Zustand, Orval no carregamento inicial
+- Preview deployments por PR no Vercel sem afetar o app
+
+**Custos do Hobby Tier (ambos projetos):**
 
 - Build time: Ilimitado
-- Bandwidth: 100GB/mês
-- **Estimativa MVP:** 10GB/mês (R$ 0/mês)
+- Bandwidth: 100GB/mês (compartilhado entre projetos)
+- **Estimativa MVP:** 15GB/mês (R$ 0/mês)
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,10 +15,10 @@
 │                      FRONTEND LAYER                          │
 │  ┌──────────────────────────┐  ┌──────────────────────────┐ │
 │  │  React SPA (App)        │  │  Astro Landing Page      │ │
-│  │  React 19 + Vite 7      │  │  Astro 5 + React        │ │
+ │  │  React 19 + Vite 7      │  │  Astro 6 + React        │ │
 │  │  - Tailwind CSS v4      │  │  - Tailwind CSS v4      │ │
 │  │  - Zustand 5            │  │  - shadcn/ui            │ │
-│  │  - TanStack Query 5     │  │  - SEO-first SSR        │ │
+│  │  - TanStack Query 5     │  │  - SEO-first SSG        │ │
 │  │  - Orval hooks          │  │  - simaceito.site       │ │
 │  └──────────────────────────┘  └──────────────────────────┘ │
 │                          ↕ HTTPS (JWT ou público)           │
@@ -172,7 +172,7 @@ A landing page institucional foi separada do SPA principal para garantir **SEO o
 
 ```json
 {
-  "astro": "^5.x",
+  "astro": "^6.x",
   "react": "^19.x",
   "tailwindcss": "^4.x"
 }
@@ -185,7 +185,7 @@ landing/
 ├── src/
 │   ├── components/      # Componentes Astro/React
 │   ├── layouts/         # Layouts Astro
-│   ├── pages/           # Rotas SSR/SSG
+│   ├── pages/           # Rotas SSG
 │   ├── styles/          # Estilos globais
 │   └── lib/             # Utilitários
 ├── public/              # Assets estáticos
@@ -604,7 +604,7 @@ export default defineConfig({
 ```
 
 **Benefícios da separação:**
-- SEO nativo (SSR/SSG via Astro sem cliente React pesado)
+- SEO nativo (SSG via Astro sem cliente React pesado)
 - Deploy independente — landing não quebra em deploy do app
 - Bundle pequeno — sem TanStack Query, Zustand, Orval no carregamento inicial
 - Preview deployments por PR no Vercel sem afetar o app

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -61,8 +61,11 @@ Se preferir rodar sem containers, você precisará do **[UV](https://docs.astral
 cd backend && uv sync --group dev
 uv run python manage.py runserver
 
-# Frontend
+# Frontend — App principal (React SPA)
 cd frontend && npm ci && npm run dev
+
+# Landing page (Astro)
+cd landing && npm install && npm run dev
 ```
 
 ### Qualidade e Testes


### PR DESCRIPTION
- Add landing/ to project structure in README
- Update architecture diagram to show both React SPA and Astro landing page
- Add section 2.2.1 for Astro Landing Page in architecture docs
- Split Vercel section (4.2) into 4.2.1 (React SPA) and 4.2.2 (Astro Landing)
- Add landing page dev instructions to environment guide
- Update tech stack summary to include Astro and Vercel