### PR TITLE
docs(expense): document intentional self.pk guard in clean() tolerance validation

### DIFF
--- a/backend/apps/finances/models/expense.py
+++ b/backend/apps/finances/models/expense.py
@@ -52,15 +52,25 @@ class Expense(TenantModel, WeddingOwnedMixin):
         return self.name or f"Despesa #{self.pk}"
 
     def clean(self) -> None:
+        """
+        Valida a regra de Tolerância Zero (BR-F01 / ADR-010).
+
+        A verificação só roda para instâncias já persistidas (self.pk existe)
+        porque durante a criação as parcelas ainda não existem — elas são
+        geradas posteriormente por InstallmentService.auto_generate_installments()
+        no service layer (ExpenseService.create).
+
+        O guard self.pk previne um falso positivo no primeiro save, onde
+        a soma das parcelas seria 0 e actual_amount > 0.
+        """
         super().clean()
 
-        # TOLERÂNCIA ZERO: A soma das parcelas deve ser EXATA
         if self.pk and self.actual_amount:
             total_installments = self.installments.aggregate(models.Sum("amount"))[
                 "amount__sum"
             ] or Decimal("0.00")
             if total_installments != self.actual_amount:
                 raise ValidationError(
-                    f"ERRO DE INTEGRIDADE: A soma das parcelas (R${total_installments}) "  # noqa
-                    f"não bate com o valor total (R${self.actual_amount})."
+                    f"ERRO DE INTEGRIDADE: A soma das parcelas (R${total_installments})"
+                    f" não bate com o valor total (R${self.actual_amount})."
                 )

--- a/backend/apps/finances/tests/expenses/test_models.py
+++ b/backend/apps/finances/tests/expenses/test_models.py
@@ -103,3 +103,35 @@ class TestExpenseToleranceZero:
             expense.full_clean()
 
         assert "não bate" in str(exc_info.value).lower()
+
+    def test_expense_creation_skips_tolerance_validation(self, user):
+        """Criação (primeiro save) não valida Tolerância Zero — gap intencional.
+
+        O guard self.pk em Expense.clean() impede a validação durante o
+        primeiro save porque as parcelas ainda não existem. O service layer
+        (ExpenseService.create) é responsável por gerar as parcelas via
+        InstallmentService.auto_generate_installments() após o save.
+
+        Este teste documenta o comportamento esperado: criação via modelo
+        direto (sem service layer) com actual_amount > 0 e sem parcelas
+        passa no primeiro save mas falha em full_clean() posterior.
+        """
+        _, category = _setup_expense(user)
+        expense = Expense(
+            company=category.wedding.company,
+            wedding=category.wedding,
+            category=category,
+            contract=None,
+            name="Teste gap criação",
+            estimated_amount=Decimal("500.00"),
+            actual_amount=Decimal("500.00"),
+        )
+
+        assert expense.pk is None
+        expense.save()
+        assert expense.pk is not None
+
+        with pytest.raises(ValidationError) as exc_info:
+            expense.full_clean()
+
+        assert "não bate" in str(exc_info.value).lower()


### PR DESCRIPTION
## Summary

Documents the intentional design of the `self.pk` guard in `Expense.clean()`. The validation of Tolerância Zero (BR-F01 / ADR-010) is skipped during creation because installments don't exist yet — they are generated afterward by `InstallmentService.auto_generate_installments()` in the service layer.

## Changes

- **models/expense.py**: Added docstring to `clean()` explaining why `self.pk` is checked and that creation-time validation is the service layer's responsibility
- **tests/expenses/test_models.py**: Added `test_expense_creation_skips_tolerance_validation` documenting that:
  - First save passes (gap by design — installments don't exist yet)
  - Subsequent `full_clean()` catches the mismatch

## Related

Closes #65