### PR TITLE
fix(backend): add @transaction.atomic to helpers missing protection

### DIFF
--- a/backend/apps/finances/services/installment_service.py
+++ b/backend/apps/finances/services/installment_service.py
@@ -414,6 +414,7 @@ class InstallmentService:
             ) from e
 
 
+@transaction.atomic
 def _delete_payment_events_for_expense(company: Company, expense: Expense) -> None:
     """Remove todos os eventos PAYMENT do scheduler vinculados a esta despesa."""
     from apps.scheduler.models import Event as SchedulerEvent
@@ -425,6 +426,7 @@ def _delete_payment_events_for_expense(company: Company, expense: Expense) -> No
     ).delete()
 
 
+@transaction.atomic
 def _delete_payment_event_for_single(company: Company, instance: Installment) -> None:
     """Remove o evento PAYMENT vinculado a uma parcela específica."""
     from apps.scheduler.models import Event as SchedulerEvent
@@ -436,6 +438,7 @@ def _delete_payment_event_for_single(company: Company, instance: Installment) ->
     ).delete()
 
 
+@transaction.atomic
 def _create_payment_events(
     company: Company,
     expense: Expense,

--- a/backend/apps/logistics/services/contract_service.py
+++ b/backend/apps/logistics/services/contract_service.py
@@ -382,6 +382,7 @@ class ContractService:
         return contract
 
     @staticmethod
+    @transaction.atomic
     def delete_file(company: Company, uuid: UUID | str) -> None:
         """
         Remove o arquivo vinculado ao contrato.

--- a/backend/apps/weddings/services/wedding_service.py
+++ b/backend/apps/weddings/services/wedding_service.py
@@ -171,6 +171,7 @@ class WeddingService:
             ) from e
 
 
+@transaction.atomic
 def _apply_template_events(
     company: Company, wedding: Wedding, template_name: str
 ) -> None:


### PR DESCRIPTION
Closes #144

## Summary

Adds `@transaction.atomic` to 5 methods/functions that perform multiple write operations but lacked their own transaction guarantee.

## Changes

| File | Function | Reason |
|---|---|---|
| `contract_service.py` | `ContractService.delete_file` | Called directly from API endpoint - **critical** |
| `installment_service.py` | `_delete_payment_events_for_expense` | Bulk delete in helper |
| `installment_service.py` | `_delete_payment_event_for_single` | Single delete in helper |
| `installment_service.py` | `_create_payment_events` | Creates events in loop |
| `wedding_service.py` | `_apply_template_events` | Creates template events in loop |

## Notes

The issue also mentioned `BudgetCategoryService.setup_defaults` and `ContractService.upload_file` as missing `@transaction.atomic`, but both already had the decorator — the issue was outdated.