### PR TITLE
refactor(installments): move _delete_payment_event_for_single before instance.delete()

### DIFF
--- a/backend/apps/finances/services/installment_service.py
+++ b/backend/apps/finances/services/installment_service.py
@@ -389,12 +389,11 @@ class InstallmentService:
         expense = instance.expense
 
         try:
+            _delete_payment_event_for_single(company, instance)
+
             instance.delete()
 
-            # Checagem de Ricochete após deleção
             expense.full_clean()
-
-            _delete_payment_event_for_single(company, instance)
 
             logger.warning(
                 f"Parcela uuid={instance.uuid} DESTRUÍDA por company_id={company.id}"


### PR DESCRIPTION
## Summary

Moves the `_delete_payment_event_for_single` call to **before** `instance.delete()` in `InstallmentService.delete`.

## Problem

`_delete_payment_event_for_single(company, instance)` was called **after** `instance.delete()` (line 392). It accesses `instance.expense.wedding`, `instance.expense.name`, and `instance.installment_number` — attributes that persist only in memory after deletion. If `refresh_from_db()` is ever called between the two operations, it breaks.

## Change

```diff
-            instance.delete()
-            expense.full_clean()
-            _delete_payment_event_for_single(company, instance)
+            _delete_payment_event_for_single(company, instance)
+            instance.delete()
+            expense.full_clean()
```

Now the scheduler event cleanup runs while the installment still exists in the database.

Closes #147