### PR TITLE
fix(backend): mark_overdue_installments query race condition

### DIFF
--- a/backend/apps/finances/management/commands/mark_overdue_installments.py
+++ b/backend/apps/finances/management/commands/mark_overdue_installments.py
@@ -14,19 +14,14 @@ class Command(BaseCommand):
 
     def handle(self, *args, **kwargs):
         today = date.today()
-        count = Installment.objects.filter(
-            status=Installment.StatusChoices.PENDING,
-            due_date__lt=today,
-        ).count()
-
-        if count == 0:
-            self.stdout.write(self.style.SUCCESS("Nenhuma parcela vencida encontrada."))
-            return
-
         updated = Installment.objects.filter(
             status=Installment.StatusChoices.PENDING,
             due_date__lt=today,
         ).update(status=Installment.StatusChoices.OVERDUE)
+
+        if updated == 0:
+            self.stdout.write(self.style.SUCCESS("Nenhuma parcela vencida encontrada."))
+            return
 
         self.stdout.write(
             self.style.WARNING(


### PR DESCRIPTION
## Description

This PR resolves a database race condition in the `mark_overdue_installments` management command. 

Previously, the command executed two database queries:
1. A `.count()` check to see if any installments were overdue.
2. A `.update()` command to mark those same installments as overdue.

In a concurrent production environment, installments could change status between the count and update calls, leading to potential inconsistencies and inaccurate logged metrics. 

This PR updates the command to execute a single `.update()` call directly. Since Django's `QuerySet.update()` returns the number of rows matched and updated, we now use that return value directly to determine if any rows were processed and log it.

Closes #90