### PR TITLE
fix(landing): solve react/react-dom version mismatch

### DIFF
--- a/landing/package-lock.json
+++ b/landing/package-lock.json
@@ -19,7 +19,7 @@
         "lucide-react": "^1.17.0",
         "radix-ui": "^1.5.0",
         "react": "^19.2.7",
-        "react-dom": "^19.2.6",
+        "react-dom": "^19.2.7",
         "shadcn": "^4.8.0",
         "tailwind-merge": "^3.6.0",
         "tailwindcss": "^4.3.0",
@@ -9620,15 +9620,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.6"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-refresh": {

--- a/landing/package.json
+++ b/landing/package.json
@@ -23,7 +23,7 @@
     "lucide-react": "^1.17.0",
     "radix-ui": "^1.5.0",
     "react": "^19.2.7",
-    "react-dom": "^19.2.6",
+    "react-dom": "^19.2.7",
     "shadcn": "^4.8.0",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.0",


### PR DESCRIPTION
Bumps `react-dom` to `19.2.7` in the `landing` workspace to match `react`'s version (`19.2.7`) and resolve the React version mismatch build error that failed in the CI/CD pipeline on `main`.