### PR TITLE
fix(ci): add id-token write permission to ai-docs-review workflow

### DIFF
--- a/.github/workflows/ai-docs-review.yml
+++ b/.github/workflows/ai-docs-review.yml
@@ -13,6 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  id-token: write
   contents: read
   pull-requests: write
 


### PR DESCRIPTION
Adiciona a permissão `id-token: write` ao workflow `ai-docs-review.yml`. Essa permissão é necessária para que a action do OpenCode consiga obter o token OIDC do GitHub Actions e autenticar com sucesso a chamada à API externa.