### PR TITLE
test(e2e): weddings CRUD — criar, listar, editar e deletar casamento

### DIFF
--- a/frontend/e2e/components/confirm-delete.component.ts
+++ b/frontend/e2e/components/confirm-delete.component.ts
@@ -1,0 +1,26 @@
+import { type Page, type Locator, expect } from "@playwright/test";
+
+export class ConfirmDeleteComponent {
+  readonly dialog: Locator;
+  readonly confirmInput: Locator;
+  readonly confirmButton: Locator;
+
+  constructor(private readonly page: Page) {
+    this.dialog = this.page.getByRole("dialog");
+    this.confirmInput = this.page.getByPlaceholder("Digite o nome aqui...");
+    this.confirmButton = this.page.getByRole("button", { name: "Deletar Permanentemente" });
+  }
+
+  async confirm(itemName: string) {
+    await this.confirmInput.fill(itemName);
+    await this.confirmButton.click();
+  }
+
+  async cancel() {
+    await this.dialog.getByRole("button", { name: "Cancelar" }).click();
+  }
+
+  async expectVisible() {
+    await expect(this.dialog).toBeVisible();
+  }
+}

--- a/frontend/e2e/components/form-dialog.component.ts
+++ b/frontend/e2e/components/form-dialog.component.ts
@@ -8,12 +8,16 @@ export class FormDialogComponent {
   }
 
   async fillField(label: string, value: string) {
-    await this.page.getByLabel(label).fill(value);
+    await this.dialog.getByLabel(label).fill(value);
   }
 
   async fillSelectField(label: string, optionLabel: string) {
-    await this.page.getByLabel(label).click();
+    await this.dialog.getByLabel(label).click();
     await this.page.getByRole("option", { name: optionLabel }).click();
+  }
+
+  async expectValidationError() {
+    await expect(this.dialog.getByRole("alert")).toBeVisible();
   }
 
   async submit() {

--- a/frontend/e2e/components/form-dialog.component.ts
+++ b/frontend/e2e/components/form-dialog.component.ts
@@ -1,0 +1,35 @@
+import { type Page, type Locator, expect } from "@playwright/test";
+
+export class FormDialogComponent {
+  readonly dialog: Locator;
+
+  constructor(private readonly page: Page) {
+    this.dialog = this.page.getByRole("dialog");
+  }
+
+  async fillField(label: string, value: string) {
+    await this.page.getByLabel(label).fill(value);
+  }
+
+  async fillSelectField(label: string, optionLabel: string) {
+    await this.page.getByLabel(label).click();
+    await this.page.getByRole("option", { name: optionLabel }).click();
+  }
+
+  async submit() {
+    const submitButton = this.dialog.getByRole("button", { name: /^(Criar|Salvar)/ });
+    await submitButton.click();
+  }
+
+  async cancel() {
+    await this.dialog.getByRole("button", { name: "Cancelar" }).click();
+  }
+
+  async expectVisible(title: string | RegExp) {
+    await expect(this.dialog.getByRole("heading", { name: title })).toBeVisible();
+  }
+
+  async expectClosed() {
+    await expect(this.dialog).not.toBeVisible();
+  }
+}

--- a/frontend/e2e/pages/wedding-detail.page.ts
+++ b/frontend/e2e/pages/wedding-detail.page.ts
@@ -1,0 +1,23 @@
+import { type Page, expect } from "@playwright/test";
+
+export class WeddingDetailPage {
+  constructor(private readonly page: Page) {}
+
+  async expectHeading(groom: string, bride: string) {
+    await expect(
+      this.page.getByRole("heading", { level: 2, name: `${groom} & ${bride}` }),
+    ).toBeVisible();
+  }
+
+  async expectStatus(status: string) {
+    await expect(this.page.getByText(status)).toBeVisible();
+  }
+
+  async goBack() {
+    await this.page.getByRole("button", { name: "Voltar para lista" }).click();
+  }
+
+  async expectUrlMatch() {
+    await expect(this.page).toHaveURL(/\/weddings\/[\w-]+/);
+  }
+}

--- a/frontend/e2e/pages/weddings-list.page.ts
+++ b/frontend/e2e/pages/weddings-list.page.ts
@@ -1,0 +1,108 @@
+import { type Page, expect } from "@playwright/test";
+import { faker } from "@faker-js/faker";
+import { FormDialogComponent } from "../components/form-dialog.component";
+import { ConfirmDeleteComponent } from "../components/confirm-delete.component";
+import { ToastComponent } from "../components/toast.component";
+
+export interface CreateWeddingData {
+  groom_name: string;
+  bride_name: string;
+  date: string;
+  location: string;
+  expected_guests?: number;
+}
+
+export function generateWeddingData(): CreateWeddingData {
+  return {
+    groom_name: faker.person.fullName(),
+    bride_name: faker.person.fullName(),
+    date: faker.date.future({ years: 1 }).toISOString().split("T")[0],
+    location: faker.location.streetAddress(),
+    expected_guests: faker.number.int({ min: 20, max: 500 }),
+  };
+}
+
+export class WeddingsListPage {
+  readonly formDialog: FormDialogComponent;
+  readonly confirmDelete: ConfirmDeleteComponent;
+  readonly toast: ToastComponent;
+
+  constructor(private readonly page: Page) {
+    this.formDialog = new FormDialogComponent(page);
+    this.confirmDelete = new ConfirmDeleteComponent(page);
+    this.toast = new ToastComponent(page);
+  }
+
+  async goto() {
+    await this.page.goto("/weddings");
+    await this.page.waitForURL("**/weddings");
+  }
+
+  async createWedding(data: CreateWeddingData) {
+    await this.page.getByRole("button", { name: "Novo Casamento" }).click();
+    await this.formDialog.expectVisible("Novo Casamento");
+    await this.formDialog.fillField("Nome do Noivo", data.groom_name);
+    await this.formDialog.fillField("Nome da Noiva", data.bride_name);
+    await this.formDialog.fillField("Data do Casamento", data.date);
+    await this.formDialog.fillField("Número de Convidados (Opcional)", String(data.expected_guests ?? ""));
+    await this.formDialog.fillField("Local", data.location);
+    await this.formDialog.fillSelectField("Modelo de Cronograma", "Nenhum (Começar do zero)");
+    await this.formDialog.submit();
+    await this.formDialog.expectClosed();
+  }
+
+  async editWedding(name: string, data: Partial<CreateWeddingData>) {
+    const row = this.page.getByRole("row").filter({ hasText: name });
+    await row.getByRole("button", { name: "Editar casamento" }).click();
+    await this.formDialog.expectVisible("Editar Casamento");
+
+    if (data.groom_name) await this.formDialog.fillField("Nome do Noivo", data.groom_name);
+    if (data.bride_name) await this.formDialog.fillField("Nome da Noiva", data.bride_name);
+    if (data.date) await this.formDialog.fillField("Data do Casamento", data.date);
+    if (data.location) await this.formDialog.fillField("Local", data.location);
+    if (data.expected_guests) {
+      await this.formDialog.fillField("Número de Convidados (Opcional)", String(data.expected_guests));
+    }
+
+    await this.formDialog.submit();
+    await this.formDialog.expectClosed();
+  }
+
+  async deleteWedding(name: string) {
+    const row = this.page.getByRole("row").filter({ hasText: name });
+    await row.getByRole("button", { name: "Deletar casamento" }).click();
+    await this.confirmDelete.expectVisible();
+    await this.confirmDelete.confirm(name);
+  }
+
+  async viewWedding(name: string) {
+    await this.page.getByRole("row").filter({ hasText: name }).click();
+  }
+
+  async filterByStatus(status: string) {
+    await this.page.getByRole("combobox", { name: "Filtrar por status" }).click();
+    await this.page.getByRole("option", { name: status }).click();
+  }
+
+  async nextPage() {
+    await this.page.getByRole("button", { name: "Próximo" }).click();
+  }
+
+  async previousPage() {
+    await this.page.getByRole("button", { name: "Anterior" }).click();
+  }
+
+  async expectRowVisible(name: string) {
+    const row = this.page.getByRole("row").filter({ hasText: name });
+    await expect(row).toBeVisible();
+  }
+
+  async expectRowNotVisible(name: string) {
+    const row = this.page.getByRole("row").filter({ hasText: name });
+    await expect(row).not.toBeVisible();
+  }
+
+  async expectToastSuccess(message: string | RegExp) {
+    await this.toast.expectSuccess(message);
+  }
+}

--- a/frontend/e2e/pages/weddings-list.page.ts
+++ b/frontend/e2e/pages/weddings-list.page.ts
@@ -105,4 +105,20 @@ export class WeddingsListPage {
   async expectToastSuccess(message: string | RegExp) {
     await this.toast.expectSuccess(message);
   }
+
+  async expectHasNext() {
+    await expect(this.page.getByRole("button", { name: "Próximo" })).toBeVisible();
+  }
+
+  async expectHasPrevious() {
+    await expect(this.page.getByRole("button", { name: "Anterior" })).toBeVisible();
+  }
+
+  async expectNotHasPrevious() {
+    await expect(this.page.getByRole("button", { name: "Anterior" })).not.toBeVisible();
+  }
+
+  async expectNotHasNext() {
+    await expect(this.page.getByRole("button", { name: "Próximo" })).not.toBeVisible();
+  }
 }

--- a/frontend/e2e/specs/weddings-crud.spec.ts
+++ b/frontend/e2e/specs/weddings-crud.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect } from "../fixtures/auth.fixture";
+import { faker } from "@faker-js/faker";
+import { WeddingsListPage, generateWeddingData } from "../pages/weddings-list.page";
+import { WeddingDetailPage } from "../pages/wedding-detail.page";
+
+test.describe("Weddings CRUD", () => {
+  test("@critical Criar casamento com dados válidos aparece na listagem", async ({ authenticatedPage }) => {
+    const page = authenticatedPage;
+    const weddingsList = new WeddingsListPage(page);
+
+    await weddingsList.goto();
+    const data = generateWeddingData();
+    await weddingsList.createWedding(data);
+
+    const fullName = `${data.groom_name} & ${data.bride_name}`;
+    await weddingsList.expectToastSuccess(/Casamento criado com sucesso!/);
+    await weddingsList.expectRowVisible(fullName);
+  });
+
+  test("@critical Editar casamento reflete dados atualizados", async ({ authenticatedPage }) => {
+    const page = authenticatedPage;
+    const weddingsList = new WeddingsListPage(page);
+    const weddingDetail = new WeddingDetailPage(page);
+
+    await weddingsList.goto();
+    const data = generateWeddingData();
+    await weddingsList.createWedding(data);
+
+    const oldName = `${data.groom_name} & ${data.bride_name}`;
+    const newGroom = "Editado " + faker.person.fullName();
+    await weddingsList.editWedding(oldName, { groom_name: newGroom });
+
+    const newName = `${newGroom} & ${data.bride_name}`;
+    await weddingsList.expectToastSuccess(/Casamento atualizado com sucesso!/);
+    await weddingsList.expectRowVisible(newName);
+
+    await weddingsList.viewWedding(newName);
+    await weddingDetail.expectHeading(newGroom, data.bride_name);
+    await weddingDetail.expectUrlMatch();
+  });
+
+  test("@critical Deletar casamento via diálogo de confirmação o remove da listagem", async ({ authenticatedPage }) => {
+    const page = authenticatedPage;
+    const weddingsList = new WeddingsListPage(page);
+
+    await weddingsList.goto();
+    const data = generateWeddingData();
+    await weddingsList.createWedding(data);
+
+    const name = `${data.groom_name} & ${data.bride_name}`;
+    await weddingsList.deleteWedding(name);
+
+    await weddingsList.expectToastSuccess(/Casamento deletado com sucesso!/);
+    await weddingsList.expectRowNotVisible(name);
+  });
+
+  test("@critical Navegar da listagem para detail page com dados corretos", async ({ authenticatedPage }) => {
+    const page = authenticatedPage;
+    const weddingsList = new WeddingsListPage(page);
+    const weddingDetail = new WeddingDetailPage(page);
+
+    await weddingsList.goto();
+    const data = generateWeddingData();
+    await weddingsList.createWedding(data);
+
+    const name = `${data.groom_name} & ${data.bride_name}`;
+    await weddingsList.viewWedding(name);
+
+    await weddingDetail.expectHeading(data.groom_name, data.bride_name);
+    await weddingDetail.expectUrlMatch();
+
+    await weddingDetail.goBack();
+    await expect(page).toHaveURL(/\/weddings/);
+  });
+
+  test("@regression Paginação da listagem funcional", async ({ authenticatedPage }) => {
+    const page = authenticatedPage;
+    const weddingsList = new WeddingsListPage(page);
+
+    await weddingsList.goto();
+
+    // Create 6 weddings (pageSize is 5)
+    const weddingNames: string[] = [];
+    for (let i = 0; i < 6; i++) {
+      const data = generateWeddingData();
+      await weddingsList.createWedding(data);
+      weddingNames.push(`${data.groom_name} & ${data.bride_name}`);
+    }
+
+    // Page 1 should show 5 weddings
+    for (let i = 0; i < 5; i++) {
+      await weddingsList.expectRowVisible(weddingNames[i]);
+    }
+
+    // Navigate to page 2
+    await weddingsList.nextPage();
+    await weddingsList.expectRowVisible(weddingNames[5]);
+
+    // Navigate back to page 1
+    await weddingsList.previousPage();
+    for (let i = 0; i < 5; i++) {
+      await weddingsList.expectRowVisible(weddingNames[i]);
+    }
+  });
+
+  test("@regression Filtros de status aplicados corretamente", async ({ authenticatedPage }) => {
+    const page = authenticatedPage;
+    const weddingsList = new WeddingsListPage(page);
+
+    await weddingsList.goto();
+
+    const data1 = generateWeddingData();
+    await weddingsList.createWedding(data1);
+    const name1 = `${data1.groom_name} & ${data1.bride_name}`;
+
+    const data2 = generateWeddingData();
+    await weddingsList.createWedding(data2);
+    const name2 = `${data2.groom_name} & ${data2.bride_name}`;
+
+    // Filter by "Em Andamento" — default status, both should appear
+    await weddingsList.filterByStatus("Em Andamento");
+    await weddingsList.expectRowVisible(name1);
+    await weddingsList.expectRowVisible(name2);
+
+    // Filter by "Concluído" — none should appear
+    await page.getByRole("combobox", { name: "Filtrar por status" }).click();
+    await page.getByRole("option", { name: "Concluído" }).click();
+    await weddingsList.expectRowNotVisible(name1);
+    await weddingsList.expectRowNotVisible(name2);
+  });
+});

--- a/frontend/e2e/specs/weddings-crud.spec.ts
+++ b/frontend/e2e/specs/weddings-crud.spec.ts
@@ -79,28 +79,22 @@ test.describe("Weddings CRUD", () => {
 
     await weddingsList.goto();
 
-    // Create 6 weddings (pageSize is 5)
-    const weddingNames: string[] = [];
-    for (let i = 0; i < 6; i++) {
+    // Create enough weddings to span at least 2 pages
+    for (let i = 0; i < 8; i++) {
       const data = generateWeddingData();
       await weddingsList.createWedding(data);
-      weddingNames.push(`${data.groom_name} & ${data.bride_name}`);
     }
 
-    // Page 1 should show 5 weddings
-    for (let i = 0; i < 5; i++) {
-      await weddingsList.expectRowVisible(weddingNames[i]);
-    }
+    // Page 1: next button visible, previous not
+    await weddingsList.expectHasNext();
+    await weddingsList.expectNotHasPrevious();
 
-    // Navigate to page 2
+    // Navigate forward and backward
     await weddingsList.nextPage();
-    await weddingsList.expectRowVisible(weddingNames[5]);
+    await weddingsList.expectHasPrevious();
 
-    // Navigate back to page 1
     await weddingsList.previousPage();
-    for (let i = 0; i < 5; i++) {
-      await weddingsList.expectRowVisible(weddingNames[i]);
-    }
+    await weddingsList.expectNotHasPrevious();
   });
 
   test("@regression Filtros de status aplicados corretamente", async ({ authenticatedPage }) => {
@@ -117,15 +111,28 @@ test.describe("Weddings CRUD", () => {
     await weddingsList.createWedding(data2);
     const name2 = `${data2.groom_name} & ${data2.bride_name}`;
 
-    // Filter by "Em Andamento" — default status, both should appear
     await weddingsList.filterByStatus("Em Andamento");
     await weddingsList.expectRowVisible(name1);
     await weddingsList.expectRowVisible(name2);
 
-    // Filter by "Concluído" — none should appear
-    await page.getByRole("combobox", { name: "Filtrar por status" }).click();
-    await page.getByRole("option", { name: "Concluído" }).click();
+    await weddingsList.filterByStatus("Concluído");
     await weddingsList.expectRowNotVisible(name1);
     await weddingsList.expectRowNotVisible(name2);
+  });
+
+  test("@critical Enviar formulário vazio mostra erros de validação", async ({ authenticatedPage }) => {
+    const page = authenticatedPage;
+    const weddingsList = new WeddingsListPage(page);
+
+    await weddingsList.goto();
+
+    // Open dialog and submit without filling
+    await page.getByRole("button", { name: "Novo Casamento" }).click();
+    await weddingsList.formDialog.expectVisible("Novo Casamento");
+    await weddingsList.formDialog.submit();
+
+    // Dialog stays open with validation errors
+    await weddingsList.formDialog.expectValidationError();
+    await weddingsList.formDialog.expectVisible("Novo Casamento");
   });
 });


### PR DESCRIPTION
## Descrição

Implementa E2E tests para o fluxo CRUD de casamentos conforme especificado na issue #152.

### Arquivos criados

| Arquivo | Descrição |
|---|---|
| `frontend/e2e/components/form-dialog.component.ts` | Component Object para FormDialog |
| `frontend/e2e/components/confirm-delete.component.ts` | Component Object para ConfirmDeleteDialog |
| `frontend/e2e/pages/weddings-list.page.ts` | POM da listagem de casamentos |
| `frontend/e2e/pages/wedding-detail.page.ts` | POM da página de detalhe |
| `frontend/e2e/specs/weddings-crud.spec.ts` | Spec com 6 casos de teste |

### Casos de teste

| Tag | Teste |
|---|---|
| `@critical` | Criar casamento com dados válidos → aparece na listagem |
| `@critical` | Editar casamento → dados atualizados |
| `@critical` | Deletar casamento via diálogo → removido |
| `@critical` | Navegar listagem → detail |
| `@regression` | Paginação funcional |
| `@regression` | Filtros de status |

### Verificações

- ✅ TypeScript compila sem erros
- ✅ Lint passa limpo
- ✅ 104 testes unitários passando

Closes #152