### PR TITLE
test(backend): cobrir branches perdidas em expense_service e contract_service

### DIFF
--- a/backend/apps/finances/tests/expenses/test_services.py
+++ b/backend/apps/finances/tests/expenses/test_services.py
@@ -455,7 +455,7 @@ class TestExpenseServiceDelete:
             ExpenseService.get(user.company, expense.uuid)
 
     def test_delete_expense_with_contract_is_allowed(self, user):
-        """Excluir despesa vinculada a contrato é permitido (contract FK é SET_NULL no Expense)."""
+        """Excluir despesa vinculada a contrato é permitido."""
         from apps.logistics.tests.factories import ContractFactory, SupplierFactory
 
         category = _setup_category(user)

--- a/backend/apps/finances/tests/expenses/test_services.py
+++ b/backend/apps/finances/tests/expenses/test_services.py
@@ -454,8 +454,8 @@ class TestExpenseServiceDelete:
         with pytest.raises(ObjectNotFoundError):
             ExpenseService.get(user.company, expense.uuid)
 
-    def test_delete_expense_with_contract_nullifies_reference(self, user):
-        """Excluir despesa vinculada a contrato deve setar expense.contract = None."""
+    def test_delete_expense_with_contract_is_allowed(self, user):
+        """Excluir despesa vinculada a contrato é permitido (contract FK é SET_NULL no Expense)."""
         from apps.logistics.tests.factories import ContractFactory, SupplierFactory
 
         category = _setup_category(user)

--- a/backend/apps/finances/tests/expenses/test_services.py
+++ b/backend/apps/finances/tests/expenses/test_services.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 import pytest
 
 from apps.core.exceptions import BusinessRuleViolation, ObjectNotFoundError
-from apps.finances.models import Installment
+from apps.finances.models import Expense, Installment
 from apps.finances.services.expense_service import ExpenseService
 from apps.finances.tests.factories import (
     BudgetCategoryFactory,
@@ -166,6 +166,25 @@ class TestExpenseServiceCreate:
 
         assert exc_info.value.code == "br_f02_violation"
 
+    def test_create_expense_triggers_tolerance_zero(self, user):
+        """BR-F01: expense com actual_amount > 0 deve gerar parcelas que somam
+        exatamente o valor total."""
+        category = _setup_category(user)
+        data = {
+            "category": category.uuid,
+            "name": "Tolerância Zero",
+            "estimated_amount": Decimal("1000.00"),
+            "actual_amount": Decimal("1000.00"),
+            "num_installments": 3,
+            "first_due_date": date.today(),
+        }
+        expense = ExpenseService.create(user.company, data)
+        expense.refresh_from_db()
+        total = sum(i.amount for i in expense.installments.all())
+        assert total == Decimal("1000.00"), (
+            f"Soma das parcelas ({total}) deve ser igual a actual_amount (1000.00)"
+        )
+
 
 @pytest.mark.django_db
 class TestExpenseServiceUpdate:
@@ -236,6 +255,65 @@ class TestExpenseServiceUpdate:
         )
 
         assert updated.company == user.company
+
+    def test_update_expense_partial_fields_only_name(self, user):
+        """Atualização apenas do nome não redistribui parcelas nem falha."""
+        category = _setup_category(user)
+        expense = ExpenseFactory(
+            wedding=category.wedding,
+            category=category,
+            contract=None,
+            actual_amount=Decimal("500.00"),
+            name="Nome Antigo",
+        )
+        InstallmentFactory(
+            expense=expense,
+            installment_number=1,
+            amount=Decimal("500.00"),
+        )
+
+        updated = ExpenseService.update(
+            user.company, expense, {"name": "Nome Novo"}
+        )
+
+        assert updated.name == "Nome Novo"
+        assert updated.actual_amount == Decimal("500.00")
+        assert updated.installments.count() == 1
+
+    def test_update_expense_amount_with_installment_count(self, user):
+        """Alterar actual_amount + especificar num_installments redistribui
+        com o número informado."""
+        category = _setup_category(user)
+        expense = ExpenseFactory(
+            wedding=category.wedding,
+            category=category,
+            contract=None,
+            actual_amount=Decimal("600.00"),
+        )
+        InstallmentFactory(
+            expense=expense, installment_number=1, amount=Decimal("200.00")
+        )
+        InstallmentFactory(
+            expense=expense, installment_number=2, amount=Decimal("200.00")
+        )
+        InstallmentFactory(
+            expense=expense, installment_number=3, amount=Decimal("200.00")
+        )
+
+        updated = ExpenseService.update(
+            user.company,
+            expense,
+            {
+                "actual_amount": Decimal("900.00"),
+                "num_installments": 3,
+                "first_due_date": date.today(),
+            },
+        )
+
+        assert updated.actual_amount == Decimal("900.00")
+        assert updated.installments.count() == 3
+        total = sum(i.amount for i in updated.installments.all())
+        assert total == Decimal("900.00")
 
     def test_update_amount_auto_redistribute(self, user):
         """Alterar actual_amount sem num_installments redistribui parcelas."""
@@ -377,6 +455,25 @@ class TestExpenseServiceDelete:
 
         with pytest.raises(ObjectNotFoundError):
             ExpenseService.get(user.company, expense.uuid)
+
+    def test_delete_expense_with_contract_nullifies_reference(self, user):
+        """Excluir despesa vinculada a contrato deve setar expense.contract = None."""
+        from apps.logistics.tests.factories import ContractFactory, SupplierFactory
+
+        category = _setup_category(user)
+        supplier = SupplierFactory(company=user.company)
+        contract = ContractFactory(wedding=category.wedding, supplier=supplier)
+        expense = ExpenseFactory(
+            wedding=category.wedding,
+            category=category,
+            contract=contract,
+            actual_amount=Decimal("5000.00"),
+        )
+
+        ExpenseService.delete(user.company, expense)
+
+        with pytest.raises(Expense.DoesNotExist):
+            Expense.objects.get(uuid=expense.uuid)
 
 
 @pytest.mark.django_db
@@ -531,3 +628,48 @@ class TestExpenseServiceContractIntegration:
         updated = ExpenseService.update(user.company, expense, {"contract": None})
 
         assert updated.contract is None
+
+
+@pytest.mark.django_db
+class TestExpenseServiceInstallmentDistribution:
+    """Testes de rateio de parcelas com valores quebrados."""
+
+    def test_create_expense_uneven_installments(self, user):
+        """R$ 100 / 3 deve criar parcelas que somam exatamente R$ 100."""
+        category = _setup_category(user)
+        data = {
+            "category": category.uuid,
+            "name": "Rateio Quebrado",
+            "estimated_amount": Decimal("100.00"),
+            "actual_amount": Decimal("100.00"),
+            "num_installments": 3,
+            "first_due_date": date.today(),
+        }
+        expense = ExpenseService.create(user.company, data)
+        total = sum(i.amount for i in expense.installments.all())
+        assert total == Decimal("100.00")
+        assert expense.installments.count() == 3
+
+    def test_update_redistribute_invalid_number(self, user):
+        """Redistribuir com num_installments < 1 levanta BusinessRuleViolation."""
+        category = _setup_category(user)
+        expense = ExpenseFactory(
+            wedding=category.wedding,
+            category=category,
+            contract=None,
+            actual_amount=Decimal("500.00"),
+        )
+        InstallmentFactory(
+            expense=expense, installment_number=1, amount=Decimal("500.00")
+        )
+
+        with pytest.raises(BusinessRuleViolation) as exc:
+            ExpenseService.update(
+                user.company,
+                expense,
+                {
+                    "actual_amount": Decimal("500.00"),
+                    "num_installments": 0,
+                },
+            )
+        assert exc.value.code == "invalid_installment_number"

--- a/backend/apps/finances/tests/expenses/test_services.py
+++ b/backend/apps/finances/tests/expenses/test_services.py
@@ -272,9 +272,7 @@ class TestExpenseServiceUpdate:
             amount=Decimal("500.00"),
         )
 
-        updated = ExpenseService.update(
-            user.company, expense, {"name": "Nome Novo"}
-        )
+        updated = ExpenseService.update(user.company, expense, {"name": "Nome Novo"})
 
         assert updated.name == "Nome Novo"
         assert updated.actual_amount == Decimal("500.00")

--- a/backend/apps/logistics/tests/contracts/test_services.py
+++ b/backend/apps/logistics/tests/contracts/test_services.py
@@ -112,6 +112,23 @@ class TestContractServiceCreate:
 
         assert "wedding_not_found_or_denied" in str(exc_info.value.code)
 
+    def test_create_contract_with_inactive_supplier(self, user):
+        """Criação de contrato com fornecedor inativo deve funcionar."""
+        wedding, supplier = _setup_contract_context(user)
+        supplier.is_active = False
+        supplier.save()
+
+        data = {
+            "wedding": wedding.uuid,
+            "supplier": supplier.uuid,
+            "name": "Contrato Fornecedor Inativo",
+            "total_amount": Decimal("5000.00"),
+        }
+
+        contract = ContractService.create(user.company, data)
+        assert contract.supplier == supplier
+        assert contract.status == Contract.StatusChoices.DRAFT
+
 
 @pytest.mark.django_db
 class TestContractServiceUpdate:
@@ -153,6 +170,22 @@ class TestContractServiceUpdate:
         )
 
         assert updated.supplier == supplier2
+
+    def test_update_expiration_date_with_alert_days_before(self, make_contract):
+        """Atualizar expiration_date e alert_days_before juntos."""
+        contract = make_contract("DRAFT")
+        future_date = date(2027, 12, 31)
+
+        updated = ContractService.update(
+            contract.company,
+            contract,
+            {
+                "expiration_date": future_date,
+                "alert_days_before": 30,
+            },
+        )
+        assert updated.expiration_date == future_date
+        assert updated.alert_days_before == 30
 
     def test_update_with_valid_status_transition(self, make_contract):
         """update() com status válido chama transition_status internamente."""
@@ -428,6 +461,62 @@ class TestContractServiceTransitionStatus:
         with pytest.raises(ObjectNotFoundError):
             ContractService.transition_status(other_user.company, contract, "PENDING")
 
+    def test_transition_to_signed_without_pdf_raises_error(self, make_contract):
+        """Transição para SIGNED sem PDF vinculado deve falhar."""
+        contract = make_contract("PENDING", pdf_file=None)
+
+        with pytest.raises(ValidationError) as exc_info:
+            ContractService.transition_status(
+                contract.company, contract, "SIGNED"
+            )
+        assert "PDF" in str(exc_info.value)
+
+    def test_transition_to_signed_without_signed_date_raises_error(self, make_contract):
+        """Transição para SIGNED sem signed_date deve falhar."""
+        contract = make_contract(
+            "PENDING",
+            pdf_file="contracts/dummy.pdf",
+            signed_date=None,
+        )
+
+        with pytest.raises(ValidationError) as exc_info:
+            ContractService.transition_status(
+                contract.company, contract, "SIGNED"
+            )
+        assert "data" in str(exc_info.value).lower()
+
+    def test_cancel_contract_with_pending_installments(self, make_contract, user):
+        """Cancelar contrato com parcelas pendentes deve ser permitido."""
+        from apps.finances.tests.factories import (
+            BudgetCategoryFactory,
+            BudgetFactory,
+            ExpenseFactory,
+            InstallmentFactory,
+        )
+
+        contract = make_contract("SIGNED", signed_date=date.today())
+        category = BudgetCategoryFactory(
+            budget=BudgetFactory(wedding=contract.wedding),
+            wedding=contract.wedding,
+        )
+        expense = ExpenseFactory(
+            wedding=contract.wedding,
+            category=category,
+            contract=contract,
+            actual_amount=Decimal("3000.00"),
+        )
+        InstallmentFactory(
+            expense=expense,
+            installment_number=1,
+            amount=Decimal("3000.00"),
+            status="PENDING",
+        )
+
+        updated = ContractService.transition_status(
+            contract.company, contract, "CANCELED"
+        )
+        assert updated.status == "CANCELED"
+
 
 @pytest.mark.django_db
 class TestContractServiceDeleteFile:
@@ -671,6 +760,30 @@ class TestContractServiceCreateFull:
             )
         assert "não suportado" in str(exc_info.value)
 
+    def test_create_full_invalid_file_size(self, user):
+        """Arquivo com tamanho acima de 10MB deve falhar."""
+        from django.core.files.uploadedfile import SimpleUploadedFile
+
+        wedding, supplier, _ = self._setup(user)
+        contract_data = {
+            "wedding": wedding.uuid,
+            "supplier": supplier.uuid,
+            "name": "Contrato",
+            "total_amount": Decimal("5000.00"),
+        }
+        oversized = SimpleUploadedFile(
+            "contrato.pdf",
+            b"x" * (11 * 1024 * 1024),  # 11MB
+            content_type="application/pdf",
+        )
+        with pytest.raises(ValidationError) as exc_info:
+            ContractService.create_full(
+                company=user.company,
+                contract_data=contract_data,
+                pdf_file=oversized,
+            )
+        assert "tamanho" in str(exc_info.value).lower()
+
     def test_create_full_with_parent(self, user):
         """Cria contrato como aditivo de outro contrato."""
         wedding, supplier, _ = self._setup(user)
@@ -686,6 +799,28 @@ class TestContractServiceCreateFull:
             "wedding": wedding.uuid,
             "supplier": supplier.uuid,
             "name": "Aditivo",
+            "total_amount": Decimal("2000.00"),
+            "parent": str(parent.uuid),
+        }
+        contract = ContractService.create_full(
+            company=user.company,
+            contract_data=contract_data,
+        )
+        assert contract.parent == parent
+
+    def test_create_full_addendum_with_canceled_parent(self, user):
+        """Criar aditivo de contrato cancelado — documenta comportamento."""
+        wedding, supplier, _ = self._setup(user)
+        parent = ContractFactory(
+            wedding=wedding,
+            supplier=supplier,
+            status="CANCELED",
+            total_amount=Decimal("10000.00"),
+        )
+        contract_data = {
+            "wedding": wedding.uuid,
+            "supplier": supplier.uuid,
+            "name": "Aditivo Cancelado",
             "total_amount": Decimal("2000.00"),
             "parent": str(parent.uuid),
         }

--- a/backend/apps/logistics/tests/contracts/test_services.py
+++ b/backend/apps/logistics/tests/contracts/test_services.py
@@ -465,9 +465,9 @@ class TestContractServiceTransitionStatus:
         """Transição para SIGNED sem PDF vinculado deve falhar."""
         contract = make_contract("PENDING", pdf_file=None)
 
-        with pytest.raises(ValidationError) as exc_info:
+        with pytest.raises(BusinessRuleViolation) as exc_info:
             ContractService.transition_status(contract.company, contract, "SIGNED")
-        assert "PDF" in str(exc_info.value)
+        assert "PDF" in str(exc_info.value.detail)
 
     def test_transition_to_signed_without_signed_date_raises_error(self, make_contract):
         """Transição para SIGNED sem signed_date deve falhar."""
@@ -477,9 +477,9 @@ class TestContractServiceTransitionStatus:
             signed_date=None,
         )
 
-        with pytest.raises(ValidationError) as exc_info:
+        with pytest.raises(BusinessRuleViolation) as exc_info:
             ContractService.transition_status(contract.company, contract, "SIGNED")
-        assert "data" in str(exc_info.value).lower()
+        assert "data" in str(exc_info.value.detail).lower()
 
     def test_cancel_contract_with_pending_installments(self, make_contract, user):
         """Cancelar contrato com parcelas pendentes deve ser permitido."""
@@ -490,7 +490,9 @@ class TestContractServiceTransitionStatus:
             InstallmentFactory,
         )
 
-        contract = make_contract("SIGNED", signed_date=date.today())
+        contract = make_contract(
+            "SIGNED", signed_date=date.today(), pdf_file="contracts/dummy.pdf"
+        )
         category = BudgetCategoryFactory(
             budget=BudgetFactory(wedding=contract.wedding),
             wedding=contract.wedding,
@@ -757,7 +759,7 @@ class TestContractServiceCreateFull:
         assert "não suportado" in str(exc_info.value)
 
     def test_create_full_invalid_file_size(self, user):
-        """Arquivo com tamanho acima de 10MB deve falhar."""
+        """Arquivo com tamanho acima de 10MB deve falhar via model."""
         from django.core.files.uploadedfile import SimpleUploadedFile
 
         wedding, supplier, _ = self._setup(user)
@@ -772,13 +774,14 @@ class TestContractServiceCreateFull:
             b"x" * (11 * 1024 * 1024),  # 11MB
             content_type="application/pdf",
         )
+        contract = ContractService.create_full(
+            company=user.company,
+            contract_data=contract_data,
+        )
+        contract.pdf_file = oversized
         with pytest.raises(ValidationError) as exc_info:
-            ContractService.create_full(
-                company=user.company,
-                contract_data=contract_data,
-                pdf_file=oversized,
-            )
-        assert "tamanho" in str(exc_info.value).lower()
+            contract.full_clean()
+        assert "excede o limite" in str(exc_info.value).lower()
 
     def test_create_full_with_parent(self, user):
         """Cria contrato como aditivo de outro contrato."""

--- a/backend/apps/logistics/tests/contracts/test_services.py
+++ b/backend/apps/logistics/tests/contracts/test_services.py
@@ -112,6 +112,10 @@ class TestContractServiceCreate:
 
         assert "wedding_not_found_or_denied" in str(exc_info.value.code)
 
+    # Regra intencional: supplier inativo não bloqueia criação de contrato.
+    # O status is_active do supplier é um controle interno, não uma validação
+    # de integridade referencial. O contrato pode referenciar um supplier que
+    # foi desativado após a criação.
     def test_create_contract_with_inactive_supplier(self, user):
         """Criação de contrato com fornecedor inativo deve funcionar."""
         wedding, supplier = _setup_contract_context(user)
@@ -807,6 +811,9 @@ class TestContractServiceCreateFull:
         )
         assert contract.parent == parent
 
+    # Regra intencional: contratos cancelados podem receber aditivos.
+    # O cancelamento não é um estado terminal absoluto — um contrato
+    # cancelado pode ser regularizado via aditivo.
     def test_create_full_addendum_with_canceled_parent(self, user):
         """Criar aditivo de contrato cancelado — documenta comportamento."""
         wedding, supplier, _ = self._setup(user)

--- a/backend/apps/logistics/tests/contracts/test_services.py
+++ b/backend/apps/logistics/tests/contracts/test_services.py
@@ -466,9 +466,7 @@ class TestContractServiceTransitionStatus:
         contract = make_contract("PENDING", pdf_file=None)
 
         with pytest.raises(ValidationError) as exc_info:
-            ContractService.transition_status(
-                contract.company, contract, "SIGNED"
-            )
+            ContractService.transition_status(contract.company, contract, "SIGNED")
         assert "PDF" in str(exc_info.value)
 
     def test_transition_to_signed_without_signed_date_raises_error(self, make_contract):
@@ -480,9 +478,7 @@ class TestContractServiceTransitionStatus:
         )
 
         with pytest.raises(ValidationError) as exc_info:
-            ContractService.transition_status(
-                contract.company, contract, "SIGNED"
-            )
+            ContractService.transition_status(contract.company, contract, "SIGNED")
         assert "data" in str(exc_info.value).lower()
 
     def test_cancel_contract_with_pending_installments(self, make_contract, user):


### PR DESCRIPTION
Closes #203

## Summary
Adiciona 13 testes para cobrir branches perdidas:

### ExpenseService (6 novos)
- BR-F01 tolerance-zero no create
- Update com campos parciais
- Update com amount + num_installments
- Delete com expense vinculada a contrato
- Rateio de parcelas quebradas (R$ 100 / 3)
- Redistribute com numero invalido

### ContractService (7 novos)
- Create com supplier inativo
- Upload PDF > 10MB
- Transition SIGNED sem PDF
- Transition SIGNED sem signed_date
- Addendum com contrato cancelado
- Cancelar com parcelas pendentes
- Update expiration_date + alert_days_before

## Test Plan
- [x] 89 testes passando