### PR TITLE
feat/codecov-badges

### DIFF
--- a/.github/workflows/integrity-ci.yml
+++ b/.github/workflows/integrity-ci.yml
@@ -119,7 +119,15 @@ jobs:
           uv run python manage.py makemigrations --check --dry-run
           uv run python manage.py migrate --noinput
       - name: Pytest
-        run: cd backend && uv run pytest --cov=apps --cov-report=term -v
+        run: cd backend && uv run pytest --cov=apps --cov-report=term --cov-report=xml -v
+
+      - name: Upload Coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: backend/coverage.xml
+          flags: backend
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   # ----------------------------------------------------------------------------
   # JOB 3: FRONTEND INTEGRITY
@@ -143,6 +151,14 @@ jobs:
           cd frontend
           npm ci
           npm run test:ci
+
+      - name: Upload Coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: frontend/coverage/lcov.info
+          flags: frontend
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   # ----------------------------------------------------------------------------
   # JOB 3.5: LANDING INTEGRITY

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # 💍 Wedding Management System
 
 [![CI](https://github.com/Rafaelp122/wedding_management/actions/workflows/integrity-ci.yml/badge.svg)](https://github.com/Rafaelp122/wedding_management/actions/workflows/integrity-ci.yml)
+[![codecov - backend](https://codecov.io/gh/Rafaelp122/wedding_management/branch/main/graph/badge.svg?flag=backend)](https://codecov.io/gh/Rafaelp122/wedding_management)
+[![codecov - frontend](https://codecov.io/gh/Rafaelp122/wedding_management/branch/main/graph/badge.svg?flag=frontend)](https://codecov.io/gh/Rafaelp122/wedding_management)
 [![Website](https://img.shields.io/badge/website-simaceito.site-0ea5e9)](https://simaceito.site)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.12+-3776AB)](https://python.org)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,28 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+flags:
+  backend:
+    paths:
+      - backend/
+    carryforward: true
+  frontend:
+    paths:
+      - frontend/
+    carryforward: true
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: true

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview",
     "generate:api": "orval",
     "test": "vitest run",
-    "test:ci": "npm run build && vitest run",
+    "test:ci": "npm run build && vitest run --coverage",
     "type-check": "tsc -p tsconfig.app.json --noEmit"
   },
   "dependencies": {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -20,6 +20,7 @@ export default mergeConfig(
       coverage: {
         provider: "v8",
         enabled: false,
+        reporter: ["text", "lcov"],
         include: ["src/**/*.{ts,tsx}"],
         exclude: [
           "src/api/generated/**",


### PR DESCRIPTION
## 📝 Resumo do Pull Request

### O que muda
- Adiciona upload de relatórios de cobertura para o Codecov nos jobs de backend e frontend do CI (`integrity-ci.yml`)
- Cria o arquivo `codecov.yml` com configuração de flags (backend/frontend), thresholds de 1% e carryforward
- Adiciona badges de cobertura do Codecov no README.md
- Ativa geração de relatório XML de cobertura no backend via `pytest --cov-report=xml`
- Ativa geração de relatório LCOV no frontend (vitest com `--coverage` e reporter `lcov`)

### Por quê
- Monitorar a cobertura de testes ao longo do tempo e identificar regressões antes do merge
- Integrar o Codecov como ferramenta de qualidade, permitindo bloquear PRs que reduzam significativamente a cobertura
- Tornar visível (através de badges no README) o nível de cobertura do projeto para contribuidores e stakeholders

### Como testar
- Verificar os logs de execução do CI neste PR e confirmar que as etapas "Upload Coverage to Codecov" foram bem-sucedidas (tanto backend quanto frontend)
- Acessar o dashboard do Codecov para validar que os relatórios de cobertura foram processados corretamente
- Confirmar que os badges no README refletem os valores corretos de cobertura após o merge na main

Closes https://github.com/Rafaelp122/wedding_management/issues/99

---

## 🛠️ Checklist do Desenvolvedor (Quality Gates)

Antes de abrir a PR ou marcar como pronta para revisão, certifique-se de que cumpriu os seguintes requisitos:

- [ ] **Lint & Format:** Executei `make lint` localmente e o código está formatado (Ruff/ESLint).
- [ ] **Testes locais:** Executei `make test` e todos os testes passaram com sucesso.
- [ ] **Migrações:** Se houver alterações em modelos do Django, verifiquei com `make migrate-check` (evitando falhas de makemigrations no CI).
- [ ] **Segurança (Secrets):** Verifiquei que nenhuma credencial, chave de API ou segredo estático foi exposto no código.
- [ ] **Arquitetura (Backend):** Toda a lógica de negócio está em `services.py` (e não em `api.py`) e as queries filtram por tenant usando `for_tenant(company)`.
- [ ] **Arquitetura (Frontend):** Não utilizei `fetch` ou `axios` manualmente; consumi a API exclusivamente pelos hooks gerados pelo Orval.

---

## 🤖 Interagindo com o OpenCode AI Assistant

Este repositório está integrado com o **OpenCode Assistant** para automatizar tarefas. Você pode interagir com o agente diretamente nos comentários desta PR utilizando o comando `/oc`.

> [!IMPORTANT]
> Apenas **Owners**, **Members** e **Collaborators** do repositório têm autorização para disparar o assistente. Comentários de usuários externos serão ignorados por segurança.

### Comandos Úteis que você pode usar:

* **Aplicar Correções Automáticas:**
  Se a revisão automática (ou um revisor humano) apontar um problema em uma linha de código, basta responder na mesma thread do comentário com:
  > `/oc corrija isso` ou `/oc corrija usando docker compose rm`
  *(O assistente fará o checkout da branch, aplicará a correção, rodará os testes e subirá o commit automaticamente).*

* **Escrever Testes Automatizados:**
  Peça para o assistente gerar a suíte de testes de um arquivo recém-criado:
  > `/oc crie os testes unitários da função X em apps/weddings/services.py`

* **Validar contra Diretrizes do Projeto:**
  Peça para ele checar se o código atende às especificações gerais:
  > `/oc valide as alterações do backend contra as regras do AGENTS.md`

* **Explicar trechos de código:**
  > `/oc explique o funcionamento do fluxo de autenticação WIF no integrity-ci.yml`