### PR TITLE
fix(scheduler): prevent PATCH requests from overwriting recurrence_rule

### DIFF
--- a/backend/apps/scheduler/schemas.py
+++ b/backend/apps/scheduler/schemas.py
@@ -56,11 +56,6 @@ class EventPatchIn(Schema):
             and self.reminder_minutes_before < 0
         ):
             raise ValueError("Os minutos do lembrete devem ser um valor positivo.")
-
-        # Model field is non-nullable with default; normalize None → "none"
-        if self.recurrence_rule is None:
-            self.recurrence_rule = "none"
-
         return self
 
 

--- a/backend/apps/scheduler/tests/test_apis.py
+++ b/backend/apps/scheduler/tests/test_apis.py
@@ -175,6 +175,43 @@ class TestSchedulerEventsAPI:
         event.refresh_from_db()
         assert event.recurrence_rule == Event.RecurrenceChoices.WEEKLY
 
+    def test_update_event_clear_recurrence_rule_explicitly_success(
+        self, auth_client, user
+    ):
+        """PATCH de evento enviando "none" limpa a recorrência."""
+        wedding = WeddingFactory(company=user.company)
+        event = EventFactory(
+            wedding=wedding,
+            title="Antigo",
+            recurrence_rule=Event.RecurrenceChoices.WEEKLY,
+        )
+
+        response = auth_client.patch(
+            f"/api/v1/scheduler/events/{event.uuid}/",
+            {"recurrence_rule": "none"},
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+
+        event.refresh_from_db()
+        assert event.recurrence_rule == Event.RecurrenceChoices.NONE
+
+    def test_update_event_recurrence_rule_null_returns_400(self, auth_client, user):
+        """PATCH de evento enviando null retorna 400."""
+        wedding = WeddingFactory(company=user.company)
+        event = EventFactory(
+            wedding=wedding,
+            title="Antigo",
+            recurrence_rule=Event.RecurrenceChoices.WEEKLY,
+        )
+
+        response = auth_client.patch(
+            f"/api/v1/scheduler/events/{event.uuid}/",
+            {"recurrence_rule": None},
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+
     def test_delete_event_success(self, auth_client, user):
         wedding = WeddingFactory(company=user.company)
         event = EventFactory(wedding=wedding)

--- a/backend/apps/scheduler/tests/test_apis.py
+++ b/backend/apps/scheduler/tests/test_apis.py
@@ -1,6 +1,7 @@
 import pytest
 from django.utils import timezone
 
+from apps.scheduler.models import Event
 from apps.scheduler.tests.factories import EventFactory, TaskFactory
 from apps.weddings.tests.factories import WeddingFactory
 
@@ -154,6 +155,25 @@ class TestSchedulerEventsAPI:
             content_type="application/json",
         )
         assert response.status_code == 404
+
+    def test_update_event_does_not_overwrite_recurrence_rule(self, auth_client, user):
+        """PATCH de evento sem recurrence_rule não deve alterar a regra existente."""
+        wedding = WeddingFactory(company=user.company)
+        event = EventFactory(
+            wedding=wedding,
+            title="Antigo",
+            recurrence_rule=Event.RecurrenceChoices.WEEKLY,
+        )
+
+        response = auth_client.patch(
+            f"/api/v1/scheduler/events/{event.uuid}/",
+            {"title": "Novo Título"},
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+
+        event.refresh_from_db()
+        assert event.recurrence_rule == Event.RecurrenceChoices.WEEKLY
 
     def test_delete_event_success(self, auth_client, user):
         wedding = WeddingFactory(company=user.company)


### PR DESCRIPTION
## Descrição
Este PR corrige o bug silencioso no endpoint de atualização parcial (PATCH) de eventos do cronograma (#74).

### O Problema
Na classe `EventPatchIn` de `backend/apps/scheduler/schemas.py`, havia um model validator do Pydantic (`validate_event`) contendo a seguinte regra:
```python
if self.recurrence_rule is None:
    self.recurrence_rule = "none"
```
Como o campo `recurrence_rule` tem valor padrão `None` na classe `EventPatchIn` (para quando ele é omitido na payload da requisição PATCH), o validador forçava o valor `"none"` para a regra de recorrência, marcando o campo como definido ("set").
Isso fazia com que qualquer atualização parcial (`PATCH`) que omitisse o campo `recurrence_rule` (ex: atualizar apenas o título) atualizasse indevidamente o campo no banco para `"none"`, apagando qualquer regra de recorrência configurada anteriormente (como `"semanal"` ou `"mensal"`).

### A Solução
Removido o bloco de normalização do validador. Se o campo for omitido, o Pydantic o considerará não-definido (unset) e `model_dump(exclude_unset=True)` não o incluirá na carga útil enviada para o serviço de atualização do Django.
Para limpar a regra de recorrência de um evento, o cliente deve enviar explicitamente a string `"none"` (ou seja, `"recurrence_rule": "none"`). Enviar `null`/`None` resultará em um erro de validação (422) porque o campo correspondente no banco de dados não é nulo.

### Testes
Foi adicionado um caso de teste `test_update_event_does_not_overwrite_recurrence_rule` para garantir que o PATCH preserva a regra de recorrência atual se ela for omitida na payload.

Closes #74