### PR TITLE
fix(frontend): remove duplicate toast from connection-error interceptor

### DIFF
--- a/frontend/src/api/interceptors/connection-error.test.ts
+++ b/frontend/src/api/interceptors/connection-error.test.ts
@@ -7,14 +7,7 @@ vi.mock("@sentry/react", () => ({
   captureException: vi.fn(),
 }));
 
-vi.mock("sonner", () => ({
-  toast: {
-    error: vi.fn(),
-  },
-}));
-
 import * as Sentry from "@sentry/react";
-import { toast } from "sonner";
 
 function createMockInstance() {
   const handlers = {
@@ -80,7 +73,7 @@ describe("addConnectionErrorInterceptor", () => {
   });
 
   describe("error handler", () => {
-    it("captures network error to Sentry and shows toast", async () => {
+    it("captures network error to Sentry", async () => {
       const handlers = createMockInstance();
       const error = new AxiosError("Network Error", "ERR_NETWORK");
 
@@ -89,14 +82,10 @@ describe("addConnectionErrorInterceptor", () => {
       expect(Sentry.captureException).toHaveBeenCalledWith(error, {
         tags: { source: "connection-error-interceptor" },
       });
-      expect(toast.error).toHaveBeenCalledWith(
-        "Não foi possível conectar ao servidor. Por favor, tente novamente mais tarde.",
-        { id: "network-error" },
-      );
       await expect(result).rejects.toBe(error);
     });
 
-    it("captures 502 error to Sentry and shows toast", async () => {
+    it("captures 502 error to Sentry", async () => {
       const handlers = createMockInstance();
       const error = new AxiosError(
         "Bad Gateway",
@@ -117,14 +106,10 @@ describe("addConnectionErrorInterceptor", () => {
       expect(Sentry.captureException).toHaveBeenCalledWith(error, {
         tags: { source: "connection-error-interceptor" },
       });
-      expect(toast.error).toHaveBeenCalledWith(
-        "Não foi possível conectar ao servidor. Por favor, tente novamente mais tarde.",
-        { id: "network-error" },
-      );
       await expect(result).rejects.toBe(error);
     });
 
-    it("captures 503 error to Sentry and shows toast", async () => {
+    it("captures 503 error to Sentry", async () => {
       const handlers = createMockInstance();
       const error = new AxiosError(
         "Service Unavailable",
@@ -148,7 +133,7 @@ describe("addConnectionErrorInterceptor", () => {
       await expect(result).rejects.toBe(error);
     });
 
-    it("captures 504 error to Sentry and shows toast", async () => {
+    it("captures 504 error to Sentry", async () => {
       const handlers = createMockInstance();
       const error = new AxiosError(
         "Gateway Timeout",
@@ -191,7 +176,6 @@ describe("addConnectionErrorInterceptor", () => {
       const result = handlers.error?.(error);
 
       expect(Sentry.captureException).not.toHaveBeenCalled();
-      expect(toast.error).not.toHaveBeenCalled();
       await expect(result).rejects.toBe(error);
     });
 

--- a/frontend/src/api/interceptors/connection-error.ts
+++ b/frontend/src/api/interceptors/connection-error.ts
@@ -1,6 +1,5 @@
 import type { AxiosInstance, AxiosResponse } from "axios";
 import * as Sentry from "@sentry/react";
-import { toast } from "sonner";
 
 /**
  * Interceptador de resposta global para capturar falhas críticas de infraestrutura,
@@ -9,8 +8,9 @@ import { toast } from "sonner";
  * Também propaga o X-Request-ID do backend para o Sentry como contexto,
  * permitindo correlacionar erros frontend com logs backend.
  *
- * Utiliza o parâmetro `id` do toast da biblioteca Sonner para evitar a
- * sobreposição/acumulação de múltiplos alertas em chamadas simultâneas.
+ * A exibição de toast para o usuário fica a cargo da camada de UI
+ * (QueryCache, mutation callbacks), que tem contexto para deduplicar
+ * mensagens e adaptar o texto conforme a operação.
  */
 export function addConnectionErrorInterceptor(instance: AxiosInstance) {
   instance.interceptors.response.use(
@@ -33,10 +33,6 @@ export function addConnectionErrorInterceptor(instance: AxiosInstance) {
         (error.response && [502, 503, 504].includes(error.response.status));
 
       if (isConnectionError) {
-        toast.error("Não foi possível conectar ao servidor. Por favor, tente novamente mais tarde.", {
-          id: "network-error",
-        });
-
         Sentry.captureException(error, {
           tags: { source: "connection-error-interceptor" },
         });


### PR DESCRIPTION
## Problema

A mensagem "Não foi possível conectar ao servidor. Por favor, tente novamente mais tarde." aparecia duplicada em erros de rede. O interceptor Axios em `connection-error.ts` mostrava um toast global, e o erro propagava para a camada de UI (QueryCache / mutation `onError`) que mostrava um segundo toast com a mesma mensagem via `getApiErrorInfo()`.

## Solução

Removido o `toast.error` do interceptor. Ele continua reportando ao Sentry e propagando `X-Request-ID`. A exibição de toast ao usuário fica a cargo da camada de UI, que já cobre todos os caminhos de erro.

## Arquivos alterados

- `frontend/src/api/interceptors/connection-error.ts` — removeu import e chamada do sonner toast
- `frontend/src/api/interceptors/connection-error.test.ts` — removeu mock do sonner e assertions de toast

## Testes

```
✅ src/api/interceptors/connection-error.test.ts — 11 tests passed
✅ src/api/error-utils.test.ts — 25 tests passed
✅ src/features/auth/components/LoginForm.test.tsx — 6 tests passed
✅ src/hooks/use-pagination.test.ts — 14 tests passed
```