### PR TITLE
fix(frontend): replace client-side expenses.slice(0,5) with server-side limit

### DIFF
--- a/frontend/src/features/finances/components/FinancesView.test.tsx
+++ b/frontend/src/features/finances/components/FinancesView.test.tsx
@@ -50,8 +50,10 @@ describe("WeddingFinancesView", () => {
 
   beforeEach(() => {
     vi.mocked(useWeddingBudget).mockReturnValue(defaultBudgetData as any);
-    vi.mocked(useFinancesExpensesList).mockReturnValue(
-      defaultExpensesData as any,
+    vi.mocked(useFinancesExpensesList).mockImplementation(
+      (_params?: { wedding_id?: string | null; limit?: number; offset?: number }) => {
+        return defaultExpensesData as any;
+      },
     );
   });
 
@@ -161,7 +163,7 @@ describe("WeddingFinancesView", () => {
       status: "PARTIALLY_PAID",
     };
 
-    vi.mocked(useFinancesExpensesList).mockReturnValue({
+    const fullExpensesData = {
       data: {
         data: {
           items: [mockExpense],
@@ -169,7 +171,26 @@ describe("WeddingFinancesView", () => {
         },
       },
       isLoading: false,
-    } as any);
+    };
+
+    const recentExpensesData = {
+      data: {
+        data: {
+          items: [mockExpense],
+          count: 1,
+        },
+      },
+      isLoading: false,
+    };
+
+    vi.mocked(useFinancesExpensesList).mockImplementation(
+      (params?: { wedding_id?: string | null; limit?: number; offset?: number }) => {
+        if (params?.limit === 5) {
+          return recentExpensesData as any;
+        }
+        return fullExpensesData as any;
+      },
+    );
 
     render(<WeddingFinancesView weddingUuid="w-1" />);
 
@@ -178,5 +199,9 @@ describe("WeddingFinancesView", () => {
       // Appears in both RecentExpenses card and ExpensesTable rows
       expect(matches.length).toBeGreaterThanOrEqual(2);
     });
+
+    expect(useFinancesExpensesList).toHaveBeenCalledWith(
+      expect.objectContaining({ wedding_id: "w-1", limit: 5 }),
+    );
   });
 });

--- a/frontend/src/features/finances/components/FinancesView.test.tsx
+++ b/frontend/src/features/finances/components/FinancesView.test.tsx
@@ -51,7 +51,7 @@ describe("WeddingFinancesView", () => {
   beforeEach(() => {
     vi.mocked(useWeddingBudget).mockReturnValue(defaultBudgetData as any);
     vi.mocked(useFinancesExpensesList).mockImplementation(
-      (_params?: { wedding_id?: string | null; limit?: number; offset?: number }) => {
+      () => {
         return defaultExpensesData as any;
       },
     );

--- a/frontend/src/features/finances/components/FinancesView.tsx
+++ b/frontend/src/features/finances/components/FinancesView.tsx
@@ -41,7 +41,7 @@ export function WeddingFinancesView({ weddingUuid }: WeddingFinancesViewProps) {
   const { data: expensesResponse, isLoading: isExpensesLoading } =
     useFinancesExpensesList({ wedding_id: weddingUuid });
 
-  const { data: recentExpensesResponse } =
+  const { data: recentExpensesResponse, isLoading: isRecentExpensesLoading } =
     useFinancesExpensesList({ wedding_id: weddingUuid, limit: 5 });
 
   const handleExpenseCreated = () => {
@@ -62,7 +62,7 @@ export function WeddingFinancesView({ weddingUuid }: WeddingFinancesViewProps) {
     });
   };
 
-  if (isBudgetLoading || isExpensesLoading) {
+  if (isBudgetLoading || isExpensesLoading || isRecentExpensesLoading) {
     return (
       <div className="flex items-center justify-center h-64">
         <p className="text-zinc-500 animate-pulse">

--- a/frontend/src/features/finances/components/FinancesView.tsx
+++ b/frontend/src/features/finances/components/FinancesView.tsx
@@ -41,10 +41,16 @@ export function WeddingFinancesView({ weddingUuid }: WeddingFinancesViewProps) {
   const { data: expensesResponse, isLoading: isExpensesLoading } =
     useFinancesExpensesList({ wedding_id: weddingUuid });
 
+  const { data: recentExpensesResponse } =
+    useFinancesExpensesList({ wedding_id: weddingUuid, limit: 5 });
+
   const handleExpenseCreated = () => {
     setCreateDialogOpen(false);
     queryClient.invalidateQueries({
       queryKey: getFinancesExpensesListQueryKey({ wedding_id: weddingUuid }),
+    });
+    queryClient.invalidateQueries({
+      queryKey: getFinancesExpensesListQueryKey({ wedding_id: weddingUuid, limit: 5 }),
     });
     queryClient.invalidateQueries({
       queryKey: getFinancesBudgetsForWeddingQueryKey(weddingUuid),
@@ -67,6 +73,7 @@ export function WeddingFinancesView({ weddingUuid }: WeddingFinancesViewProps) {
   }
 
   const expenses = expensesResponse?.data?.items || [];
+  const recentExpensesItems = recentExpensesResponse?.data?.items || [];
 
   return (
     <div className="space-y-8 pb-12">
@@ -105,7 +112,7 @@ export function WeddingFinancesView({ weddingUuid }: WeddingFinancesViewProps) {
 
       {/* Despesas Recentes (cards) */}
       <WeddingFinancesRecentExpenses
-        expenses={expenses.slice(0, 5)}
+        expenses={recentExpensesItems}
         onAddExpense={() => setCreateDialogOpen(true)}
       />
 
@@ -118,6 +125,12 @@ export function WeddingFinancesView({ weddingUuid }: WeddingFinancesViewProps) {
             queryClient.invalidateQueries({
               queryKey: getFinancesExpensesListQueryKey({
                 wedding_id: weddingUuid,
+              }),
+            });
+            queryClient.invalidateQueries({
+              queryKey: getFinancesExpensesListQueryKey({
+                wedding_id: weddingUuid,
+                limit: 5,
               }),
             });
             queryClient.invalidateQueries({


### PR DESCRIPTION
## 📝 Resumo do Pull Request

### O que muda
- Adiciona nova chamada `useFinancesExpensesList` com parâmetro `limit: 5` para buscar apenas as 5 despesas mais recentes do servidor
- Substitui `expenses.slice(0, 5)` (filtragem client-side) por `recentExpensesItems` (dados já limitados pelo servidor)
- Invalida a query key com `limit: 5` ao criar ou excluir despesas, mantendo a lista de recentes atualizada

### Por quê
A API já suporta o parâmetro `limit` para paginação, mas o frontend ignorava esse recurso e fazia o slice manualmente após baixar todas as despesas. A antiga abordagem baixava o dataset completo de despesas apenas para exibir 5 itens, causando tráfego desnecessário e pior performance — especialmente prejudicial para organizadores com muitas despesas registradas.

### Como testar
- Criar mais de 5 despesas para um casamento e verificar que a seção "Despesas Recentes" exibe apenas 5 cards
- Confirmar que ao criar uma nova despesa a lista de recentes é atualizada corretamente
- Confirmar que ao excluir um orçamento vinculado a despesas recentes a lista também é atualizada
- Executar `make test` no frontend para garantir que os testes existentes continuam passando

closes #76 

---

## 🛠️ Checklist do Desenvolvedor (Quality Gates)

Antes de abrir a PR ou marcar como pronta para revisão, certifique-se de que cumpriu os seguintes requisitos:

- [ ] **Lint & Format:** Executei `make lint` localmente e o código está formatado (Ruff/ESLint).
- [ ] **Testes locais:** Executei `make test` e todos os testes passaram com sucesso.
- [ ] **Migrações:** Se houver alterações em modelos do Django, verifiquei com `make migrate-check` (evitando falhas de makemigrations no CI).
- [ ] **Segurança (Secrets):** Verifiquei que nenhuma credencial, chave de API ou segredo estático foi exposto no código.
- [ ] **Arquitetura (Backend):** Toda a lógica de negócio está em `services.py` (e não em `api.py`) e as queries filtram por tenant usando `for_tenant(company)`.
- [ ] **Arquitetura (Frontend):** Não utilizei `fetch` ou `axios` manualmente; consumi a API exclusivamente pelos hooks gerados pelo Orval.

---

## 🤖 Interagindo com o OpenCode AI Assistant

Este repositório está integrado com o **OpenCode Assistant** para automatizar tarefas. Você pode interagir com o agente diretamente nos comentários desta PR utilizando o comando `/oc`.

> [!IMPORTANT]
> Apenas **Owners**, **Members** e **Collaborators** do repositório têm autorização para disparar o assistente. Comentários de usuários externos serão ignorados por segurança.

### Comandos Úteis que você pode usar:

* **Aplicar Correções Automáticas:**
  Se a revisão automática (ou um revisor humano) apontar um problema em uma linha de código, basta responder na mesma thread do comentário com:
  > `/oc corrija isso` ou `/oc corrija usando docker compose rm`
  *(O assistente fará o checkout da branch, aplicará a correção, rodará os testes e subirá o commit automaticamente).*

* **Escrever Testes Automatizados:**
  Peça para o assistente gerar a suíte de testes de um arquivo recém-criado:
  > `/oc crie os testes unitários da função X em apps/weddings/services.py`

* **Validar contra Diretrizes do Projeto:**
  Peça para ele checar se o código atende às especificações gerais:
  > `/oc valide as alterações do backend contra as regras do AGENTS.md`

* **Explicar trechos de código:**
  > `/oc explique o funcionamento do fluxo de autenticação WIF no integrity-ci.yml`
