### PR TITLE
refactor(frontend): remove dayjs, use date-fns exclusively (#75)

### DIFF
--- a/frontend/src/features/scheduler/components/SchedulerCalendar.tsx
+++ b/frontend/src/features/scheduler/components/SchedulerCalendar.tsx
@@ -1,12 +1,10 @@
 import { memo, useCallback, useMemo, useState } from "react";
-import { Calendar, dayjsLocalizer, type SlotInfo, type View, Views } from "react-big-calendar";
+import { Calendar, dateFnsLocalizer, type SlotInfo, type View, Views } from "react-big-calendar";
 import "react-big-calendar/lib/css/react-big-calendar.css";
 import "./SchedulerCalendar.css";
-import dayjs from "dayjs";
-import "dayjs/locale/pt-br";
+import { format, getDay, startOfWeek } from "date-fns";
+import { ptBR } from "date-fns/locale";
 import { Info } from "lucide-react";
-
-dayjs.locale("pt-br");
 
 import type { EventOut } from "@/api/generated/v1/models/eventOut";
 
@@ -20,7 +18,14 @@ import { Badge } from "@/components/ui/badge";
 
 import { EVENT_LABELS, EVENT_COLORS } from "../constants";
 
-const localizer = dayjsLocalizer(dayjs);
+const locales = { "pt-BR": ptBR };
+
+const localizer = dateFnsLocalizer({
+  format,
+  startOfWeek: (date: Date) => startOfWeek(date, { locale: ptBR }),
+  getDay,
+  locales,
+});
 
 interface CalendarEvent {
   title: string;
@@ -53,12 +58,12 @@ const EventRenderer = memo(function EventRenderer({
               event.resource.event_type}
           </p>
           <p>
-            Início: {dayjs(event.start).format("DD/MM/YYYY HH:mm")}
+            Início: {format(event.start, "dd/MM/yyyy HH:mm")}
           </p>
           {event.resource.end_time ? (
             <p>
               Fim:{" "}
-              {dayjs(event.end).format("DD/MM/YYYY HH:mm")}
+              {format(event.end, "dd/MM/yyyy HH:mm")}
             </p>
           ) : null}
           {event.resource.location ? (


### PR DESCRIPTION
## What

Remove `dayjs` usage from the frontend, using only `date-fns` as the project's date library.

## Changes

- **`SchedulerCalendar.tsx`**: Replaced `dayjs` imports and `dayjsLocalizer` with `date-fns` (`format`, `getDay`, `startOfWeek`) and `dateFnsLocalizer` from `react-big-calendar`
- `dayjs` remains only as a transitive dependency of `react-big-calendar` (not a direct dependency)

## Verification

- [x] Lint passes (`npm run lint`)
- [x] Type-check passes (`tsc --noEmit`)
- [x] All 51 scheduler tests pass (`vitest run src/features/scheduler/`)

Closes #75