### PR TITLE
fix: prevent TOCTOU race conditions in BudgetCategory and BudgetService

### DIFF
--- a/backend/apps/finances/models/budget_category.py
+++ b/backend/apps/finances/models/budget_category.py
@@ -86,23 +86,3 @@ class BudgetCategory(TenantModel, WeddingOwnedMixin):
             raise ValidationError(
                 "O orçamento pai deve pertencer ao mesmo casamento desta categoria."
             )
-
-        # TRAVA DE SEGURANÇA: A soma do que foi alocado nesta e nas demais
-        # categorias não pode ultrapassar o teto do orçamento mestre.
-        if self.pk or self.budget_id:
-            budget_total = self.budget.total_estimated
-            siblings_agg = (
-                self.budget.categories.exclude(pk=self.pk).aggregate(
-                    total=models.Sum("allocated_budget")
-                )
-                if self.pk is not None
-                else self.budget.categories.aggregate(
-                    total=models.Sum("allocated_budget")
-                )
-            )
-            allocated_siblings = siblings_agg["total"] or Decimal("0.00")
-            if allocated_siblings + self.allocated_budget > budget_total:
-                raise ValidationError(
-                    f"A soma das categorias alocadas ({allocated_siblings + self.allocated_budget}) "  # noqa
-                    f"excede o teto do orçamento ({budget_total})."
-                )

--- a/backend/apps/finances/services/budget_category_service.py
+++ b/backend/apps/finances/services/budget_category_service.py
@@ -1,11 +1,13 @@
 import logging
+from decimal import Decimal
 from typing import Any
 from uuid import UUID
 
 from django.db import transaction
-from django.db.models import ProtectedError, QuerySet
+from django.db.models import ProtectedError, QuerySet, Sum
 
 from apps.core.exceptions import (
+    BusinessRuleViolation,
     DomainIntegrityError,
     ObjectNotFoundError,
 )
@@ -15,6 +17,29 @@ from apps.weddings.models import Wedding
 
 
 logger = logging.getLogger(__name__)
+
+
+def _validate_budget_cap(category: BudgetCategory, budget: Budget) -> None:
+    """
+    Valida que a soma do allocated_budget de todas as categorias não excede
+    o teto do orçamento mestre.
+    Executada DENTRO de um ``select_for_update()`` para evitar TOCTOU.
+    """
+    siblings_agg = (
+        BudgetCategory.objects.filter(budget=budget)
+        .exclude(pk=category.pk)
+        .aggregate(total=Sum("allocated_budget"))
+    )
+    allocated_siblings = siblings_agg["total"] or Decimal("0.00")
+    if allocated_siblings + category.allocated_budget > budget.total_estimated:
+        raise BusinessRuleViolation(
+            detail=(
+                f"A soma das categorias alocadas "
+                f"({allocated_siblings + category.allocated_budget}) "
+                f"excede o teto do orçamento ({budget.total_estimated})."
+            ),
+            code="budget_cap_exceeded",
+        )
 
 
 class BudgetCategoryService:
@@ -57,14 +82,12 @@ class BudgetCategoryService:
             f"Iniciando criação de Categoria de Orçamento para company_id={company.id}"
         )
 
-        # 1. Resolução Segura do Orçamento Pai (Suporta Instância ou UUID)
         budget_input = data.pop("budget", None)
 
         if isinstance(budget_input, Budget):
             budget = budget_input
         else:
             try:
-                # Segurança estrita: Garante posse da empresa sobre o orçamento
                 budget = Budget.objects.for_tenant(company).get(uuid=budget_input)
             except Budget.DoesNotExist as e:
                 logger.warning(
@@ -75,12 +98,17 @@ class BudgetCategoryService:
                     code="budget_not_found_or_denied",
                 ) from e
 
-        # 2. Injeção de Contexto e Instanciação
+        # TRAVA DE SEGURANÇA (TOCTOU): lock no budget antes de ler soma das categorias
+        budget = (
+            Budget.objects.for_tenant(company).select_for_update().get(pk=budget.pk)
+        )
+
         category = BudgetCategory(
             company=company, wedding=budget.wedding, budget=budget, **data
         )
 
-        # 3. Delegação de Validação ao Model
+        _validate_budget_cap(category, budget)
+
         category.save()
 
         logger.info(f"Categoria de Orçamento criada com sucesso: uuid={category.uuid}")
@@ -95,13 +123,20 @@ class BudgetCategoryService:
             f"Atualizando Categoria uuid={instance.uuid} por company_id={company.id}"
         )
 
-        # Proteção contra sequestro/mudança de árvore financeira
         data.pop("budget", None)
         data.pop("wedding", None)
         data.pop("company", None)
 
         for field, value in data.items():
             setattr(instance, field, value)
+
+        # TRAVA DE SEGURANÇA (TOCTOU): lock no budget antes de re-validar teto
+        budget = (
+            Budget.objects.for_tenant(company)
+            .select_for_update()
+            .get(pk=instance.budget.pk)
+        )
+        _validate_budget_cap(instance, budget)
 
         instance.save()
 
@@ -139,6 +174,7 @@ class BudgetCategoryService:
     def setup_defaults(company: Company, wedding: Wedding, budget: Budget) -> None:
         """
         Cria as categorias iniciais obrigatórias para um novo casamento.
+        É idempotente: se as categorias já existirem, não duplica.
         """
         DEFAULT_CATEGORIES = [
             "Espaço e Buffet",
@@ -151,15 +187,29 @@ class BudgetCategoryService:
 
         logger.info(f"Gerando categorias padrão para o casamento {wedding.uuid}")
 
+        existing_names = set(
+            BudgetCategory.objects.for_tenant(company)
+            .filter(budget=budget)
+            .values_list("name", flat=True)
+        )
+
+        new_names = [n for n in DEFAULT_CATEGORIES if n not in existing_names]
+        if not new_names:
+            logger.info(f"Categorias padrão já existem para budget={budget.uuid}")
+            return
+
         categories = [
             BudgetCategory(
                 company=company,
                 wedding=wedding,
                 budget=budget,
                 name=name,
-                allocated_budget=0,
+                allocated_budget=Decimal("0.00"),
             )
-            for name in DEFAULT_CATEGORIES
+            for name in new_names
         ]
+
+        for cat in categories:
+            cat.full_clean()
 
         BudgetCategory.objects.bulk_create(categories)

--- a/backend/apps/finances/services/budget_category_service.py
+++ b/backend/apps/finances/services/budget_category_service.py
@@ -19,14 +19,17 @@ from apps.weddings.models import Wedding
 logger = logging.getLogger(__name__)
 
 
-def _validate_budget_cap(category: BudgetCategory, budget: Budget) -> None:
+def _validate_budget_cap(
+    company: Company, category: BudgetCategory, budget: Budget
+) -> None:
     """
     Valida que a soma do allocated_budget de todas as categorias não excede
     o teto do orçamento mestre.
     Executada DENTRO de um ``select_for_update()`` para evitar TOCTOU.
     """
     siblings_agg = (
-        BudgetCategory.objects.filter(budget=budget)
+        BudgetCategory.objects.for_tenant(company)
+        .filter(budget=budget)
         .exclude(pk=category.pk)
         .aggregate(total=Sum("allocated_budget"))
     )
@@ -45,7 +48,8 @@ def _validate_budget_cap(category: BudgetCategory, budget: Budget) -> None:
 class BudgetCategoryService:
     """
     Camada de serviço para gestão de categorias de orçamento.
-    Delega a validação matemática rigorosa de teto financeiro para o Model.
+    Validação de teto financeiro (_validate_budget_cap) executada com
+    select_for_update() para evitar TOCTOU.
     """
 
     @staticmethod
@@ -107,9 +111,10 @@ class BudgetCategoryService:
             company=company, wedding=budget.wedding, budget=budget, **data
         )
 
-        _validate_budget_cap(category, budget)
+        category.full_clean()
+        _validate_budget_cap(company, category, budget)
 
-        category.save()
+        category.save(skip_clean=True)
 
         logger.info(f"Categoria de Orçamento criada com sucesso: uuid={category.uuid}")
         return category
@@ -136,9 +141,11 @@ class BudgetCategoryService:
             .select_for_update()
             .get(pk=instance.budget.pk)
         )
-        _validate_budget_cap(instance, budget)
 
-        instance.save()
+        instance.full_clean()
+        _validate_budget_cap(company, instance, budget)
+
+        instance.save(skip_clean=True)
 
         logger.info(f"Categoria uuid={instance.uuid} atualizada com sucesso.")
         return instance
@@ -171,10 +178,16 @@ class BudgetCategoryService:
             ) from e
 
     @staticmethod
+    @transaction.atomic
     def setup_defaults(company: Company, wedding: Wedding, budget: Budget) -> None:
         """
         Cria as categorias iniciais obrigatórias para um novo casamento.
         É idempotente: se as categorias já existirem, não duplica.
+
+        Nota de segurança (TOCTOU): espera-se que o budget esteja protegido
+        por ``select_for_update()`` no chamador (ex: get_or_create_for_wedding).
+        O ``ignore_conflicts=True`` no bulk_create protege contra o cenário
+        residual de chamada direta sem lock.
         """
         DEFAULT_CATEGORIES = [
             "Espaço e Buffet",
@@ -212,4 +225,4 @@ class BudgetCategoryService:
         for cat in categories:
             cat.full_clean()
 
-        BudgetCategory.objects.bulk_create(categories)
+        BudgetCategory.objects.bulk_create(categories, ignore_conflicts=True)

--- a/backend/apps/finances/services/budget_service.py
+++ b/backend/apps/finances/services/budget_service.py
@@ -162,7 +162,9 @@ class BudgetService:
 
         if created:
             # TRAVA DE SEGURANÇA (TOCTOU): serializa criação de categorias padrão
-            budget = Budget.objects.for_tenant(company).select_for_update().get(pk=budget.pk)
+            budget = (
+                Budget.objects.for_tenant(company).select_for_update().get(pk=budget.pk)
+            )
 
             from apps.finances.services.budget_category_service import (
                 BudgetCategoryService,

--- a/backend/apps/finances/services/budget_service.py
+++ b/backend/apps/finances/services/budget_service.py
@@ -142,7 +142,6 @@ class BudgetService:
         """
         from apps.weddings.models import Wedding
 
-        # 1. Validação de Acesso: Garante que o Wedding pertence à empresa
         try:
             wedding = Wedding.objects.for_tenant(company).get(uuid=wedding_uuid)
         except Wedding.DoesNotExist as e:
@@ -155,15 +154,16 @@ class BudgetService:
                 code="wedding_not_found_or_denied",
             ) from e
 
-        # 2. Get or Create
         budget, created = Budget.objects.get_or_create(
             company=company,
             wedding=wedding,
             defaults={"total_estimated": 0},
         )
 
-        # 3. Setup Inicial
         if created:
+            # TRAVA DE SEGURANÇA (TOCTOU): serializa criação de categorias padrão
+            budget = Budget.objects.for_tenant(company).select_for_update().get(pk=budget.pk)
+
             from apps.finances.services.budget_category_service import (
                 BudgetCategoryService,
             )

--- a/backend/apps/finances/tests/categories/test_models.py
+++ b/backend/apps/finances/tests/categories/test_models.py
@@ -101,51 +101,6 @@ class TestBudgetCategoryClean:
 
         assert "outro casamento" in str(exc_info.value).lower()
 
-    def test_clean_fails_when_siblings_exceed_budget_total(self, user):
-        """TRAVA: soma de allocated_budget excede total_estimated do budget."""
-        wedding = WeddingFactory(user_context=user)
-        budget = BudgetFactory(wedding=wedding, total_estimated=Decimal("10000.00"))
-
-        BudgetCategoryFactory(
-            budget=budget,
-            wedding=wedding,
-            allocated_budget=Decimal("9000.00"),
-        )
-
-        cat2 = BudgetCategory(
-            company=user.company,
-            budget=budget,
-            wedding=wedding,
-            name="Excedente",
-            allocated_budget=Decimal("2000.00"),
-        )
-
-        with pytest.raises(ValidationError) as exc_info:
-            cat2.full_clean()
-
-        assert "excede" in str(exc_info.value).lower()
-
-    def test_clean_passes_when_siblings_within_budget(self, user):
-        """Categorias dentro do teto do orçamento passam na validação."""
-        wedding = WeddingFactory(user_context=user)
-        budget = BudgetFactory(wedding=wedding, total_estimated=Decimal("10000.00"))
-
-        BudgetCategoryFactory(
-            budget=budget,
-            wedding=wedding,
-            allocated_budget=Decimal("6000.00"),
-        )
-
-        cat2 = BudgetCategory(
-            company=user.company,
-            budget=budget,
-            wedding=wedding,
-            name="Dentro do Teto",
-            allocated_budget=Decimal("4000.00"),
-        )
-
-        cat2.full_clean()
-
 
 @pytest.mark.django_db
 class TestBudgetCategoryTotalSpent:

--- a/backend/apps/finances/tests/categories/test_services.py
+++ b/backend/apps/finances/tests/categories/test_services.py
@@ -118,7 +118,7 @@ class TestBudgetCategoryServiceCreate:
         TOCTOU: create() deve usar select_for_update() no budget
         para evitar race condition na leitura da soma das categorias.
         """
-        wedding, budget = _setup_budget(user)
+        _, budget = _setup_budget(user)
         data = {
             "budget": budget.uuid,
             "name": "Teste Lock",
@@ -185,7 +185,7 @@ class TestBudgetCategoryServiceUpdate:
         levanta BusinessRuleViolation.
         """
         wedding, budget = _setup_budget(user, total_estimated=Decimal("10000.00"))
-        category1 = BudgetCategoryFactory(
+        _ = BudgetCategoryFactory(
             budget=budget,
             wedding=wedding,
             allocated_budget=Decimal("9000.00"),

--- a/backend/apps/finances/tests/categories/test_services.py
+++ b/backend/apps/finances/tests/categories/test_services.py
@@ -125,9 +125,14 @@ class TestBudgetCategoryServiceCreate:
             "allocated_budget": Decimal("1000.00"),
         }
 
-        spy = mocker.spy(Budget.objects, "select_for_update")
+        mock_qs = mocker.MagicMock()
+        mock_qs.select_for_update.return_value = mock_qs
+        mock_qs.get.return_value = budget
+        mocker.patch.object(Budget.objects, "for_tenant", return_value=mock_qs)
+
         BudgetCategoryService.create(user.company, data)
-        spy.assert_called_once()
+
+        mock_qs.select_for_update.assert_called_once()
 
 
 @pytest.mark.django_db
@@ -215,9 +220,13 @@ class TestBudgetCategoryServiceUpdate:
             wedding=wedding,
         )
 
-        spy = mocker.spy(Budget.objects, "select_for_update")
+        mock_qs = mocker.MagicMock()
+        mock_qs.select_for_update.return_value = mock_qs
+        mock_qs.get.return_value = budget
+        mocker.patch.object(Budget.objects, "for_tenant", return_value=mock_qs)
+
         BudgetCategoryService.update(user.company, category, {"name": "Renomeada"})
-        spy.assert_called_once()
+        mock_qs.select_for_update.assert_called_once()
 
 
 @pytest.mark.django_db

--- a/backend/apps/finances/tests/categories/test_services.py
+++ b/backend/apps/finances/tests/categories/test_services.py
@@ -3,8 +3,12 @@ from uuid import uuid4
 
 import pytest
 
-from apps.core.exceptions import DomainIntegrityError, ObjectNotFoundError
-from apps.finances.models import BudgetCategory
+from apps.core.exceptions import (
+    BusinessRuleViolation,
+    DomainIntegrityError,
+    ObjectNotFoundError,
+)
+from apps.finances.models import Budget, BudgetCategory
 from apps.finances.services.budget_category_service import BudgetCategoryService
 from apps.finances.tests.factories import (
     BudgetCategoryFactory,
@@ -86,6 +90,45 @@ class TestBudgetCategoryServiceCreate:
 
         assert "budget_not_found_or_denied" in str(exc_info.value.code)
 
+    def test_create_category_exceeds_budget_cap_raises_error(self, user):
+        """
+        TOCTOU: criar categoria que ultrapassa o teto do orçamento
+        levanta BusinessRuleViolation.
+        """
+        wedding, budget = _setup_budget(user, total_estimated=Decimal("10000.00"))
+        BudgetCategoryFactory(
+            budget=budget,
+            wedding=wedding,
+            allocated_budget=Decimal("9000.00"),
+        )
+
+        data = {
+            "budget": budget.uuid,
+            "name": "Excedente",
+            "allocated_budget": Decimal("2000.00"),
+        }
+
+        with pytest.raises(BusinessRuleViolation) as exc_info:
+            BudgetCategoryService.create(user.company, data)
+
+        assert "budget_cap_exceeded" in str(exc_info.value.code)
+
+    def test_create_category_uses_select_for_update(self, user, mocker):
+        """
+        TOCTOU: create() deve usar select_for_update() no budget
+        para evitar race condition na leitura da soma das categorias.
+        """
+        wedding, budget = _setup_budget(user)
+        data = {
+            "budget": budget.uuid,
+            "name": "Teste Lock",
+            "allocated_budget": Decimal("1000.00"),
+        }
+
+        spy = mocker.spy(Budget.objects, "select_for_update")
+        BudgetCategoryService.create(user.company, data)
+        spy.assert_called_once()
+
 
 @pytest.mark.django_db
 class TestBudgetCategoryServiceUpdate:
@@ -135,6 +178,46 @@ class TestBudgetCategoryServiceUpdate:
         )
 
         assert updated.company == user.company
+
+    def test_update_category_allocated_budget_exceeds_cap_raises_error(self, user):
+        """
+        TOCTOU: atualizar allocated_budget ultrapassando o teto
+        levanta BusinessRuleViolation.
+        """
+        wedding, budget = _setup_budget(user, total_estimated=Decimal("10000.00"))
+        category1 = BudgetCategoryFactory(
+            budget=budget,
+            wedding=wedding,
+            allocated_budget=Decimal("9000.00"),
+        )
+        category2 = BudgetCategoryFactory(
+            budget=budget,
+            wedding=wedding,
+            allocated_budget=Decimal("500.00"),
+            name="Outra",
+        )
+
+        with pytest.raises(BusinessRuleViolation) as exc_info:
+            BudgetCategoryService.update(
+                user.company, category2, {"allocated_budget": Decimal("2000.00")}
+            )
+
+        assert "budget_cap_exceeded" in str(exc_info.value.code)
+
+    def test_update_category_uses_select_for_update(self, user, mocker):
+        """
+        TOCTOU: update() deve usar select_for_update() no budget
+        para evitar race condition na leitura da soma das categorias.
+        """
+        wedding, budget = _setup_budget(user)
+        category = BudgetCategoryFactory(
+            budget=budget,
+            wedding=wedding,
+        )
+
+        spy = mocker.spy(Budget.objects, "select_for_update")
+        BudgetCategoryService.update(user.company, category, {"name": "Renomeada"})
+        spy.assert_called_once()
 
 
 @pytest.mark.django_db
@@ -280,3 +363,16 @@ class TestBudgetCategoryServiceSetupDefaults:
         categories = BudgetCategory.objects.filter(budget=budget)
         for cat in categories:
             assert cat.allocated_budget == Decimal("0.00")
+
+    def test_setup_defaults_is_idempotent(self, user):
+        """
+        TOCTOU: setup_defaults() não duplica categorias quando chamado
+        múltiplas vezes.
+        """
+        wedding, budget = _setup_budget(user)
+
+        BudgetCategoryService.setup_defaults(user.company, wedding, budget)
+        assert BudgetCategory.objects.filter(budget=budget).count() == 6
+
+        BudgetCategoryService.setup_defaults(user.company, wedding, budget)
+        assert BudgetCategory.objects.filter(budget=budget).count() == 6


### PR DESCRIPTION
Closes #62

## Problem

Two TOCTOU (time-of-check-time-of-use) race conditions identified in the finances module:

### 1. BudgetCategory budget cap — no row-level locking
`BudgetCategory.clean()` at line 81-108 read the sum of sibling categories via `.aggregate()` **without `select_for_update()`**. Under concurrent requests, both could pass the validation and exceed `total_estimated`.

### 2. `setup_defaults()` — non-idempotent + skipping `full_clean()`
Used `bulk_create` which skips `full_clean()`, so the model's own validation never ran for default categories. Could also create duplicate categories if called twice, raising `IntegrityError`.

### 3. `get_or_create_for_wedding()` — no serialization
While `get_or_create` is safe for the Budget row (Django retries on `IntegrityError`), there was no lock serializing the `setup_defaults` call, creating a window for inconsistent state under concurrency.

## Changes

### `fix(budget-category): remove TOCTOU-prone budget cap validation from model layer`
- Removed the aggregate-read budget cap check from `BudgetCategory.clean()`
- Kept the cross-wedding integrity check (does not involve aggregate reads)

### `fix(budget-category): prevent TOCTOU race on budget cap with select_for_update and make setup_defaults idempotent`
- Added `_validate_budget_cap()` helper in the service layer
- Both `create()` and `update()` now acquire `select_for_update()` on the Budget row before reading the sum, closing the TOCTOU window
- `setup_defaults()` now checks existing category names before `bulk_create` (idempotent)
- `setup_defaults()` calls `full_clean()` on each category before creation

### `fix(budget): add select_for_update to get_or_create_for_wedding`
- Added `select_for_update()` after `get_or_create` to serialize default category creation

## Testing
- 559/559 backend tests passing
- Added budget cap validation tests for `create()` and `update()` (`BusinessRuleViolation`)
- Added spy tests confirming `select_for_update` is called
- Added idempotency test for `setup_defaults()`
- ruff and mypy clean