### PR TITLE
fix(item-service): remove isinstance redundante e adiciona validação de wedding obrigatório

### DIFF
--- a/backend/apps/logistics/services/item_service.py
+++ b/backend/apps/logistics/services/item_service.py
@@ -86,7 +86,7 @@ class ItemService:
                         detail="Contrato não encontrado ou acesso negado.",
                         code="contract_not_found_or_denied",
                     ) from e
-        elif isinstance(wedding_input, UUID | str) or isinstance(wedding_input, str):
+        elif isinstance(wedding_input, UUID | str):
             from apps.weddings.models import Wedding
 
             try:
@@ -98,6 +98,12 @@ class ItemService:
                 ) from e
 
         # 3. Instanciação
+        if wedding is None:
+            raise BusinessRuleViolation(
+                detail="É necessário informar um casamento ou um contrato vinculado.",
+                code="item_missing_wedding",
+            )
+
         item = Item(company=company, wedding=wedding, contract=contract, **data)
 
         item.save()

--- a/backend/apps/logistics/tests/items/test_services.py
+++ b/backend/apps/logistics/tests/items/test_services.py
@@ -98,6 +98,21 @@ class TestItemServiceCreate:
 
         assert "contract_not_found_or_denied" in str(exc_info.value.code)
 
+    def test_create_item_without_contract_and_wedding_raises_error(self, user):
+        """
+        Sem contrato E sem wedding, create() levanta BusinessRuleViolation
+        em vez de IntegrityError obscuro do banco.
+        """
+        data = {
+            "name": "Item solto no vácuo",
+            "quantity": 1,
+        }
+
+        with pytest.raises(BusinessRuleViolation) as exc_info:
+            ItemService.create(user.company, data)
+
+        assert "item_missing_wedding" in str(exc_info.value.code)
+
 
 @pytest.mark.django_db
 class TestItemServiceUpdate:


### PR DESCRIPTION
## Descrição

Corrige os dois problemas apontados na issue #95:

### 1. isinstance redundante (`item_service.py:89`)
`isinstance(wedding_input, UUID | str) or isinstance(wedding_input, str)` — o segundo `isinstance` é redundante pois `UUID | str` já cobre `str`.

### 2. Wedding obrigatório sem fallback explícito
Quando `contract=None` e `wedding_input=None`, `wedding` ficava `None` e o `Item(..., wedding=None).save()` quebrava com `IntegrityError` obscuro do banco (pois `WeddingOwnedMixin.wedding` não é nullable). Agora levanta `BusinessRuleViolation` com mensagem clara e código `item_missing_wedding`.

## Mudanças

- `backend/apps/logistics/services/item_service.py`: corrige isinstance redundante + adiciona validação de wedding obrigatório
- `backend/apps/logistics/tests/items/test_services.py`: adiciona teste `test_create_item_without_contract_and_wedding_raises_error`

## Verificação

- ✅ 24/24 testes passando
- ✅ Ruff lint limpo

Closes #95