### PR TITLE
chore(ci): ignore auto-generated files in CodeQL analysis

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,0 +1,5 @@
+name: "CodeQL Custom Configuration"
+
+paths-ignore:
+  - 'frontend/src/api/generated/**'
+  - '**/migrations/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,6 +37,7 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
+          config-file: .github/codeql-config.yml
           # Caso queira adicionar pacotes de queries estendidos ou customizados:
           # queries: +security-extended,security-and-quality
 


### PR DESCRIPTION
Cria a configuração `.github/codeql-config.yml` para excluir a pasta de código gerado pelo Orval (`frontend/src/api/generated/`) e as migrações do Django (`**/migrations/**`) das varreduras do CodeQL. Isso remove todos os alertas redundantes (como os de escapes inúteis em Regex) do painel de segurança do GitHub Actions.