### PR TITLE
chore(backend): synchronize lockfile metadata constraints

### DIFF
--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1491,7 +1491,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "django", specifier = ">=5.2.9,<6.0" },
-    { name = "django-cors-headers", specifier = ">=4.6.0,<4.7" },
+    { name = "django-cors-headers", specifier = ">=4.6.0,<4.10" },
     { name = "django-environ", specifier = ">=0.12.0,<1.0" },
     { name = "django-ninja", specifier = ">=1.6.2" },
     { name = "django-ninja-jwt", specifier = ">=5.4.4" },
@@ -1507,12 +1507,12 @@ dev = [
     { name = "bandit", specifier = ">=1.9.3,<2.0" },
     { name = "detect-secrets", specifier = ">=1.5.0" },
     { name = "django-extensions", specifier = ">=4.1,<4.2" },
-    { name = "django-stubs", specifier = ">=5.2.7,<6.0" },
+    { name = "django-stubs", specifier = ">=5.2.7,<7.0" },
     { name = "django-zeal", specifier = ">=2.0.4,<3.0" },
     { name = "factory-boy", specifier = ">=3.3.1,<3.4" },
     { name = "faker", specifier = ">=34.0.0,<35.0" },
     { name = "ipython", specifier = ">=9.8.0,<10.0" },
-    { name = "mypy", specifier = ">=1.18.2,<2.0" },
+    { name = "mypy", specifier = ">=1.18.2,<3.0" },
     { name = "pre-commit", specifier = ">=3.7.1,<3.8" },
     { name = "pytest", specifier = ">=8.3.4,<9.0" },
     { name = "pytest-cov", specifier = ">=6.0.0,<7.0" },


### PR DESCRIPTION
Sincroniza o arquivo `backend/uv.lock` com as regras de constraints de dependências atualizadas no `pyproject.toml` da `main` (referentes a `mypy`, `django-stubs` e `django-cors-headers`), mantendo o lockfile limpo e consistente.