### PR TITLE
test(users): close coverage gaps — obtain, require_user, factory, model

### DIFF
--- a/backend/apps/users/tests/factories.py
+++ b/backend/apps/users/tests/factories.py
@@ -26,8 +26,9 @@ class UserFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = User
 
-    # Vincula explicitamente a uma Company para evitar dependência oculta
-    # do CustomUserManager em TenantService.create_company().
+    # Vincula explicitamente a uma Company via SubFactory (cross-app).
+    # A alternativa anterior (depender do CustomUserManager._create_user
+    # chamar TenantService.create_company() implicitamente) era pior.
     company = factory.SubFactory("apps.tenants.tests.factories.CompanyFactory")
 
     # Gera emails únicos: planner0@example.com, planner1@example.com...

--- a/backend/apps/users/tests/factories.py
+++ b/backend/apps/users/tests/factories.py
@@ -26,6 +26,10 @@ class UserFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = User
 
+    # Vincula explicitamente a uma Company para evitar dependência oculta
+    # do CustomUserManager em TenantService.create_company().
+    company = factory.SubFactory("apps.tenants.tests.factories.CompanyFactory")
+
     # Gera emails únicos: planner0@example.com, planner1@example.com...
     # Essencial para evitar erros de integridade no seu modelo
     email = factory.Sequence(lambda n: f"planner{n}@example.com")

--- a/backend/apps/users/tests/test_auth.py
+++ b/backend/apps/users/tests/test_auth.py
@@ -1,0 +1,31 @@
+import pytest
+from django.contrib.auth.models import AnonymousUser
+
+from apps.core.exceptions import BusinessRuleViolation
+from apps.users.auth import require_user
+from apps.users.tests.factories import UserFactory
+
+
+pytestmark = pytest.mark.django_db
+
+
+class TestRequireUser:
+    """Testes para require_user()."""
+
+    def test_require_user_authenticated_returns_user(self):
+        """Usuário autenticado deve retornar a instância de User."""
+        user = UserFactory(is_active=True)
+
+        result = require_user(user)
+
+        assert result == user
+        assert result.is_authenticated
+
+    def test_require_user_unauthenticated_raises_error(self):
+        """Usuário não autenticado deve levantar BusinessRuleViolation."""
+        anon = AnonymousUser()
+
+        with pytest.raises(BusinessRuleViolation) as exc_info:
+            require_user(anon)
+
+        assert exc_info.value.code == "authentication_required"

--- a/backend/apps/users/tests/test_models.py
+++ b/backend/apps/users/tests/test_models.py
@@ -90,3 +90,18 @@ class TestUserModel:
             password="pass",
         )
         assert user.email == "USER@domain.com"
+
+
+@pytest.mark.django_db
+class TestUserCompanyProtect:
+    """Testes da constraint on_delete=PROTECT no FK company."""
+
+    def test_delete_company_with_users_raises_protected_error(self):
+        """Não é possível deletar Company que possui Users vinculados."""
+        from django.db.models import ProtectedError
+
+        user = UserFactory()
+        company = user.company
+
+        with pytest.raises(ProtectedError):
+            company.delete()

--- a/backend/apps/users/tests/test_models.py
+++ b/backend/apps/users/tests/test_models.py
@@ -3,6 +3,7 @@
 import pytest
 from django.contrib.auth import get_user_model
 from django.db import IntegrityError
+from django.db import models as db_models
 
 from .factories import AdminFactory, UserFactory
 
@@ -98,10 +99,8 @@ class TestUserCompanyProtect:
 
     def test_delete_company_with_users_raises_protected_error(self):
         """Não é possível deletar Company que possui Users vinculados."""
-        from django.db.models import ProtectedError
-
         user = UserFactory()
         company = user.company
 
-        with pytest.raises(ProtectedError):
+        with pytest.raises(db_models.ProtectedError):
             company.delete()

--- a/backend/apps/users/tests/test_token_service.py
+++ b/backend/apps/users/tests/test_token_service.py
@@ -15,11 +15,51 @@ from ninja.errors import HttpError
 from ninja_jwt.schema import TokenRefreshOutputSchema
 from ninja_jwt.tokens import RefreshToken
 
-from apps.users.schemas import VerifyTokenOut
+from apps.users.schemas import TokenOut, UserDataOut, VerifyTokenOut
 from apps.users.services.token_service import TokenService
 
 
 pytestmark = pytest.mark.django_db
+
+
+class TestTokenServiceObtain:
+    """Testes para TokenService.obtain()."""
+
+    def test_obtain_success(self, user_factory):
+        """Credenciais válidas retornam TokenOut com access + refresh."""
+        user_factory.create(
+            email="auth@example.com", password="secure123", is_active=True
+        )
+
+        result = TokenService.obtain("auth@example.com", "secure123")
+
+        assert isinstance(result, TokenOut)
+        assert isinstance(result.user, UserDataOut)
+        assert result.access
+        assert result.refresh
+        assert result.user.email == "auth@example.com"
+
+    def test_obtain_wrong_password_raises_401(self, user_factory):
+        """Senha incorreta levanta HttpError 401."""
+        user_factory.create(
+            email="auth@example.com", password="secure123", is_active=True
+        )
+
+        with pytest.raises(HttpError) as exc_info:
+            TokenService.obtain("auth@example.com", "wrong")
+
+        assert exc_info.value.status_code == 401
+
+    def test_obtain_inactive_user_raises_401(self, user_factory):
+        """Usuário inativo levanta HttpError 401."""
+        user_factory.create(
+            email="inactive@example.com", password="secure123", is_active=False
+        )
+
+        with pytest.raises(HttpError) as exc_info:
+            TokenService.obtain("inactive@example.com", "secure123")
+
+        assert exc_info.value.status_code == 401
 
 
 class TestTokenServiceRefresh:


### PR DESCRIPTION
Add TokenService.obtain() tests at service layer (was only tested via API integration):
- test_obtain_success: valid credentials return TokenOut
- test_obtain_wrong_password_raises_401: wrong password
- test_obtain_inactive_user_raises_401: inactive user

Add require_user() tests (was at 0% coverage):
- Authenticated user returns the User instance
- AnonymousUser raises BusinessRuleViolation

Fix UserFactory: add explicit company SubFactory to eliminate hidden cross-app dependency on TenantService.create_company().

Add model test: User.company on_delete=PROTECT prevents deleting Company with linked Users.

432 tests passed, 0 failures.