### PR TITLE
fix(logistics): cleanup orphaned file on upload error

### DIFF
--- a/backend/apps/logistics/services/contract_service.py
+++ b/backend/apps/logistics/services/contract_service.py
@@ -195,18 +195,26 @@ class ContractService:
             if pdf_file.size and pdf_file.size > max_size:
                 raise ValidationError({"pdf_file": "Arquivo excede o limite de 10MB."})
 
-            contract.pdf_file.save(pdf_file.name, pdf_file, save=False)
-            contract.save(update_fields=["pdf_file"])
+        file_saved = False
+        try:
+            if pdf_file:
+                contract.pdf_file.save(pdf_file.name, pdf_file, save=False)
+                contract.save(update_fields=["pdf_file"])
+                file_saved = True
 
-        if items_data:
-            for item_dict in items_data:  # type: ignore[attr-defined]
-                item_dict["wedding"] = contract.wedding
-                item_dict["contract"] = contract
-                ItemService.create(company=company, data=item_dict)
+            if items_data:
+                for item_dict in items_data:  # type: ignore[attr-defined]
+                    item_dict["wedding"] = contract.wedding
+                    item_dict["contract"] = contract
+                    ItemService.create(company=company, data=item_dict)
 
-        if expense_data:
-            expense_data["contract"] = contract
-            ExpenseService.create(company=company, data=expense_data)
+            if expense_data:
+                expense_data["contract"] = contract
+                ExpenseService.create(company=company, data=expense_data)
+        except Exception:
+            if file_saved and contract.pdf_file:
+                contract.pdf_file.delete(save=False)
+            raise
 
         logger.info(f"Criação completa de Contrato finalizada: uuid={contract.uuid}")
         return contract
@@ -356,6 +364,7 @@ class ContractService:
         return instance
 
     @staticmethod
+    @transaction.atomic
     def upload_file(company: Company, uuid: UUID | str, uploaded_file: Any) -> Contract:
         """
         Faz upload de um arquivo (PDF, PNG, JPEG) para o contrato.
@@ -394,8 +403,15 @@ class ContractService:
             raise ValidationError({"pdf_file": "Arquivo excede o limite de 10MB."})
 
         contract = ContractService.get(company, uuid)
-        contract.pdf_file.save(uploaded_file.name, uploaded_file, save=False)
-        contract.save(update_fields=["pdf_file"])
+
+        try:
+            contract.pdf_file.save(uploaded_file.name, uploaded_file, save=False)
+            contract.save(update_fields=["pdf_file"])
+        except Exception:
+            if contract.pdf_file:
+                contract.pdf_file.delete(save=False)
+            raise
+
         logger.info(f"Arquivo salvo no contrato uuid={uuid}")
         return contract
 

--- a/backend/apps/logistics/services/contract_service.py
+++ b/backend/apps/logistics/services/contract_service.py
@@ -160,6 +160,38 @@ class ContractService:
         return contract
 
     @staticmethod
+    def _validate_uploaded_file(uploaded_file: Any, context_label: str) -> None:
+        """
+        Valida o tipo MIME (content_type) e o tamanho máximo de um arquivo de upload.
+        Emite avisos se os metadados forem omitidos, delegando à validação
+        de extensão do modelo.
+        """
+        allowed_content_types = [
+            "application/pdf",
+            "image/png",
+            "image/jpeg",
+        ]
+        file_content_type = getattr(uploaded_file, "content_type", None)
+        if file_content_type is None:
+            logger.warning(
+                f"Upload sem Content-Type header para {context_label} — "
+                "validação de MIME bypassada, extensão será verificada no modelo."
+            )
+        elif file_content_type not in allowed_content_types:
+            raise ValidationError(
+                {"pdf_file": "Tipo de arquivo não suportado. Use PDF, PNG ou JPEG."}
+            )
+
+        max_size = 10 * 1024 * 1024  # 10MB
+        if uploaded_file.size is None:
+            logger.warning(
+                f"Upload sem size reportado para {context_label} — "
+                "validação de tamanho bypassada, será verificada no modelo."
+            )
+        elif uploaded_file.size > max_size:
+            raise ValidationError({"pdf_file": "Arquivo excede o limite de 10MB."})
+
+    @staticmethod
     @transaction.atomic
     def create_full(
         company: Company,
@@ -169,6 +201,14 @@ class ContractService:
         expense_data: dict[str, Any] | None = None,
         pdf_file: Any | None = None,
     ) -> Contract:
+        """
+        Orquestra a criação completa de um contrato.
+        Cria o contrato base, valida e associa opcionalmente um arquivo PDF/imagem,
+        cria os itens logísticos associados e inicializa o fluxo de despesa
+        financeira correspondente.
+        Em caso de falha em qualquer etapa, garante o rollback no banco e a
+        deleção de arquivos órfãos no storage.
+        """
         logger.info(
             f"Iniciando criação completa de Contrato para company_id={company.id}"
         )
@@ -176,24 +216,9 @@ class ContractService:
         contract = ContractService.create(company=company, data=contract_data)
 
         if pdf_file:
-            allowed_content_types = [
-                "application/pdf",
-                "image/png",
-                "image/jpeg",
-            ]
-            file_content_type = getattr(pdf_file, "content_type", None)
-            if file_content_type and file_content_type not in allowed_content_types:
-                raise ValidationError(
-                    {
-                        "pdf_file": (
-                            "Tipo de arquivo não suportado. Use PDF, PNG ou JPEG."
-                        ),
-                    }
-                )
-
-            max_size = 10 * 1024 * 1024
-            if pdf_file.size and pdf_file.size > max_size:
-                raise ValidationError({"pdf_file": "Arquivo excede o limite de 10MB."})
+            ContractService._validate_uploaded_file(
+                pdf_file, "criação completa de contrato"
+            )
 
         file_saved = False
         try:
@@ -372,35 +397,7 @@ class ContractService:
         """
         logger.info(f"Upload de arquivo para contrato uuid={uuid}")
 
-        # Defesa em camadas: o service valida MIME (content_type do UploadedFile)
-        # como fast-fail antes de I/O; o modelo valida extensão via
-        # FileExtensionValidator no clean(). MIME não é acessível no modelo,
-        # extensão não é confiável isoladamente — os critérios são complementares.
-        allowed_content_types = [
-            "application/pdf",
-            "image/png",
-            "image/jpeg",
-        ]
-        file_content_type = getattr(uploaded_file, "content_type", None)
-        if file_content_type is None:
-            logger.warning(
-                f"Upload sem Content-Type header para contrato uuid={uuid} — "
-                f"validação de MIME bypassada, extensão será verificada no modelo."
-            )
-        elif file_content_type not in allowed_content_types:
-            raise ValidationError(
-                {"pdf_file": "Tipo de arquivo não suportado. Use PDF, PNG ou JPEG."}
-            )
-
-        # Fast-fail: validação de tamanho
-        max_size = 10 * 1024 * 1024  # 10MB
-        if uploaded_file.size is None:
-            logger.warning(
-                f"Upload sem size reportado para contrato uuid={uuid} — "
-                f"validação de tamanho bypassada, será verificada no modelo."
-            )
-        elif uploaded_file.size > max_size:
-            raise ValidationError({"pdf_file": "Arquivo excede o limite de 10MB."})
+        ContractService._validate_uploaded_file(uploaded_file, f"contrato uuid={uuid}")
 
         contract = ContractService.get(company, uuid)
 

--- a/backend/apps/logistics/tests/contracts/test_services.py
+++ b/backend/apps/logistics/tests/contracts/test_services.py
@@ -1,5 +1,6 @@
 from datetime import date
 from decimal import Decimal
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
@@ -328,6 +329,24 @@ class TestContractServiceUploadFile:
 
         assert result.pdf_file.name.endswith(".pdf")
         assert result.uuid == contract.uuid
+
+    def test_upload_file_db_error_cleans_up_storage(self, user):
+        """Se ocorrer um erro no DB, o arquivo deve ser removido do storage."""
+        wedding, supplier = _setup_contract_context(user)
+        contract = ContractFactory(wedding=wedding, supplier=supplier)
+        valid_file = SimpleUploadedFile(
+            name="valid_contract.pdf",
+            content=b"valid pdf content",
+            content_type="application/pdf",
+        )
+
+        with patch("apps.logistics.models.Contract.save") as mock_save:
+            mock_save.side_effect = Exception("DB Error")
+            with patch("django.db.models.fields.files.FieldFile.delete") as mock_delete:
+                with pytest.raises(Exception, match="DB Error"):
+                    ContractService.upload_file(user.company, contract.uuid, valid_file)
+
+                mock_delete.assert_called_once_with(save=False)
 
 
 @pytest.mark.django_db
@@ -787,3 +806,33 @@ class TestContractServiceCreateFull:
                 expense_data=expense_data,
             )
         assert "br_f02_violation" in str(exc_info.value.code)
+
+    @patch("apps.logistics.services.item_service.ItemService.create")
+    def test_create_full_db_error_cleans_up_storage(self, mock_item_create, user):
+        """Se ocorrer um erro subsequente (ex: no ItemService),
+        o arquivo no storage deve ser deletado."""
+        wedding, supplier, _ = self._setup(user)
+        contract_data = {
+            "wedding": wedding.uuid,
+            "supplier": supplier.uuid,
+            "name": "Contrato",
+            "total_amount": Decimal("5000.00"),
+        }
+        pdf_file = SimpleUploadedFile(
+            "contrato.pdf", b"pdf content", content_type="application/pdf"
+        )
+        items_data = [
+            {"name": "Item 1", "quantity": 10, "acquisition_status": "PENDING"},
+        ]
+
+        mock_item_create.side_effect = Exception("Item Creation Error")
+
+        with patch("django.db.models.fields.files.FieldFile.delete") as mock_delete:
+            with pytest.raises(Exception, match="Item Creation Error"):
+                ContractService.create_full(
+                    company=user.company,
+                    contract_data=contract_data,
+                    pdf_file=pdf_file,
+                    items_data=items_data,
+                )
+            mock_delete.assert_called_once_with(save=False)

--- a/backend/apps/logistics/tests/contracts/test_services.py
+++ b/backend/apps/logistics/tests/contracts/test_services.py
@@ -836,3 +836,29 @@ class TestContractServiceCreateFull:
                     items_data=items_data,
                 )
             mock_delete.assert_called_once_with(save=False)
+
+    def test_create_full_file_save_db_error_no_cleanup(self, user):
+        """Se o erro ocorrer antes de salvar o arquivo no storage (ex: erro ao
+        chamar save do FieldFile), o cleanup (FieldFile.delete) não deve ser
+        acionado porque o arquivo nunca foi salvo com sucesso."""
+        wedding, supplier, _ = self._setup(user)
+        contract_data = {
+            "wedding": wedding.uuid,
+            "supplier": supplier.uuid,
+            "name": "Contrato",
+            "total_amount": Decimal("5000.00"),
+        }
+        pdf_file = SimpleUploadedFile(
+            "contrato.pdf", b"pdf content", content_type="application/pdf"
+        )
+
+        with patch("django.db.models.fields.files.FieldFile.save") as mock_save:
+            mock_save.side_effect = Exception("Storage Save Error")
+            with patch("django.db.models.fields.files.FieldFile.delete") as mock_delete:
+                with pytest.raises(Exception, match="Storage Save Error"):
+                    ContractService.create_full(
+                        company=user.company,
+                        contract_data=contract_data,
+                        pdf_file=pdf_file,
+                    )
+                mock_delete.assert_not_called()


### PR DESCRIPTION
This PR fixes an issue where a failed DB save operation left orphaned files in the storage during Contract uploads.

Fixes #63