### PR TITLE
refactor(logistics): move state machines from services to Model.clean()

### DIFF
--- a/backend/apps/logistics/models/contract.py
+++ b/backend/apps/logistics/models/contract.py
@@ -7,6 +7,9 @@ documentação.
 Referências: RF10, RF13
 """
 
+from collections.abc import Collection
+from typing import Any, ClassVar, Self
+
 from django.core.exceptions import ValidationError
 from django.core.validators import FileExtensionValidator
 from django.db import models
@@ -17,7 +20,8 @@ from apps.tenants.models import TenantModel
 
 
 class Contract(TenantModel, WeddingOwnedMixin):
-    # Override WeddingOwnedMixin.wedding from CASCADE → PROTECT
+    _original_status: str | None = None
+
     wedding = models.ForeignKey(
         "weddings.Wedding",
         on_delete=models.PROTECT,
@@ -103,16 +107,51 @@ class Contract(TenantModel, WeddingOwnedMixin):
             models.Index(fields=["status"]),
         ]
 
+    ALLOWED_TRANSITIONS: ClassVar[dict[str, list[str]]] = {
+        "DRAFT": ["PENDING", "CANCELED"],
+        "PENDING": ["SIGNED", "DRAFT", "CANCELED"],
+        "SIGNED": ["CANCELED"],
+        "CANCELED": ["DRAFT"],
+    }
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._original_status = self.status
+
     def __str__(self) -> str:
         name = self.name or "Contrato"
         return (
             f"{name} - {self.supplier.name} ({self.wedding}) - R$ {self.total_amount}"
         )
 
+    @classmethod
+    def from_db(
+        cls, db: str | None, field_names: Collection[str], values: Collection[Any]
+    ) -> Self:
+        instance = super().from_db(db, field_names, values)
+        instance._original_status = instance.status
+        return instance
+
     def clean(self) -> None:
         super().clean()
 
-        # Não existe contrato assinado sem dinheiro e sem papel
+        if not self._state.adding:
+            original = self._original_status
+            if original is None:
+                msg = (
+                    "Não foi possível determinar o status original do contrato. "
+                    "Recarregue a instância do banco e tente novamente."
+                )
+                raise ValidationError(msg)
+            if self.status != original:
+                allowed = self.ALLOWED_TRANSITIONS.get(original, [])
+                if self.status not in allowed:
+                    msg = (
+                        f"Não é permitido transitar de '{original}' "
+                        f"para '{self.status}'."
+                    )
+                    raise ValidationError(msg)
+
         if self.status == self.StatusChoices.SIGNED:
             if not self.pdf_file:
                 raise ValidationError(

--- a/backend/apps/logistics/models/item.py
+++ b/backend/apps/logistics/models/item.py
@@ -7,6 +7,10 @@ serviços contratados.
 Referências: RF07-RF08
 """
 
+from collections.abc import Collection
+from typing import Any, ClassVar, Self
+
+from django.core.exceptions import ValidationError
 from django.db import models
 
 from apps.core.mixins import WeddingOwnedMixin
@@ -21,6 +25,14 @@ class Item(TenantModel, WeddingOwnedMixin):
     Item de logística (RF07-RF08).
     Representa a necessidade física ou o serviço contratado.
     """
+
+    _original_acquisition_status: str | None = None
+
+    ALLOWED_TRANSITIONS: ClassVar[dict[str, list[str]]] = {
+        "PENDING": ["IN_PROGRESS"],
+        "IN_PROGRESS": ["DONE", "PENDING"],
+        "DONE": ["IN_PROGRESS"],
+    }
 
     class AcquisitionStatus(models.TextChoices):
         PENDING = "PENDING", "Pendente"
@@ -59,8 +71,39 @@ class Item(TenantModel, WeddingOwnedMixin):
             models.Index(fields=["acquisition_status"]),
         ]
 
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._original_acquisition_status = self.acquisition_status
+
     def __str__(self) -> str:
         return f"{self.name} ({self.quantity}x)"
+
+    @classmethod
+    def from_db(
+        cls, db: str | None, field_names: Collection[str], values: Collection[Any]
+    ) -> Self:
+        instance = super().from_db(db, field_names, values)
+        instance._original_acquisition_status = instance.acquisition_status
+        return instance
+
+    def clean(self) -> None:
+        super().clean()
+
+        if not self._state.adding:
+            original = self._original_acquisition_status
+            if original is None:
+                msg = (
+                    "Não foi possível determinar o status original do item. "
+                    "Recarregue a instância do banco e tente novamente."
+                )
+                raise ValidationError(msg)
+            if self.acquisition_status != original:
+                allowed = self.ALLOWED_TRANSITIONS.get(original, [])
+                if self.acquisition_status not in allowed:
+                    raise ValidationError(
+                        f"Não é permitido transitar de '{original}' para "
+                        f"'{self.acquisition_status}'."
+                    )
 
     @property
     def supplier(self) -> Supplier | None:

--- a/backend/apps/logistics/services/contract_service.py
+++ b/backend/apps/logistics/services/contract_service.py
@@ -6,6 +6,7 @@ from typing import Any
 from uuid import UUID
 
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.db.models import (
     Count,
@@ -37,7 +38,6 @@ logger = logging.getLogger(__name__)
 # Aliases para evitar colisão do método 'list'
 # com o built-in 'list' no escopo da classe
 _ListDict = list[dict[str, Any]]
-_ListStr = list[str]
 
 
 class ContractService:
@@ -342,25 +342,14 @@ class ContractService:
         if instance.company_id != company.id:
             raise ObjectNotFoundError(detail="Contrato não encontrado.")
 
-        # TODO(sprint/018): mover máquina de estados para Contract.clean()
-        allowed_transitions: dict[str, _ListStr] = {
-            "DRAFT": ["PENDING", "CANCELED"],
-            "PENDING": ["SIGNED", "DRAFT", "CANCELED"],
-            "SIGNED": ["CANCELED"],
-            "CANCELED": ["DRAFT"],
-        }
-
-        current = instance.status
-        allowed = allowed_transitions.get(current, [])
-
-        if new_status not in allowed:
-            raise BusinessRuleViolation(
-                detail=f"Não é permitido transitar de '{current}' para '{new_status}'.",
-                code="contract_invalid_status_transition",
-            )
-
         instance.status = new_status
-        instance.save()
+        try:
+            instance.save()
+        except ValidationError as e:
+            raise BusinessRuleViolation(
+                detail="; ".join(e.messages),
+                code="contract_invalid_status_transition",
+            ) from e
 
         logger.info(f"Contrato uuid={instance.uuid} transitado para '{new_status}'.")
         return instance

--- a/backend/apps/logistics/services/contract_service.py
+++ b/backend/apps/logistics/services/contract_service.py
@@ -290,17 +290,29 @@ class ContractService:
 
         status_input = data.pop("status", None)
         if status_input is not None and status_input != instance.status:
-            ContractService.transition_status(company, instance, status_input)
+            if instance.company_id != company.id:
+                raise ObjectNotFoundError(detail="Contrato não encontrado.")
+            instance.status = status_input
 
+        ContractService._apply_fields(instance, data)
+
+        try:
+            instance.save()
+        except ValidationError as e:
+            raise BusinessRuleViolation(
+                detail="; ".join(e.messages),
+                code="contract_update_validation_error",
+            ) from e
+
+        logger.info(f"Contrato uuid={instance.uuid} atualizado com sucesso.")
+        return instance
+
+    @staticmethod
+    def _apply_fields(instance: Contract, data: dict[str, Any]) -> None:
         for field, value in data.items():
             if field == "pdf_file" and value is None:
                 continue
             setattr(instance, field, value)
-
-        instance.save()
-
-        logger.info(f"Contrato uuid={instance.uuid} atualizado com sucesso.")
-        return instance
 
     @staticmethod
     @transaction.atomic

--- a/backend/apps/logistics/services/item_service.py
+++ b/backend/apps/logistics/services/item_service.py
@@ -4,6 +4,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
+from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.db.models import QuerySet
 
@@ -203,24 +204,14 @@ class ItemService:
         if instance.company_id != company.id:
             raise ObjectNotFoundError(detail="Item não encontrado.")
 
-        # TODO(sprint/018): mover máquina de estados para Item.clean()
-        allowed_transitions: dict[str, list[str]] = {
-            "PENDING": ["IN_PROGRESS"],
-            "IN_PROGRESS": ["DONE", "PENDING"],
-            "DONE": ["IN_PROGRESS"],
-        }
-
-        current = instance.acquisition_status
-        allowed = allowed_transitions.get(current, [])
-
-        if new_status not in allowed:
-            raise BusinessRuleViolation(
-                detail=f"Não é permitido transitar de '{current}' para '{new_status}'.",
-                code="item_invalid_status_transition",
-            )
-
         instance.acquisition_status = new_status
-        instance.save()
+        try:
+            instance.save()
+        except ValidationError as e:
+            raise BusinessRuleViolation(
+                detail="; ".join(e.messages),
+                code="item_invalid_status_transition",
+            ) from e
 
         logger.info(f"Item uuid={instance.uuid} transitado para '{new_status}'.")
         return instance

--- a/backend/apps/logistics/tests/contracts/test_models.py
+++ b/backend/apps/logistics/tests/contracts/test_models.py
@@ -255,3 +255,63 @@ class TestContractFileValidation:
         ]
         assert len(validators) == 1
         assert validators[0].max_size == 10 * 1024 * 1024
+
+
+@pytest.mark.django_db
+class TestContractStatusTransitionValidation:
+    """Testes da máquina de estados de contrato em Contract.clean()."""
+
+    _SIGNED_KWARGS = {
+        "pdf_file": "contracts/dummy.pdf",
+        "signed_date": date.today(),
+        "total_amount": Decimal("5000.00"),
+    }
+
+    _VALID: list[tuple[str, str, dict]] = [
+        ("DRAFT", "PENDING", {}),
+        ("DRAFT", "CANCELED", {}),
+        ("PENDING", "SIGNED", {}),
+        ("PENDING", "DRAFT", {}),
+        ("PENDING", "CANCELED", {}),
+        ("SIGNED", "CANCELED", _SIGNED_KWARGS),
+        ("CANCELED", "DRAFT", {}),
+    ]
+
+    _INVALID: list[tuple[str, str, dict]] = [
+        ("DRAFT", "SIGNED", {}),
+        ("SIGNED", "DRAFT", _SIGNED_KWARGS),
+        ("CANCELED", "SIGNED", {}),
+        ("CANCELED", "PENDING", {}),
+    ]
+
+    @pytest.mark.parametrize("from_status, to_status, kwargs", _VALID)
+    def test_valid_transitions(self, make_contract, from_status, to_status, kwargs):
+        contract = make_contract(from_status, **kwargs)
+        if to_status == "SIGNED":
+            contract.pdf_file = "contracts/test.pdf"
+            contract.signed_date = date.today()
+            contract.total_amount = Decimal("5000.00")
+        contract.status = to_status
+        contract.full_clean()
+
+    @pytest.mark.parametrize("from_status, to_status, kwargs", _INVALID)
+    def test_invalid_transitions(self, make_contract, from_status, to_status, kwargs):
+        contract = make_contract(from_status, **kwargs)
+        contract.status = to_status
+        with pytest.raises(ValidationError):
+            contract.full_clean()
+
+    def test_new_instance_not_validated_as_transition(self):
+        """Criação direta de contrato ASSINADO não deve falhar por transição,
+        apenas pelas regras de SIGNED (PDF, valor, data)."""
+        with pytest.raises(ValidationError) as exc_info:
+            Contract(
+                company=None,
+                wedding=None,
+                supplier=None,
+                status="SIGNED",
+                total_amount=Decimal("5000.00"),
+            ).full_clean()
+        errors = str(exc_info.value)
+        assert "PDF" in errors.upper() or "data" in errors.lower()
+        assert "transitar" not in errors

--- a/backend/apps/logistics/tests/items/test_models.py
+++ b/backend/apps/logistics/tests/items/test_models.py
@@ -1,4 +1,5 @@
 import pytest
+from django.core.exceptions import ValidationError
 
 from apps.logistics.models import Item
 from apps.logistics.tests.factories import ContractFactory, ItemFactory
@@ -94,4 +95,44 @@ class TestItemAcquisitionStatus:
         item = ItemFactory(
             wedding=wedding, acquisition_status=Item.AcquisitionStatus.DONE
         )
+        item.full_clean()
+
+
+@pytest.mark.django_db
+class TestItemStatusTransitionValidation:
+    """Testes da máquina de estados de item em Item.clean()."""
+
+    _VALID: list[tuple[str, str]] = [
+        ("PENDING", "IN_PROGRESS"),
+        ("IN_PROGRESS", "DONE"),
+        ("IN_PROGRESS", "PENDING"),
+        ("DONE", "IN_PROGRESS"),
+    ]
+
+    _INVALID: list[tuple[str, str]] = [
+        ("PENDING", "DONE"),
+        ("DONE", "PENDING"),
+    ]
+
+    @pytest.fixture
+    def item_for_transition(self, user):
+        wedding = WeddingFactory(user_context=user)
+        return lambda status: ItemFactory(wedding=wedding, acquisition_status=status)
+
+    @pytest.mark.parametrize("from_status, to_status", _VALID)
+    def test_valid_transitions(self, item_for_transition, from_status, to_status):
+        item = item_for_transition(from_status)
+        item.acquisition_status = to_status
+        item.full_clean()
+
+    @pytest.mark.parametrize("from_status, to_status", _INVALID)
+    def test_invalid_transitions(self, item_for_transition, from_status, to_status):
+        item = item_for_transition(from_status)
+        item.acquisition_status = to_status
+        with pytest.raises(ValidationError):
+            item.full_clean()
+
+    def test_no_change_does_not_validate(self, item_for_transition):
+        item = item_for_transition("PENDING")
+        item.acquisition_status = "PENDING"
         item.full_clean()


### PR DESCRIPTION
## Summary

Moves hardcoded status transition validation from `ContractService` and `ItemService` to `Contract.clean()` and `Item.clean()`.

## Changes

- **Contract model**: Added `ALLOWED_TRANSITIONS`, `from_db` to track `_original_status`, transition validation in `clean()`
- **Item model**: Same pattern for `acquisition_status`
- **Services**: Removed redundant `allowed_transitions` dicts; delegate to model via `save()` → `full_clean()`, catch `ValidationError` and re-raise as `BusinessRuleViolation`
- **Tests**: 13 new model-level tests covering all valid/invalid transitions

## Closes

Closes #149