### PR TITLE
fix(frontend): make notifications interactive and copyright year dynamic

### DIFF
--- a/frontend/src/components/layouts/AppLayout.test.tsx
+++ b/frontend/src/components/layouts/AppLayout.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@/test-utils";
+import { AppLayout } from "@/components/layouts/AppLayout";
+
+vi.mock("@/components/ui/sidebar", () => ({
+  SidebarProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SidebarInset: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+  SidebarTrigger: ({ className }: { className?: string }) => (
+    <button className={className}>Toggle</button>
+  ),
+}));
+
+vi.mock("@/components/ui/separator", () => ({
+  Separator: ({ orientation, className }: { orientation?: string; className?: string }) => (
+    <hr data-orientation={orientation} className={className} />
+  ),
+}));
+
+vi.mock("../app-sidebar", () => ({
+  AppSidebar: () => null,
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({ children, asChild }: { children: React.ReactNode; asChild?: boolean }) =>
+    asChild ? <>{children}</> : <button>{children}</button>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuLabel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuSeparator: () => <hr />,
+}));
+
+vi.mock("@/hooks/useDocumentTitle", () => ({
+  useDocumentTitle: vi.fn(),
+}));
+
+describe("AppLayout", () => {
+  it("renders the page title for dashboard path", () => {
+    render(<AppLayout />, { initialEntries: ["/dashboard"] });
+    expect(screen.getByText("Dashboard Geral")).toBeInTheDocument();
+  });
+
+  it("renders notification bell with correct aria-label", () => {
+    render(<AppLayout />, { initialEntries: ["/dashboard"] });
+    expect(screen.getByRole("button", { name: /notificações/i })).toBeInTheDocument();
+  });
+
+  it("renders notification dropdown with empty state message", () => {
+    render(<AppLayout />, { initialEntries: ["/dashboard"] });
+    expect(screen.getByText("Notificações")).toBeInTheDocument();
+    expect(
+      screen.getByText("Você não tem novas notificações no momento."),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render a static red badge", () => {
+    render(<AppLayout />, { initialEntries: ["/dashboard"] });
+    const bellButton = screen.getByRole("button", { name: /notificações/i });
+    expect(bellButton.querySelector(".bg-destructive")).not.toBeInTheDocument();
+  });
+
+  it("renders wedding detail title for wedding paths", () => {
+    render(<AppLayout />, { initialEntries: ["/weddings/abc-123"] });
+    expect(screen.getByText("Detalhes do Casamento")).toBeInTheDocument();
+  });
+
+  it("renders supplier detail title for supplier paths", () => {
+    render(<AppLayout />, { initialEntries: ["/suppliers/abc-123"] });
+    expect(screen.getByText("Detalhes do Fornecedor")).toBeInTheDocument();
+  });
+
+  it("renders fallback title for unknown paths", () => {
+    render(<AppLayout />, { initialEntries: ["/unknown"] });
+    expect(screen.getByText("Painel de Controle")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/layouts/AppLayout.tsx
+++ b/frontend/src/components/layouts/AppLayout.tsx
@@ -10,6 +10,13 @@ import { Button } from "@/components/ui/button";
 import { Bell } from "lucide-react";
 import { AppSidebar } from "../app-sidebar";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuSeparator,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 const PAGE_TITLES: Record<string, string> = {
   "/dashboard": "Dashboard Geral",
@@ -43,15 +50,25 @@ export const AppLayout = () => {
 
           <div className="flex items-center gap-4">
             {/* Notifications */}
-            <Button
-              variant="ghost"
-              size="icon"
-              className="relative text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100 focus-visible:ring-primary/50"
-              aria-label="Notificações"
-            >
-              <Bell className="w-5 h-5" />
-              <span className="absolute top-1.5 right-1.5 w-2.5 h-2.5 bg-destructive rounded-full ring-2 ring-white dark:ring-[#18181B]" />
-            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="relative text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100 focus-visible:ring-primary/50 cursor-pointer"
+                  aria-label="Notificações"
+                >
+                  <Bell className="w-5 h-5" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-80">
+                <DropdownMenuLabel>Notificações</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <div className="p-4 text-center text-xs text-zinc-500 dark:text-zinc-400">
+                  Você não tem novas notificações no momento.
+                </div>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         </header>
 

--- a/frontend/src/features/auth/components/AuthLayout.tsx
+++ b/frontend/src/features/auth/components/AuthLayout.tsx
@@ -124,7 +124,7 @@ export function AuthLayout({
           </div>
 
           <div className="w-full flex items-center justify-between text-[10px] text-zinc-450 dark:text-zinc-500 relative z-10">
-            <span>© 2026 Sim, Aceito! Todos os direitos reservados.</span>
+            <span>© {new Date().getFullYear()} Sim, Aceito! Todos os direitos reservados.</span>
           </div>
         </div>
       </div>

--- a/landing/src/components/Footer.astro
+++ b/landing/src/components/Footer.astro
@@ -33,7 +33,11 @@
       <h5 class="text-zinc-400 uppercase tracking-widest text-[10px] font-bold">Contato</h5>
       <p>📧 suporte@simaceito.site</p>
       <p>📍 São Paulo • Rio de Janeiro • Lisboa</p>
-      <p class="mt-4 text-[10px] font-mono">© {new Date().getFullYear()} Sim, Aceito!. Todos os direitos reservados.</p>
+      <p class="mt-4 text-[10px] font-mono">© <span id="copyright-year"></span> Sim, Aceito!. Todos os direitos reservados.</p>
+      <script>
+        const yearEl = document.getElementById('copyright-year');
+        if (yearEl) yearEl.textContent = new Date().getFullYear().toString();
+      </script>
     </div>
   </div>
 </footer>

--- a/landing/src/components/Footer.astro
+++ b/landing/src/components/Footer.astro
@@ -33,7 +33,7 @@
       <h5 class="text-zinc-400 uppercase tracking-widest text-[10px] font-bold">Contato</h5>
       <p>📧 suporte@simaceito.site</p>
       <p>📍 São Paulo • Rio de Janeiro • Lisboa</p>
-      <p class="mt-4 text-[10px] font-mono">© 2026 Sim, Aceito!. Todos os direitos reservados.</p>
+      <p class="mt-4 text-[10px] font-mono">© {new Date().getFullYear()} Sim, Aceito!. Todos os direitos reservados.</p>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
## Descrição

Este PR resolve a issue #81 corrigindo elementos estáticos e valores hardcoded remanescentes na interface:

1. **Sino de Notificações ([AppLayout.tsx](file:///home/rafael/projetos/wedding_management/frontend/src/components/layouts/AppLayout.tsx)):**
   - O sino foi encapsulado em um `DropdownMenu` do shadcn/ui.
   - O badge vermelho estático (que causava "UX enganoso") foi removido.
   - Foi implementado um menu simples com a mensagem amigável de estado vazio: *"Você não tem novas notificações no momento."*

2. **Copyright Dinâmico ([AuthLayout.tsx](file:///home/rafael/projetos/wedding_management/frontend/src/features/auth/components/AuthLayout.tsx) & [Footer.astro](file:///home/rafael/projetos/wedding_management/landing/src/components/Footer.astro)):**
   - O ano hardcoded `2026` foi substituído por uma data dinâmica calculada via `new Date().getFullYear()`.

Closes #81