### PR TITLE
fix(core): fix seed_db bugs and add E2E planner

### DIFF
--- a/backend/apps/core/management/commands/seed_db.py
+++ b/backend/apps/core/management/commands/seed_db.py
@@ -1,0 +1,205 @@
+"""
+Comando de seed para popular o banco com dados de desenvolvimento.
+
+Cria planners, casamentos, fornecedores, contratos, despesas, parcelas,
+tarefas e eventos com dados realistas para facilitar o desenvolvimento local.
+
+Uso:
+    python manage.py seed_db
+    python manage.py seed_db --planners 3 --weddings 4
+"""
+
+import secrets
+from datetime import date, timedelta
+from decimal import Decimal
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.utils import timezone
+
+from apps.finances.models import Installment
+from apps.finances.tests.factories import (
+    BudgetCategoryFactory,
+    BudgetFactory,
+    ExpenseFactory,
+    InstallmentFactory,
+)
+from apps.logistics.models import Contract
+from apps.logistics.tests.factories import (
+    ContractFactory,
+    ItemFactory,
+    SupplierFactory,
+)
+from apps.scheduler.tests.factories import EventFactory, TaskFactory
+from apps.users.tests.factories import AdminFactory, UserFactory
+from apps.weddings.tests.factories import WeddingFactory
+
+
+class Command(BaseCommand):
+    help = (
+        "Popula o banco com quantidades customizáveis de usuários, "
+        "casamentos e dados reais"
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--planners",
+            type=int,
+            default=2,
+            help="Número de Planners (usuários) a serem criados",
+        )
+        parser.add_argument(
+            "--weddings",
+            type=int,
+            default=2,
+            help="Número de casamentos por cada Planner",
+        )
+
+    @transaction.atomic
+    def handle(self, *args, **kwargs):
+        num_planners = kwargs["planners"]
+        num_weddings = kwargs["weddings"]
+
+        self.stdout.write(
+            self.style.MIGRATE_LABEL(
+                f"Iniciando seed completo: {num_planners} planners com "
+                f"{num_weddings} casamentos cada..."
+            )
+        )
+
+        # 1. Superuser (only if none exists)
+        if (
+            not AdminFactory._get_manager(AdminFactory._meta.model)
+            .filter(is_superuser=True)
+            .exists()
+        ):
+            AdminFactory.create(
+                email="admin@admin.com",
+                first_name="Admin",
+                last_name="Master",
+            )
+            self.stdout.write(
+                self.style.SUCCESS("  ✓ Superusuário admin@admin.com criado")
+            )
+
+        # 2. Planners
+        planners = UserFactory.create_batch(num_planners)
+        self.stdout.write(self.style.SUCCESS(f"  ✓ {num_planners} planners criados"))
+
+        for planner in planners:
+            # Pool of 5 suppliers for this planner's company.
+            # Override phone to avoid Faker generating values > max_length=20.
+            suppliers = SupplierFactory.create_batch(
+                5,
+                company=planner.company,
+                phone="(11) 99999-0000",
+            )
+
+            # 3. Weddings (mix of IN_PROGRESS and COMPLETED)
+            for i in range(num_weddings):
+                # Make the first wedding completed (when there are multiple).
+                if i == 0 and num_weddings > 1:
+                    # CompletedWeddingFactory uses past_date which fails the
+                    # validate_future_date field validator (raises when date <
+                    # today). Use timezone.now().date() (UTC) to match what the
+                    # validator checks, avoiding local timezone offset issues.
+                    # The model's clean() allows COMPLETED with today's date.
+                    wedding = WeddingFactory.create(
+                        user_context=planner,
+                        date=timezone.now().date(),
+                        status="COMPLETED",
+                    )
+                else:
+                    wedding = WeddingFactory.create(user_context=planner)
+
+                # Budget: OneToOne with Wedding — create one, then attach categories.
+                budget = BudgetFactory.create(wedding=wedding, company=planner.company)
+                categories = BudgetCategoryFactory.create_batch(
+                    3, budget=budget, wedding=wedding
+                )
+
+                # Contracts, Expenses, and Installments
+                for _ in range(3):
+                    supplier = secrets.choice(suppliers)
+
+                    # NOTE: Contract.clean() raises ValidationError if
+                    # status == SIGNED and pdf_file is missing. Since we cannot
+                    # upload actual files during seeding, all contracts are
+                    # created as DRAFT to avoid this validation.
+                    contract = ContractFactory.create(
+                        wedding=wedding,
+                        supplier=supplier,
+                        company=planner.company,
+                        status=Contract.StatusChoices.DRAFT,
+                    )
+                    ItemFactory.create_batch(2, contract=contract, wedding=wedding)
+
+                    # Create Expense linked to Contract.
+                    category = secrets.choice(categories)
+                    amount = Decimal("3000.00")
+                    # Exact division ensures sum of installments
+                    # equals actual_amount (BR-F01 integrity check).
+                    installment_amount = amount / Decimal("3")
+
+                    expense = ExpenseFactory.create(
+                        wedding=wedding,
+                        company=planner.company,
+                        category=category,
+                        contract=contract,
+                        name=f"Despesa: {contract.name}",
+                        actual_amount=installment_amount * 3,
+                        estimated_amount=amount,
+                    )
+
+                    # Create 3 installments with mixed statuses.
+                    # Their sum must equal expense.actual_amount (BR-F01).
+
+                    # Installment 1: PAID
+                    InstallmentFactory.create(
+                        expense=expense,
+                        company=planner.company,
+                        wedding=wedding,
+                        installment_number=1,
+                        amount=installment_amount,
+                        due_date=date.today() - timedelta(days=30),
+                        paid_date=date.today() - timedelta(days=28),
+                        status=Installment.StatusChoices.PAID,
+                    )
+
+                    # Installment 2: OVERDUE (past due, not paid)
+                    InstallmentFactory.create(
+                        expense=expense,
+                        company=planner.company,
+                        wedding=wedding,
+                        installment_number=2,
+                        amount=installment_amount,
+                        due_date=date.today() - timedelta(days=5),
+                        paid_date=None,
+                        status=Installment.StatusChoices.OVERDUE,
+                    )
+
+                    # Installment 3: PENDING (future)
+                    InstallmentFactory.create(
+                        expense=expense,
+                        company=planner.company,
+                        wedding=wedding,
+                        installment_number=3,
+                        amount=installment_amount,
+                        due_date=date.today() + timedelta(days=45),
+                        paid_date=None,
+                        status=Installment.StatusChoices.PENDING,
+                    )
+
+                # 4. Tasks (Checklist)
+                TaskFactory.create_batch(3, wedding=wedding, is_completed=True)
+                TaskFactory.create_batch(2, wedding=wedding, is_completed=False)
+
+                # 5. Calendar Events
+                EventFactory.create_batch(4, wedding=wedding)
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Sucesso! Criados {num_planners} planners e "
+                f"{num_planners * num_weddings} casamentos no total."
+            )
+        )

--- a/backend/apps/core/management/commands/seed_db.py
+++ b/backend/apps/core/management/commands/seed_db.py
@@ -11,7 +11,7 @@ Uso:
 
 import secrets
 from datetime import date, timedelta
-from decimal import ROUND_HALF_UP, Decimal
+from decimal import ROUND_DOWN, Decimal
 
 from django.core.files.base import ContentFile
 from django.core.management.base import BaseCommand
@@ -33,7 +33,7 @@ from apps.logistics.tests.factories import (
 )
 from apps.scheduler.tests.factories import EventFactory, TaskFactory
 from apps.users.tests.factories import AdminFactory, UserFactory
-from apps.weddings.models import Wedding as WeddingModel
+from apps.weddings.models import Wedding
 from apps.weddings.tests.factories import WeddingFactory
 
 
@@ -111,7 +111,7 @@ class Command(BaseCommand):
             for i in range(num_weddings):
                 if i == 0 and num_weddings > 1:
                     wedding = WeddingFactory.create(user_context=planner)
-                    wedding.status = WeddingModel.StatusChoices.COMPLETED
+                    wedding.status = Wedding.StatusChoices.COMPLETED
                     wedding.date = timezone.now().date() - timedelta(days=30)
                     wedding.save(skip_clean=True)
                 else:
@@ -165,7 +165,10 @@ class Command(BaseCommand):
 
                     installment_amount = (
                         contract.total_amount / Decimal("3")
-                    ).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+                    ).quantize(Decimal("0.01"), rounding=ROUND_DOWN)
+                    remainder_amount = contract.total_amount - (
+                        installment_amount * Decimal("2")
+                    )
 
                     InstallmentFactory.create(
                         expense=expense,
@@ -206,7 +209,7 @@ class Command(BaseCommand):
                         company=planner.company,
                         wedding=wedding,
                         installment_number=3,
-                        amount=installment_amount,
+                        amount=remainder_amount,
                         due_date=date.today() + timedelta(days=45),
                         paid_date=None,
                         status=Installment.StatusChoices.PENDING,

--- a/backend/apps/core/management/commands/seed_db.py
+++ b/backend/apps/core/management/commands/seed_db.py
@@ -11,8 +11,9 @@ Uso:
 
 import secrets
 from datetime import date, timedelta
-from decimal import Decimal
+from decimal import ROUND_HALF_UP, Decimal
 
+from django.core.files.base import ContentFile
 from django.core.management.base import BaseCommand
 from django.db import transaction
 from django.utils import timezone
@@ -32,6 +33,7 @@ from apps.logistics.tests.factories import (
 )
 from apps.scheduler.tests.factories import EventFactory, TaskFactory
 from apps.users.tests.factories import AdminFactory, UserFactory
+from apps.weddings.models import Wedding as WeddingModel
 from apps.weddings.tests.factories import WeddingFactory
 
 
@@ -67,7 +69,6 @@ class Command(BaseCommand):
             )
         )
 
-        # 1. Superuser (only if none exists)
         if (
             not AdminFactory._get_manager(AdminFactory._meta.model)
             .filter(is_superuser=True)
@@ -82,64 +83,75 @@ class Command(BaseCommand):
                 self.style.SUCCESS("  ✓ Superusuário admin@admin.com criado")
             )
 
-        # 2. Planners
-        planners = UserFactory.create_batch(num_planners)
-        self.stdout.write(self.style.SUCCESS(f"  ✓ {num_planners} planners criados"))
+        from django.contrib.auth import get_user_model
+
+        User = get_user_model()
+        e2e_planner = User.objects.filter(email="planner@example.com").first()
+        if not e2e_planner:
+            e2e_planner = UserFactory.create(
+                email="planner@example.com",
+                first_name="Planner",
+                last_name="E2E",
+            )
+            self.stdout.write(
+                self.style.SUCCESS("  ✓ Planner E2E: planner@example.com / password123")
+            )
+        planners = [e2e_planner, *UserFactory.create_batch(num_planners)]
+        self.stdout.write(
+            self.style.SUCCESS(f"  ✓ {num_planners + 1} planners criados")
+        )
 
         for planner in planners:
-            # Pool of 5 suppliers for this planner's company.
-            # Override phone to avoid Faker generating values > max_length=20.
             suppliers = SupplierFactory.create_batch(
                 5,
                 company=planner.company,
                 phone="(11) 99999-0000",
             )
 
-            # 3. Weddings (mix of IN_PROGRESS and COMPLETED)
             for i in range(num_weddings):
-                # Make the first wedding completed (when there are multiple).
                 if i == 0 and num_weddings > 1:
-                    # CompletedWeddingFactory uses past_date which fails the
-                    # validate_future_date field validator (raises when date <
-                    # today). Use timezone.now().date() (UTC) to match what the
-                    # validator checks, avoiding local timezone offset issues.
-                    # The model's clean() allows COMPLETED with today's date.
-                    wedding = WeddingFactory.create(
-                        user_context=planner,
-                        date=timezone.now().date(),
-                        status="COMPLETED",
-                    )
+                    wedding = WeddingFactory.create(user_context=planner)
+                    wedding.status = WeddingModel.StatusChoices.COMPLETED
+                    wedding.date = timezone.now().date() - timedelta(days=30)
+                    wedding.save(skip_clean=True)
                 else:
                     wedding = WeddingFactory.create(user_context=planner)
 
-                # Budget: OneToOne with Wedding — create one, then attach categories.
                 budget = BudgetFactory.create(wedding=wedding, company=planner.company)
                 categories = BudgetCategoryFactory.create_batch(
                     3, budget=budget, wedding=wedding
                 )
 
-                # Contracts, Expenses, and Installments
-                for _ in range(3):
+                for c_idx in range(3):
                     supplier = secrets.choice(suppliers)
 
-                    # NOTE: Contract.clean() raises ValidationError if
-                    # status == SIGNED and pdf_file is missing. Since we cannot
-                    # upload actual files during seeding, all contracts are
-                    # created as DRAFT to avoid this validation.
+                    status = (
+                        Contract.StatusChoices.SIGNED
+                        if c_idx < 2
+                        else Contract.StatusChoices.DRAFT
+                    )
+                    signed_date = (
+                        date.today() - timedelta(days=10)
+                        if status == Contract.StatusChoices.SIGNED
+                        else None
+                    )
+                    pdf_file = (
+                        ContentFile(b"dummy pdf content", name="contract.pdf")
+                        if status == Contract.StatusChoices.SIGNED
+                        else None
+                    )
+
                     contract = ContractFactory.create(
                         wedding=wedding,
                         supplier=supplier,
                         company=planner.company,
-                        status=Contract.StatusChoices.DRAFT,
+                        status=status,
+                        signed_date=signed_date,
+                        pdf_file=pdf_file,
                     )
                     ItemFactory.create_batch(2, contract=contract, wedding=wedding)
 
-                    # Create Expense linked to Contract.
                     category = secrets.choice(categories)
-                    amount = Decimal("3000.00")
-                    # Exact division ensures sum of installments
-                    # equals actual_amount (BR-F01 integrity check).
-                    installment_amount = amount / Decimal("3")
 
                     expense = ExpenseFactory.create(
                         wedding=wedding,
@@ -147,14 +159,14 @@ class Command(BaseCommand):
                         category=category,
                         contract=contract,
                         name=f"Despesa: {contract.name}",
-                        actual_amount=installment_amount * 3,
-                        estimated_amount=amount,
+                        actual_amount=contract.total_amount,
+                        estimated_amount=contract.total_amount,
                     )
 
-                    # Create 3 installments with mixed statuses.
-                    # Their sum must equal expense.actual_amount (BR-F01).
+                    installment_amount = (
+                        contract.total_amount / Decimal("3")
+                    ).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
 
-                    # Installment 1: PAID
                     InstallmentFactory.create(
                         expense=expense,
                         company=planner.company,
@@ -166,19 +178,29 @@ class Command(BaseCommand):
                         status=Installment.StatusChoices.PAID,
                     )
 
-                    # Installment 2: OVERDUE (past due, not paid)
-                    InstallmentFactory.create(
-                        expense=expense,
-                        company=planner.company,
-                        wedding=wedding,
-                        installment_number=2,
-                        amount=installment_amount,
-                        due_date=date.today() - timedelta(days=5),
-                        paid_date=None,
-                        status=Installment.StatusChoices.OVERDUE,
-                    )
+                    if status == Contract.StatusChoices.SIGNED:
+                        InstallmentFactory.create(
+                            expense=expense,
+                            company=planner.company,
+                            wedding=wedding,
+                            installment_number=2,
+                            amount=installment_amount,
+                            due_date=date.today() - timedelta(days=5),
+                            paid_date=None,
+                            status=Installment.StatusChoices.OVERDUE,
+                        )
+                    else:
+                        InstallmentFactory.create(
+                            expense=expense,
+                            company=planner.company,
+                            wedding=wedding,
+                            installment_number=2,
+                            amount=installment_amount,
+                            due_date=date.today() + timedelta(days=15),
+                            paid_date=None,
+                            status=Installment.StatusChoices.PENDING,
+                        )
 
-                    # Installment 3: PENDING (future)
                     InstallmentFactory.create(
                         expense=expense,
                         company=planner.company,
@@ -190,16 +212,14 @@ class Command(BaseCommand):
                         status=Installment.StatusChoices.PENDING,
                     )
 
-                # 4. Tasks (Checklist)
                 TaskFactory.create_batch(3, wedding=wedding, is_completed=True)
                 TaskFactory.create_batch(2, wedding=wedding, is_completed=False)
 
-                # 5. Calendar Events
                 EventFactory.create_batch(4, wedding=wedding)
 
         self.stdout.write(
             self.style.SUCCESS(
-                f"Sucesso! Criados {num_planners} planners e "
-                f"{num_planners * num_weddings} casamentos no total."
+                f"Sucesso! Criados {len(planners)} planners e "
+                f"{len(planners) * num_weddings} casamentos no total."
             )
         )

--- a/backend/apps/core/tests/test_commands.py
+++ b/backend/apps/core/tests/test_commands.py
@@ -27,7 +27,7 @@ class TestSeedDbCommand:
         call_command("seed_db", planners=3, weddings=0)
 
         planners = User.objects.filter(is_superuser=False, is_staff=False)
-        assert planners.count() >= 3
+        assert planners.count() == 4  # 3 batch + 1 E2E
 
     def test_seed_db_creates_weddings_with_mixed_statuses(self):
         call_command("seed_db", planners=1, weddings=3)
@@ -46,7 +46,7 @@ class TestSeedDbCommand:
         assert wedding is not None
 
         suppliers = Supplier.objects.filter(company=wedding.company)
-        assert suppliers.count() >= 5
+        assert suppliers.count() == 5
 
     def test_seed_db_creates_contracts_with_mixed_statuses(self):
         call_command("seed_db", planners=1, weddings=1)
@@ -124,3 +124,22 @@ class TestSeedDbCommand:
 
         assert Wedding.objects.count() > 0
         assert User.objects.filter(is_superuser=True).exists()
+
+    def test_seed_db_creates_e2e_planner(self):
+        call_command("seed_db", planners=0, weddings=0)
+
+        e2e = User.objects.filter(email="planner@example.com").first()
+        assert e2e is not None
+        assert e2e.is_active is True
+        assert e2e.is_staff is False
+        assert e2e.is_superuser is False
+
+    def test_seed_db_is_idempotent(self):
+        call_command("seed_db", planners=1, weddings=1)
+        call_command("seed_db", planners=1, weddings=1)
+
+        e2e_planners = User.objects.filter(email="planner@example.com")
+        assert e2e_planners.count() == 1
+
+        superusers = User.objects.filter(is_superuser=True)
+        assert superusers.count() == 1

--- a/backend/apps/core/tests/test_commands.py
+++ b/backend/apps/core/tests/test_commands.py
@@ -1,0 +1,126 @@
+"""
+Testes para o comando seed_db.
+
+Verifica se o comando popula o banco corretamente com dados de
+desenvolvimento: planners, casamentos, contratos, despesas, parcelas,
+tarefas e eventos.
+"""
+
+import pytest
+from django.core.management import call_command
+
+from apps.finances.models import Budget, BudgetCategory, Expense, Installment
+from apps.logistics.models import Contract, Item, Supplier
+from apps.scheduler.models import Event, Task
+from apps.users.models import User
+from apps.weddings.models import Wedding
+
+
+@pytest.mark.django_db
+class TestSeedDbCommand:
+    def test_seed_db_creates_superuser(self):
+        call_command("seed_db", planners=0, weddings=0)
+
+        assert User.objects.filter(is_superuser=True).exists()
+
+    def test_seed_db_creates_planners(self):
+        call_command("seed_db", planners=3, weddings=0)
+
+        planners = User.objects.filter(is_superuser=False, is_staff=False)
+        assert planners.count() >= 3
+
+    def test_seed_db_creates_weddings_with_mixed_statuses(self):
+        call_command("seed_db", planners=1, weddings=3)
+
+        weddings = Wedding.objects.order_by("-created_at")[:3]
+        assert weddings.count() == 3
+
+        statuses = {w.status for w in weddings}
+        assert Wedding.StatusChoices.COMPLETED in statuses
+        assert Wedding.StatusChoices.IN_PROGRESS in statuses
+
+    def test_seed_db_creates_suppliers_with_tenant_context(self):
+        call_command("seed_db", planners=1, weddings=1)
+
+        wedding = Wedding.objects.order_by("-created_at").first()
+        assert wedding is not None
+
+        suppliers = Supplier.objects.filter(company=wedding.company)
+        assert suppliers.count() >= 5
+
+    def test_seed_db_creates_contracts_with_mixed_statuses(self):
+        call_command("seed_db", planners=1, weddings=1)
+
+        wedding = Wedding.objects.order_by("-created_at").first()
+        contracts = Contract.objects.filter(wedding=wedding)
+
+        assert contracts.count() == 3
+
+        statuses = {c.status for c in contracts}
+        assert Contract.StatusChoices.SIGNED in statuses
+        assert Contract.StatusChoices.DRAFT in statuses
+
+    def test_seed_db_creates_items_for_contracts(self):
+        call_command("seed_db", planners=1, weddings=1)
+
+        wedding = Wedding.objects.order_by("-created_at").first()
+        items = Item.objects.filter(wedding=wedding)
+
+        assert items.count() == 6
+
+    def test_seed_db_creates_expenses_linked_to_contracts(self):
+        call_command("seed_db", planners=1, weddings=1)
+
+        wedding = Wedding.objects.order_by("-created_at").first()
+        expenses = Expense.objects.filter(wedding=wedding)
+
+        assert expenses.count() == 3
+        for expense in expenses:
+            assert expense.contract is not None
+
+    def test_seed_db_creates_installments_with_mixed_statuses(self):
+        call_command("seed_db", planners=1, weddings=1)
+
+        wedding = Wedding.objects.order_by("-created_at").first()
+        installments = Installment.objects.filter(wedding=wedding)
+
+        assert installments.count() == 9
+
+        statuses = {s for s in installments.values_list("status", flat=True)}
+        assert Installment.StatusChoices.PAID in statuses
+        assert Installment.StatusChoices.PENDING in statuses
+        assert Installment.StatusChoices.OVERDUE in statuses
+
+    def test_seed_db_creates_budget_and_categories(self):
+        call_command("seed_db", planners=1, weddings=1)
+
+        wedding = Wedding.objects.order_by("-created_at").first()
+        budgets = Budget.objects.filter(wedding=wedding)
+        categories = BudgetCategory.objects.filter(wedding=wedding)
+
+        assert budgets.count() == 1
+        assert categories.count() == 3
+
+    def test_seed_db_creates_tasks_with_mixed_completion(self):
+        call_command("seed_db", planners=1, weddings=1)
+
+        wedding = Wedding.objects.order_by("-created_at").first()
+        tasks = Task.objects.filter(wedding=wedding)
+
+        assert tasks.count() == 5
+        assert tasks.filter(is_completed=True).count() == 3
+        assert tasks.filter(is_completed=False).count() == 2
+
+    def test_seed_db_creates_calendar_events(self):
+        call_command("seed_db", planners=1, weddings=1)
+
+        wedding = Wedding.objects.order_by("-created_at").first()
+        events = Event.objects.filter(wedding=wedding)
+
+        assert events.count() == 4
+
+    def test_seed_db_generates_no_errors_on_default_run(self):
+        call_command("seed_db")
+
+        assert Wedding.objects.count() > 0
+        assert User.objects.filter(is_superuser=True).exists()

--- a/backend/apps/tenants/tests/factories.py
+++ b/backend/apps/tenants/tests/factories.py
@@ -1,3 +1,5 @@
+import uuid
+
 import factory
 
 from apps.tenants.models import Company
@@ -8,5 +10,5 @@ class CompanyFactory(factory.django.DjangoModelFactory):
         model = Company
 
     name = factory.Faker("company")
-    slug = factory.Sequence(lambda n: f"company-{n}")
+    slug = factory.LazyFunction(lambda: f"company-{uuid.uuid4().hex[:8]}")
     is_active = True

--- a/backend/apps/users/tests/factories.py
+++ b/backend/apps/users/tests/factories.py
@@ -33,7 +33,7 @@ class UserFactory(factory.django.DjangoModelFactory):
 
     # Gera emails únicos: planner0@example.com, planner1@example.com...
     # Essencial para evitar erros de integridade no seu modelo
-    email = factory.Sequence(lambda n: f"planner{n}@example.com")
+    email = factory.Faker("email")
 
     # Usa o Faker configurado como pt_BR (no conftest global) para nomes reais
     first_name = factory.Faker("first_name")


### PR DESCRIPTION
## O que foi feito

Correções no comando `seed_db` restaurado no commit `84474f0`:

### Bugs corrigidos
- **CompanyFactory slug collision**: slugs usavam sequência fixa `company-{n}`, colidiam ao rodar seed múltiplas vezes. Substituído por UUID.
- **UserFactory email collision**: emails usavam sequência `planner{n}@example.com`, mesmo problema. Substituído por Faker.
- **Divisão Decimal**: `total_amount / 3` gerava dízima infinita excedendo `max_digits=10`. Corrigido com `.quantize()`.

### Divergências do plano corrigidas
- **Status dos contratos**: agora varia entre SIGNED (2) e DRAFT (1) por casamento
- **Parcelas OVERDUE condicionais**: só criadas para contratos SIGNED; DRAFT recebe PENDING
- **CompletedWeddingFactory**: contornado bug do `validate_future_date` com `skip_clean=True`

### Adições
- **Planner fixo para E2E**: `planner@example.com` / `password123` criado sempre (idempotente)
- **_tests/test_commands.py_**: 12 testes cobrindo todos os tipos de dados do seed

### CI
- ruff check: pass
- mypy: pass
- Django check: pass
- makemigrations --check: pass
- pytest: 584 passed

Closes #58