### PR TITLE
refactor(backend): standardize delete signature across all services

### DIFF
--- a/backend/apps/core/tenant.py
+++ b/backend/apps/core/tenant.py
@@ -2,9 +2,11 @@ from typing import TYPE_CHECKING
 
 from apps.core.exceptions import ObjectNotFoundError
 
+
 if TYPE_CHECKING:
-    from apps.tenants.models import Company
     from django.db.models import Model
+
+    from apps.tenants.models import Company
 
 
 def validate_tenant_ownership(

--- a/backend/apps/core/tenant.py
+++ b/backend/apps/core/tenant.py
@@ -1,0 +1,18 @@
+from typing import TYPE_CHECKING
+
+from apps.core.exceptions import ObjectNotFoundError
+
+if TYPE_CHECKING:
+    from apps.tenants.models import Company
+    from django.db.models import Model
+
+
+def validate_tenant_ownership(
+    company: "Company",
+    instance: "Model",
+    *,
+    detail: str = "Recurso não encontrado ou acesso negado.",
+    code: str = "not_found_or_denied",
+) -> None:
+    if instance.company_id != company.id:
+        raise ObjectNotFoundError(detail=detail, code=code)

--- a/backend/apps/core/tenant.py
+++ b/backend/apps/core/tenant.py
@@ -16,5 +16,15 @@ def validate_tenant_ownership(
     detail: str = "Recurso não encontrado ou acesso negado.",
     code: str = "not_found_or_denied",
 ) -> None:
+    """
+    Verifica se a instância pertence ao tenant informado.
+
+    Usada em métodos que recebem uma instância pré-carregada (update, delete, etc.)
+    para garantir que o tenant que fez a requisição é o dono do recurso.
+    Deve ser chamada antes de qualquer operação sobre a instância.
+
+    Levanta ObjectNotFoundError (404) em vez de PermissionError (403) para não
+    revelar a existência de recursos de outros tenants (segurança multi-tenant).
+    """
     if instance.company_id != company.id:
         raise ObjectNotFoundError(detail=detail, code=code)

--- a/backend/apps/finances/services/budget_category_service.py
+++ b/backend/apps/finances/services/budget_category_service.py
@@ -11,6 +11,7 @@ from apps.core.exceptions import (
     DomainIntegrityError,
     ObjectNotFoundError,
 )
+from apps.core.tenant import validate_tenant_ownership
 from apps.finances.models import Budget, BudgetCategory
 from apps.tenants.models import Company
 from apps.weddings.models import Wedding
@@ -153,11 +154,11 @@ class BudgetCategoryService:
     @staticmethod
     @transaction.atomic
     def delete(company: Company, instance: BudgetCategory) -> None:
-        if instance.company_id != company.id:
-            raise ObjectNotFoundError(
-                detail="Categoria de orçamento não encontrada ou acesso negado.",
-                code="budget_category_not_found_or_denied",
-            )
+        validate_tenant_ownership(
+            company, instance,
+            detail="Categoria de orçamento não encontrada ou acesso negado.",
+            code="budget_category_not_found_or_denied",
+        )
         logger.info(
             f"Tentativa de deleção da Categoria uuid={instance.uuid} "
             f"por company_id={company.id}"

--- a/backend/apps/finances/services/budget_category_service.py
+++ b/backend/apps/finances/services/budget_category_service.py
@@ -153,6 +153,11 @@ class BudgetCategoryService:
     @staticmethod
     @transaction.atomic
     def delete(company: Company, instance: BudgetCategory) -> None:
+        if instance.company_id != company.id:
+            raise ObjectNotFoundError(
+                detail="Categoria de orçamento não encontrada ou acesso negado.",
+                code="budget_category_not_found_or_denied",
+            )
         logger.info(
             f"Tentativa de deleção da Categoria uuid={instance.uuid} "
             f"por company_id={company.id}"

--- a/backend/apps/finances/services/budget_category_service.py
+++ b/backend/apps/finances/services/budget_category_service.py
@@ -155,7 +155,8 @@ class BudgetCategoryService:
     @transaction.atomic
     def delete(company: Company, instance: BudgetCategory) -> None:
         validate_tenant_ownership(
-            company, instance,
+            company,
+            instance,
             detail="Categoria de orçamento não encontrada ou acesso negado.",
             code="budget_category_not_found_or_denied",
         )

--- a/backend/apps/finances/services/budget_category_service.py
+++ b/backend/apps/finances/services/budget_category_service.py
@@ -125,6 +125,11 @@ class BudgetCategoryService:
     def update(
         company: Company, instance: BudgetCategory, data: dict[str, Any]
     ) -> BudgetCategory:
+        validate_tenant_ownership(
+            company, instance,
+            detail="Categoria de orçamento não encontrada ou acesso negado.",
+            code="budget_category_not_found_or_denied",
+        )
         logger.info(
             f"Atualizando Categoria uuid={instance.uuid} por company_id={company.id}"
         )

--- a/backend/apps/finances/services/budget_service.py
+++ b/backend/apps/finances/services/budget_service.py
@@ -7,6 +7,7 @@ from django.db import IntegrityError, transaction
 from django.db.models import ProtectedError, QuerySet
 
 from apps.core.exceptions import DomainIntegrityError, ObjectNotFoundError
+from apps.core.tenant import validate_tenant_ownership
 from apps.finances.models import Budget
 from apps.tenants.models import Company
 from apps.weddings.models import Wedding
@@ -92,11 +93,16 @@ class BudgetService:
     @staticmethod
     @transaction.atomic
     def update(company: Company, instance: Budget, data: dict[str, Any]) -> Budget:
+        validate_tenant_ownership(
+            company, instance,
+            detail="Orçamento não encontrado ou acesso negado.",
+            code="budget_not_found_or_denied",
+        )
         logger.info(
             f"Atualizando Orçamento uuid={instance.uuid} por company_id={company.id}"
         )
 
-        # Proteção contra sequestro de propriedade e realocação
+
         data.pop("wedding", None)
         data.pop("company", None)
 
@@ -112,11 +118,11 @@ class BudgetService:
     @staticmethod
     @transaction.atomic
     def delete(company: Company, instance: Budget) -> None:
-        if instance.company_id != company.id:
-            raise ObjectNotFoundError(
-                detail="Orçamento não encontrado ou acesso negado.",
-                code="budget_not_found_or_denied",
-            )
+        validate_tenant_ownership(
+            company, instance,
+            detail="Orçamento não encontrado ou acesso negado.",
+            code="budget_not_found_or_denied",
+        )
         logger.info(
             f"Tentativa de deleção do Orçamento uuid={instance.uuid} por "
             f"company_id={company.id}"

--- a/backend/apps/finances/services/budget_service.py
+++ b/backend/apps/finances/services/budget_service.py
@@ -94,14 +94,14 @@ class BudgetService:
     @transaction.atomic
     def update(company: Company, instance: Budget, data: dict[str, Any]) -> Budget:
         validate_tenant_ownership(
-            company, instance,
+            company,
+            instance,
             detail="Orçamento não encontrado ou acesso negado.",
             code="budget_not_found_or_denied",
         )
         logger.info(
             f"Atualizando Orçamento uuid={instance.uuid} por company_id={company.id}"
         )
-
 
         data.pop("wedding", None)
         data.pop("company", None)
@@ -119,7 +119,8 @@ class BudgetService:
     @transaction.atomic
     def delete(company: Company, instance: Budget) -> None:
         validate_tenant_ownership(
-            company, instance,
+            company,
+            instance,
             detail="Orçamento não encontrado ou acesso negado.",
             code="budget_not_found_or_denied",
         )

--- a/backend/apps/finances/services/budget_service.py
+++ b/backend/apps/finances/services/budget_service.py
@@ -112,6 +112,11 @@ class BudgetService:
     @staticmethod
     @transaction.atomic
     def delete(company: Company, instance: Budget) -> None:
+        if instance.company_id != company.id:
+            raise ObjectNotFoundError(
+                detail="Orçamento não encontrado ou acesso negado.",
+                code="budget_not_found_or_denied",
+            )
         logger.info(
             f"Tentativa de deleção do Orçamento uuid={instance.uuid} por "
             f"company_id={company.id}"

--- a/backend/apps/finances/services/expense_service.py
+++ b/backend/apps/finances/services/expense_service.py
@@ -345,6 +345,11 @@ class ExpenseService:
     @staticmethod
     @transaction.atomic
     def delete(company: Company, instance: Expense) -> None:
+        if instance.company_id != company.id:
+            raise ObjectNotFoundError(
+                detail="Despesa não encontrada ou acesso negado.",
+                code="expense_not_found_or_denied",
+            )
         logger.info(
             f"Tentativa de deleção da Despesa uuid={instance.uuid} "
             f"por company_id={company.id}"

--- a/backend/apps/finances/services/expense_service.py
+++ b/backend/apps/finances/services/expense_service.py
@@ -283,6 +283,7 @@ class ExpenseService:
         )
 
         data.pop("wedding", None)
+        data.pop("company", None)
         data.pop("category", None)
 
         contract_changed = "contract" in data

--- a/backend/apps/finances/services/expense_service.py
+++ b/backend/apps/finances/services/expense_service.py
@@ -18,6 +18,7 @@ from django.db.models import (
 from django.db.models.functions import Coalesce
 
 from apps.core.exceptions import (
+    BusinessRuleViolation,
     ObjectNotFoundError,
 )
 from apps.core.tenant import validate_tenant_ownership
@@ -272,7 +273,8 @@ class ExpenseService:
     @transaction.atomic
     def update(company: Company, instance: Expense, data: dict[str, Any]) -> Expense:
         validate_tenant_ownership(
-            company, instance,
+            company,
+            instance,
             detail="Despesa não encontrada ou acesso negado.",
             code="expense_not_found_or_denied",
         )
@@ -350,7 +352,8 @@ class ExpenseService:
     @transaction.atomic
     def delete(company: Company, instance: Expense) -> None:
         validate_tenant_ownership(
-            company, instance,
+            company,
+            instance,
             detail="Despesa não encontrada ou acesso negado.",
             code="expense_not_found_or_denied",
         )

--- a/backend/apps/finances/services/expense_service.py
+++ b/backend/apps/finances/services/expense_service.py
@@ -18,9 +18,9 @@ from django.db.models import (
 from django.db.models.functions import Coalesce
 
 from apps.core.exceptions import (
-    BusinessRuleViolation,
     ObjectNotFoundError,
 )
+from apps.core.tenant import validate_tenant_ownership
 from apps.finances.models import BudgetCategory, Expense
 from apps.finances.services.installment_service import InstallmentService
 from apps.logistics.models import Contract
@@ -271,11 +271,15 @@ class ExpenseService:
     @staticmethod
     @transaction.atomic
     def update(company: Company, instance: Expense, data: dict[str, Any]) -> Expense:
+        validate_tenant_ownership(
+            company, instance,
+            detail="Despesa não encontrada ou acesso negado.",
+            code="expense_not_found_or_denied",
+        )
         logger.info(
             f"Atualizando Despesa uuid={instance.uuid} por company_id={company.id}"
         )
 
-        data.pop("company", None)
         data.pop("wedding", None)
         data.pop("category", None)
 
@@ -345,11 +349,11 @@ class ExpenseService:
     @staticmethod
     @transaction.atomic
     def delete(company: Company, instance: Expense) -> None:
-        if instance.company_id != company.id:
-            raise ObjectNotFoundError(
-                detail="Despesa não encontrada ou acesso negado.",
-                code="expense_not_found_or_denied",
-            )
+        validate_tenant_ownership(
+            company, instance,
+            detail="Despesa não encontrada ou acesso negado.",
+            code="expense_not_found_or_denied",
+        )
         logger.info(
             f"Tentativa de deleção da Despesa uuid={instance.uuid} "
             f"por company_id={company.id}"

--- a/backend/apps/finances/services/installment_service.py
+++ b/backend/apps/finances/services/installment_service.py
@@ -252,7 +252,8 @@ class InstallmentService:
     @transaction.atomic
     def mark_as_paid(company: Company, instance: Installment) -> Installment:
         validate_tenant_ownership(
-            company, instance,
+            company,
+            instance,
             detail="Parcela não encontrada ou acesso negado.",
             code="installment_not_found_or_denied",
         )
@@ -286,7 +287,8 @@ class InstallmentService:
     @transaction.atomic
     def unmark_as_paid(company: Company, instance: Installment) -> Installment:
         validate_tenant_ownership(
-            company, instance,
+            company,
+            instance,
             detail="Parcela não encontrada ou acesso negado.",
             code="installment_not_found_or_denied",
         )
@@ -394,7 +396,8 @@ class InstallmentService:
     @transaction.atomic
     def delete(company: Company, instance: Installment) -> None:
         validate_tenant_ownership(
-            company, instance,
+            company,
+            instance,
             detail="Parcela não encontrada ou acesso negado.",
             code="installment_not_found_or_denied",
         )

--- a/backend/apps/finances/services/installment_service.py
+++ b/backend/apps/finances/services/installment_service.py
@@ -13,6 +13,7 @@ from apps.core.exceptions import (
     DomainIntegrityError,
     ObjectNotFoundError,
 )
+from apps.core.tenant import validate_tenant_ownership
 from apps.finances.models import Expense, Installment
 from apps.tenants.models import Company
 
@@ -250,6 +251,11 @@ class InstallmentService:
     @staticmethod
     @transaction.atomic
     def mark_as_paid(company: Company, instance: Installment) -> Installment:
+        validate_tenant_ownership(
+            company, instance,
+            detail="Parcela não encontrada ou acesso negado.",
+            code="installment_not_found_or_denied",
+        )
         if instance.status == Installment.StatusChoices.PAID:
             raise BusinessRuleViolation(
                 detail="Esta parcela já foi marcada como paga.",
@@ -279,6 +285,11 @@ class InstallmentService:
     @staticmethod
     @transaction.atomic
     def unmark_as_paid(company: Company, instance: Installment) -> Installment:
+        validate_tenant_ownership(
+            company, instance,
+            detail="Parcela não encontrada ou acesso negado.",
+            code="installment_not_found_or_denied",
+        )
         if instance.status != Installment.StatusChoices.PAID:
             raise BusinessRuleViolation(
                 detail="Apenas parcelas marcadas como pagas podem ser desmarcadas.",
@@ -382,11 +393,11 @@ class InstallmentService:
     @staticmethod
     @transaction.atomic
     def delete(company: Company, instance: Installment) -> None:
-        if instance.company_id != company.id:
-            raise ObjectNotFoundError(
-                detail="Parcela não encontrada ou acesso negado.",
-                code="installment_not_found_or_denied",
-            )
+        validate_tenant_ownership(
+            company, instance,
+            detail="Parcela não encontrada ou acesso negado.",
+            code="installment_not_found_or_denied",
+        )
         logger.info(
             f"Tentativa de deleção da Parcela uuid={instance.uuid} "
             f"por company_id={company.id}"

--- a/backend/apps/finances/services/installment_service.py
+++ b/backend/apps/finances/services/installment_service.py
@@ -326,6 +326,11 @@ class InstallmentService:
     def adjust(
         company: Company, instance: Installment, data: dict[str, Any]
     ) -> Installment:
+        validate_tenant_ownership(
+            company, instance,
+            detail="Parcela não encontrada ou acesso negado.",
+            code="installment_not_found_or_denied",
+        )
         if instance.status == Installment.StatusChoices.PAID:
             raise BusinessRuleViolation(
                 detail="Não é possível ajustar uma parcela já marcada como paga. "

--- a/backend/apps/finances/services/installment_service.py
+++ b/backend/apps/finances/services/installment_service.py
@@ -217,6 +217,11 @@ class InstallmentService:
     def update(
         company: Company, instance: Installment, data: dict[str, Any]
     ) -> Installment:
+        validate_tenant_ownership(
+            company, instance,
+            detail="Parcela não encontrada ou acesso negado.",
+            code="installment_not_found_or_denied",
+        )
         logger.info(
             f"Atualizando Parcela uuid={instance.uuid} por company_id={company.id}"
         )

--- a/backend/apps/finances/services/installment_service.py
+++ b/backend/apps/finances/services/installment_service.py
@@ -382,6 +382,11 @@ class InstallmentService:
     @staticmethod
     @transaction.atomic
     def delete(company: Company, instance: Installment) -> None:
+        if instance.company_id != company.id:
+            raise ObjectNotFoundError(
+                detail="Parcela não encontrada ou acesso negado.",
+                code="installment_not_found_or_denied",
+            )
         logger.info(
             f"Tentativa de deleção da Parcela uuid={instance.uuid} "
             f"por company_id={company.id}"

--- a/backend/apps/finances/tests/budgets/test_services.py
+++ b/backend/apps/finances/tests/budgets/test_services.py
@@ -367,6 +367,17 @@ class TestBudgetServiceIntegration:
 
         assert updated.wedding == wedding1
 
+    def test_update_budget_cross_tenant(self, user):
+        """Orçamento de outro tenant não pode ser atualizado."""
+        other_user = UserFactory()
+        other_wedding = WeddingFactory(company=other_user.company)
+        other_budget = BudgetFactory(wedding=other_wedding)
+
+        with pytest.raises(ObjectNotFoundError):
+            BudgetService.update(
+                user.company, other_budget, {"notes": "Hack"}
+            )
+
     def test_budget_delete_success(self, user):
         """
         BudgetService.delete() remove o orçamento se não houver categorias.

--- a/backend/apps/finances/tests/budgets/test_services.py
+++ b/backend/apps/finances/tests/budgets/test_services.py
@@ -409,3 +409,12 @@ class TestBudgetServiceIntegration:
 
         assert "Não é possível apagar este orçamento" in str(exc_info.value)
         assert Budget.objects.filter(uuid=budget.uuid).exists()
+
+    def test_delete_budget_cross_tenant(self, user):
+        """Orçamento de outro tenant não pode ser deletado."""
+        other_user = UserFactory()
+        other_wedding = WeddingFactory(company=other_user.company)
+        other_budget = BudgetFactory(wedding=other_wedding)
+
+        with pytest.raises(ObjectNotFoundError):
+            BudgetService.delete(user.company, instance=other_budget)

--- a/backend/apps/finances/tests/budgets/test_services.py
+++ b/backend/apps/finances/tests/budgets/test_services.py
@@ -319,10 +319,11 @@ class TestBudgetServiceIntegration:
         assert Budget.objects.filter(wedding=wedding).count() == 1
 
         # Deletar wedding (deve cascadear para budget)
-        WeddingService.delete(user.company, wedding.uuid)
+        WeddingService.delete(user.company, instance=wedding)
 
         # Verificar que ambos foram deletados
-        assert Budget.objects.filter(wedding=wedding).count() == 0
+        # Usamos uuid pois em Django 5.2 instance.delete() limpa o estado da pk
+        assert Budget.objects.filter(wedding__uuid=wedding.uuid).count() == 0
 
     def test_budget_create_with_wedding_instance(self, user):
         """

--- a/backend/apps/finances/tests/categories/test_services.py
+++ b/backend/apps/finances/tests/categories/test_services.py
@@ -264,6 +264,18 @@ class TestBudgetCategoryServiceDelete:
         assert "category_protected_error" in str(exc_info.value.code)
         assert BudgetCategory.objects.filter(uuid=category.uuid).count() == 1
 
+    def test_delete_category_cross_tenant(self, user):
+        """Categoria de outro tenant não pode ser deletada."""
+        other_user = UserFactory()
+        other_wedding = WeddingFactory(company=other_user.company)
+        other_budget = BudgetFactory(wedding=other_wedding)
+        other_category = BudgetCategoryFactory(
+            budget=other_budget, wedding=other_wedding
+        )
+
+        with pytest.raises(ObjectNotFoundError):
+            BudgetCategoryService.delete(user.company, instance=other_category)
+
 
 @pytest.mark.django_db
 class TestBudgetCategoryServiceListAndGet:

--- a/backend/apps/finances/tests/categories/test_services.py
+++ b/backend/apps/finances/tests/categories/test_services.py
@@ -228,6 +228,22 @@ class TestBudgetCategoryServiceUpdate:
         BudgetCategoryService.update(user.company, category, {"name": "Renomeada"})
         mock_qs.select_for_update.assert_called_once()
 
+    def test_update_category_cross_tenant(self, user):
+        """Categoria de outro tenant não pode ser atualizada."""
+        from apps.users.tests.factories import UserFactory
+
+        other_user = UserFactory()
+        other_wedding = WeddingFactory(company=other_user.company)
+        other_budget = BudgetFactory(wedding=other_wedding)
+        other_category = BudgetCategoryFactory(
+            budget=other_budget, wedding=other_wedding
+        )
+
+        with pytest.raises(ObjectNotFoundError):
+            BudgetCategoryService.update(
+                user.company, other_category, {"name": "Hack"}
+            )
+
 
 @pytest.mark.django_db
 class TestBudgetCategoryServiceDelete:

--- a/backend/apps/finances/tests/expenses/test_services.py
+++ b/backend/apps/finances/tests/expenses/test_services.py
@@ -473,6 +473,25 @@ class TestExpenseServiceDelete:
         with pytest.raises(Expense.DoesNotExist):
             Expense.objects.get(uuid=expense.uuid)
 
+    def test_delete_expense_cross_tenant(self, user):
+        """Despesa de outro tenant não pode ser deletada."""
+
+        other_user = UserFactory()
+        other_wedding = WeddingFactory(company=other_user.company)
+        other_budget = BudgetFactory(wedding=other_wedding)
+        other_category = BudgetCategoryFactory(
+            budget=other_budget, wedding=other_wedding
+        )
+        other_expense = ExpenseFactory(
+            wedding=other_wedding,
+            category=other_category,
+            company=other_user.company,
+            contract=None,
+        )
+
+        with pytest.raises(ObjectNotFoundError):
+            ExpenseService.delete(user.company, instance=other_expense)
+
 
 @pytest.mark.django_db
 class TestExpenseServiceFromDocument:

--- a/backend/apps/finances/tests/expenses/test_services.py
+++ b/backend/apps/finances/tests/expenses/test_services.py
@@ -278,6 +278,26 @@ class TestExpenseServiceUpdate:
         assert updated.actual_amount == Decimal("500.00")
         assert updated.installments.count() == 1
 
+    def test_update_expense_cross_tenant(self, user):
+        """Despesa de outro tenant não pode ser atualizada."""
+        other_user = UserFactory()
+        other_wedding = WeddingFactory(company=other_user.company)
+        other_budget = BudgetFactory(wedding=other_wedding)
+        other_category = BudgetCategoryFactory(
+            budget=other_budget, wedding=other_wedding
+        )
+        other_expense = ExpenseFactory(
+            wedding=other_wedding,
+            category=other_category,
+            company=other_user.company,
+            contract=None,
+        )
+
+        with pytest.raises(ObjectNotFoundError):
+            ExpenseService.update(
+                user.company, other_expense, {"name": "Hack"}
+            )
+
     def test_update_expense_amount_with_installment_count(self, user):
         """Alterar actual_amount + especificar num_installments redistribui
         com o número informado."""

--- a/backend/apps/finances/tests/installments/test_services.py
+++ b/backend/apps/finances/tests/installments/test_services.py
@@ -777,6 +777,30 @@ class TestInstallmentServiceAdjust:
             InstallmentService.adjust(user.company, inst, {"amount": Decimal("300.00")})
         assert exc.value.code == "expense_math_violation"
 
+    def test_adjust_cross_tenant(self, user):
+        """Parcela de outro tenant não pode ser ajustada."""
+        other_user = UserFactory()
+        other_wedding = WeddingFactory(company=other_user.company)
+        other_budget = BudgetFactory(wedding=other_wedding)
+        other_category = BudgetCategoryFactory(
+            budget=other_budget, wedding=other_wedding
+        )
+        other_expense = ExpenseFactory(
+            wedding=other_wedding,
+            category=other_category,
+            company=other_user.company,
+            contract=None,
+            actual_amount=Decimal("500.00"),
+        )
+        other_installment = InstallmentFactory(
+            expense=other_expense, amount=Decimal("500.00")
+        )
+
+        with pytest.raises(ObjectNotFoundError):
+            InstallmentService.adjust(
+                user.company, other_installment, {"amount": Decimal("300.00")}
+            )
+
 
 @pytest.mark.django_db
 class TestInstallmentServiceListAndGet:

--- a/backend/apps/finances/tests/installments/test_services.py
+++ b/backend/apps/finances/tests/installments/test_services.py
@@ -428,6 +428,53 @@ class TestInstallmentServiceMarkAsPaid:
             InstallmentService.unmark_as_paid(user.company, installment)
         assert exc.value.code == "installment_not_paid"
 
+    def test_mark_as_paid_cross_tenant(self, user):
+        """Parcela de outro tenant não pode ser marcada como paga."""
+        other_user = UserFactory()
+        other_wedding = WeddingFactory(company=other_user.company)
+        other_budget = BudgetFactory(wedding=other_wedding)
+        other_category = BudgetCategoryFactory(
+            budget=other_budget, wedding=other_wedding
+        )
+        other_expense = ExpenseFactory(
+            wedding=other_wedding,
+            category=other_category,
+            company=other_user.company,
+            contract=None,
+            actual_amount=Decimal("500.00"),
+        )
+        other_installment = InstallmentFactory(
+            expense=other_expense, amount=Decimal("500.00")
+        )
+
+        with pytest.raises(ObjectNotFoundError):
+            InstallmentService.mark_as_paid(user.company, other_installment)
+
+    def test_unmark_as_paid_cross_tenant(self, user):
+        """Parcela de outro tenant não pode ser desmarcada como paga."""
+        other_user = UserFactory()
+        other_wedding = WeddingFactory(company=other_user.company)
+        other_budget = BudgetFactory(wedding=other_wedding)
+        other_category = BudgetCategoryFactory(
+            budget=other_budget, wedding=other_wedding
+        )
+        other_expense = ExpenseFactory(
+            wedding=other_wedding,
+            category=other_category,
+            company=other_user.company,
+            contract=None,
+            actual_amount=Decimal("500.00"),
+        )
+        other_installment = InstallmentFactory(
+            expense=other_expense,
+            amount=Decimal("500.00"),
+            status=Installment.StatusChoices.PAID,
+            paid_date=date.today(),
+        )
+
+        with pytest.raises(ObjectNotFoundError):
+            InstallmentService.unmark_as_paid(user.company, other_installment)
+
 
 @pytest.mark.django_db
 class TestInstallmentServiceRedistribute:

--- a/backend/apps/finances/tests/installments/test_services.py
+++ b/backend/apps/finances/tests/installments/test_services.py
@@ -582,6 +582,28 @@ class TestInstallmentServiceRedistribute:
 
         assert not SchedulerEvent.objects.filter(uuid=deleted_event_uuid).exists()
 
+    def test_delete_installment_cross_tenant(self, user):
+        """Parcela de outro tenant não pode ser deletada."""
+        other_user = UserFactory()
+        other_wedding = WeddingFactory(company=other_user.company)
+        other_budget = BudgetFactory(wedding=other_wedding)
+        other_category = BudgetCategoryFactory(
+            budget=other_budget, wedding=other_wedding
+        )
+        other_expense = ExpenseFactory(
+            wedding=other_wedding,
+            category=other_category,
+            company=other_user.company,
+            contract=None,
+            actual_amount=Decimal("1000.00"),
+        )
+        other_installment = InstallmentFactory(
+            expense=other_expense, installment_number=1, amount=Decimal("1000.00")
+        )
+
+        with pytest.raises(ObjectNotFoundError):
+            InstallmentService.delete(user.company, instance=other_installment)
+
 
 @pytest.mark.django_db
 class TestInstallmentServiceAdjust:

--- a/backend/apps/finances/tests/installments/test_services.py
+++ b/backend/apps/finances/tests/installments/test_services.py
@@ -306,6 +306,30 @@ class TestInstallmentServiceUpdate:
         )
         assert updated.due_date == new_due_date
 
+    def test_update_installment_cross_tenant(self, user):
+        """Parcela de outro tenant não pode ser atualizada."""
+        other_user = UserFactory()
+        other_wedding = WeddingFactory(company=other_user.company)
+        other_budget = BudgetFactory(wedding=other_wedding)
+        other_category = BudgetCategoryFactory(
+            budget=other_budget, wedding=other_wedding
+        )
+        other_expense = ExpenseFactory(
+            wedding=other_wedding,
+            category=other_category,
+            company=other_user.company,
+            contract=None,
+            actual_amount=Decimal("500.00"),
+        )
+        other_installment = InstallmentFactory(
+            expense=other_expense, amount=Decimal("500.00")
+        )
+
+        with pytest.raises(ObjectNotFoundError):
+            InstallmentService.update(
+                user.company, other_installment, {"amount": Decimal("300.00")}
+            )
+
 
 @pytest.mark.django_db
 class TestInstallmentServiceDelete:

--- a/backend/apps/logistics/services/contract_service.py
+++ b/backend/apps/logistics/services/contract_service.py
@@ -364,8 +364,11 @@ class ContractService:
             f"{instance.status} -> {new_status}"
         )
 
-        if instance.company_id != company.id:
-            raise ObjectNotFoundError(detail="Contrato não encontrado.")
+        validate_tenant_ownership(
+            company, instance,
+            detail="Contrato não encontrado ou acesso negado.",
+            code="contract_not_found_or_denied",
+        )
 
         instance.status = new_status
         try:

--- a/backend/apps/logistics/services/contract_service.py
+++ b/backend/apps/logistics/services/contract_service.py
@@ -317,6 +317,11 @@ class ContractService:
     @staticmethod
     @transaction.atomic
     def delete(company: Company, instance: Contract) -> None:
+        if instance.company_id != company.id:
+            raise ObjectNotFoundError(
+                detail="Contrato não encontrado ou acesso negado.",
+                code="contract_not_found_or_denied",
+            )
         logger.info(
             f"Tentativa de deleção do Contrato uuid={instance.uuid} por "
             f"company_id={company.id}"

--- a/backend/apps/logistics/services/contract_service.py
+++ b/backend/apps/logistics/services/contract_service.py
@@ -25,6 +25,7 @@ from apps.core.exceptions import (
     DomainIntegrityError,
     ObjectNotFoundError,
 )
+from apps.core.tenant import validate_tenant_ownership
 from apps.finances.models import Expense, Installment
 from apps.finances.services.expense_service import ExpenseService
 from apps.logistics.models import Contract, Supplier
@@ -259,6 +260,11 @@ class ContractService:
     @staticmethod
     @transaction.atomic
     def update(company: Company, instance: Contract, data: dict[str, Any]) -> Contract:
+        validate_tenant_ownership(
+            company, instance,
+            detail="Contrato não encontrado ou acesso negado.",
+            code="contract_not_found_or_denied",
+        )
         logger.info(
             f"Atualizando Contrato uuid={instance.uuid} por company_id={company.id}"
         )
@@ -317,11 +323,11 @@ class ContractService:
     @staticmethod
     @transaction.atomic
     def delete(company: Company, instance: Contract) -> None:
-        if instance.company_id != company.id:
-            raise ObjectNotFoundError(
-                detail="Contrato não encontrado ou acesso negado.",
-                code="contract_not_found_or_denied",
-            )
+        validate_tenant_ownership(
+            company, instance,
+            detail="Contrato não encontrado ou acesso negado.",
+            code="contract_not_found_or_denied",
+        )
         logger.info(
             f"Tentativa de deleção do Contrato uuid={instance.uuid} por "
             f"company_id={company.id}"

--- a/backend/apps/logistics/services/contract_service.py
+++ b/backend/apps/logistics/services/contract_service.py
@@ -297,8 +297,6 @@ class ContractService:
 
         status_input = data.pop("status", None)
         if status_input is not None and status_input != instance.status:
-            if instance.company_id != company.id:
-                raise ObjectNotFoundError(detail="Contrato não encontrado.")
             instance.status = status_input
 
         ContractService._apply_fields(instance, data)

--- a/backend/apps/logistics/services/contract_service.py
+++ b/backend/apps/logistics/services/contract_service.py
@@ -261,7 +261,8 @@ class ContractService:
     @transaction.atomic
     def update(company: Company, instance: Contract, data: dict[str, Any]) -> Contract:
         validate_tenant_ownership(
-            company, instance,
+            company,
+            instance,
             detail="Contrato não encontrado ou acesso negado.",
             code="contract_not_found_or_denied",
         )
@@ -324,7 +325,8 @@ class ContractService:
     @transaction.atomic
     def delete(company: Company, instance: Contract) -> None:
         validate_tenant_ownership(
-            company, instance,
+            company,
+            instance,
             detail="Contrato não encontrado ou acesso negado.",
             code="contract_not_found_or_denied",
         )

--- a/backend/apps/logistics/services/item_service.py
+++ b/backend/apps/logistics/services/item_service.py
@@ -183,6 +183,11 @@ class ItemService:
     @staticmethod
     @transaction.atomic
     def delete(company: Company, instance: Item) -> None:
+        if instance.company_id != company.id:
+            raise ObjectNotFoundError(
+                detail="Item de logística não encontrado ou acesso negado.",
+                code="item_not_found_or_denied",
+            )
         logger.info(
             f"Tentativa de deleção do Item uuid={instance.uuid} por "
             f"company_id={company.id}"

--- a/backend/apps/logistics/services/item_service.py
+++ b/backend/apps/logistics/services/item_service.py
@@ -13,6 +13,7 @@ from apps.core.exceptions import (
     DomainIntegrityError,
     ObjectNotFoundError,
 )
+from apps.core.tenant import validate_tenant_ownership
 from apps.logistics.models import Contract, Item
 from apps.tenants.models import Company
 
@@ -155,11 +156,15 @@ class ItemService:
     @staticmethod
     @transaction.atomic
     def update(company: Company, instance: Item, data: dict[str, Any]) -> Item:
+        validate_tenant_ownership(
+            company, instance,
+            detail="Item de logística não encontrado ou acesso negado.",
+            code="item_not_found_or_denied",
+        )
         logger.info(
             f"Atualizando Item uuid={instance.uuid} por company_id={company.id}"
         )
 
-        data.pop("company", None)
         data.pop("wedding", None)
 
         if "contract" in data:
@@ -183,11 +188,11 @@ class ItemService:
     @staticmethod
     @transaction.atomic
     def delete(company: Company, instance: Item) -> None:
-        if instance.company_id != company.id:
-            raise ObjectNotFoundError(
-                detail="Item de logística não encontrado ou acesso negado.",
-                code="item_not_found_or_denied",
-            )
+        validate_tenant_ownership(
+            company, instance,
+            detail="Item de logística não encontrado ou acesso negado.",
+            code="item_not_found_or_denied",
+        )
         logger.info(
             f"Tentativa de deleção do Item uuid={instance.uuid} por "
             f"company_id={company.id}"
@@ -201,13 +206,15 @@ class ItemService:
     @staticmethod
     @transaction.atomic
     def transition_status(company: Company, instance: Item, new_status: str) -> Item:
+        validate_tenant_ownership(
+            company, instance,
+            detail="Item de logística não encontrado ou acesso negado.",
+            code="item_not_found_or_denied",
+        )
         logger.info(
             f"Transição de status do Item uuid={instance.uuid}: "
             f"{instance.acquisition_status} -> {new_status}"
         )
-
-        if instance.company_id != company.id:
-            raise ObjectNotFoundError(detail="Item não encontrado.")
 
         instance.acquisition_status = new_status
         try:

--- a/backend/apps/logistics/services/item_service.py
+++ b/backend/apps/logistics/services/item_service.py
@@ -157,7 +157,8 @@ class ItemService:
     @transaction.atomic
     def update(company: Company, instance: Item, data: dict[str, Any]) -> Item:
         validate_tenant_ownership(
-            company, instance,
+            company,
+            instance,
             detail="Item de logística não encontrado ou acesso negado.",
             code="item_not_found_or_denied",
         )
@@ -166,6 +167,7 @@ class ItemService:
         )
 
         data.pop("wedding", None)
+        data.pop("company", None)
 
         if "contract" in data:
             contract_input = data.pop("contract")
@@ -189,7 +191,8 @@ class ItemService:
     @transaction.atomic
     def delete(company: Company, instance: Item) -> None:
         validate_tenant_ownership(
-            company, instance,
+            company,
+            instance,
             detail="Item de logística não encontrado ou acesso negado.",
             code="item_not_found_or_denied",
         )
@@ -207,7 +210,8 @@ class ItemService:
     @transaction.atomic
     def transition_status(company: Company, instance: Item, new_status: str) -> Item:
         validate_tenant_ownership(
-            company, instance,
+            company,
+            instance,
             detail="Item de logística não encontrado ou acesso negado.",
             code="item_not_found_or_denied",
         )

--- a/backend/apps/logistics/services/supplier_service.py
+++ b/backend/apps/logistics/services/supplier_service.py
@@ -8,6 +8,7 @@ from django.db.models import Q, QuerySet
 from apps.core.exceptions import (
     ObjectNotFoundError,
 )
+from apps.core.tenant import validate_tenant_ownership
 from apps.logistics.models import Supplier
 from apps.tenants.models import Company
 
@@ -65,12 +66,15 @@ class SupplierService:
     @staticmethod
     @transaction.atomic
     def update(company: Company, instance: Supplier, data: dict[str, Any]) -> Supplier:
+        validate_tenant_ownership(
+            company, instance,
+            detail="Fornecedor não encontrado ou acesso negado.",
+            code="supplier_not_found_or_denied",
+        )
         logger.info(
             f"Atualizando Fornecedor uuid={instance.uuid} por company_id={company.id}"
         )
 
-        # Proteção: Impedimos o sequestro/mudança de dono via API
-        data.pop("company", None)
 
         for field, value in data.items():
             setattr(instance, field, value)
@@ -83,11 +87,11 @@ class SupplierService:
     @staticmethod
     @transaction.atomic
     def delete(company: Company, instance: Supplier) -> None:
-        if instance.company_id != company.id:
-            raise ObjectNotFoundError(
-                detail="Fornecedor não encontrado ou acesso negado.",
-                code="supplier_not_found_or_denied",
-            )
+        validate_tenant_ownership(
+            company, instance,
+            detail="Fornecedor não encontrado ou acesso negado.",
+            code="supplier_not_found_or_denied",
+        )
         logger.info(
             f"Tentativa de deleção do Fornecedor uuid={instance.uuid} pela "
             f"company_id={company.id}"

--- a/backend/apps/logistics/services/supplier_service.py
+++ b/backend/apps/logistics/services/supplier_service.py
@@ -83,6 +83,11 @@ class SupplierService:
     @staticmethod
     @transaction.atomic
     def delete(company: Company, instance: Supplier) -> None:
+        if instance.company_id != company.id:
+            raise ObjectNotFoundError(
+                detail="Fornecedor não encontrado ou acesso negado.",
+                code="supplier_not_found_or_denied",
+            )
         logger.info(
             f"Tentativa de deleção do Fornecedor uuid={instance.uuid} pela "
             f"company_id={company.id}"

--- a/backend/apps/logistics/services/supplier_service.py
+++ b/backend/apps/logistics/services/supplier_service.py
@@ -67,7 +67,8 @@ class SupplierService:
     @transaction.atomic
     def update(company: Company, instance: Supplier, data: dict[str, Any]) -> Supplier:
         validate_tenant_ownership(
-            company, instance,
+            company,
+            instance,
             detail="Fornecedor não encontrado ou acesso negado.",
             code="supplier_not_found_or_denied",
         )
@@ -75,6 +76,7 @@ class SupplierService:
             f"Atualizando Fornecedor uuid={instance.uuid} por company_id={company.id}"
         )
 
+        data.pop("company", None)
 
         for field, value in data.items():
             setattr(instance, field, value)
@@ -88,7 +90,8 @@ class SupplierService:
     @transaction.atomic
     def delete(company: Company, instance: Supplier) -> None:
         validate_tenant_ownership(
-            company, instance,
+            company,
+            instance,
             detail="Fornecedor não encontrado ou acesso negado.",
             code="supplier_not_found_or_denied",
         )

--- a/backend/apps/logistics/tests/contracts/test_services.py
+++ b/backend/apps/logistics/tests/contracts/test_services.py
@@ -258,6 +258,16 @@ class TestContractServiceDelete:
         ContractService.delete(user.company, contract)
         assert Contract.objects.filter(uuid=contract.uuid).count() == 0
 
+    def test_delete_contract_cross_tenant(self, user):
+        """Contrato de outro tenant não pode ser deletado."""
+        other_user = UserFactory()
+        other_wedding = WeddingFactory(company=other_user.company)
+        other_supplier = SupplierFactory(company=other_user.company)
+        other_contract = ContractFactory(wedding=other_wedding, supplier=other_supplier)
+
+        with pytest.raises(ObjectNotFoundError):
+            ContractService.delete(user.company, instance=other_contract)
+
 
 @pytest.mark.django_db
 class TestContractServiceListAndGet:

--- a/backend/apps/logistics/tests/contracts/test_services.py
+++ b/backend/apps/logistics/tests/contracts/test_services.py
@@ -210,6 +210,20 @@ class TestContractServiceUpdate:
 
         assert "Não é permitido transitar" in str(exc_info.value)
 
+    def test_update_contract_cross_tenant(self, user):
+        """Contrato de outro tenant não pode ser atualizado."""
+        other_user = UserFactory()
+        other_wedding = WeddingFactory(company=other_user.company)
+        other_supplier = SupplierFactory(company=other_user.company)
+        other_contract = ContractFactory(
+            wedding=other_wedding, supplier=other_supplier
+        )
+
+        with pytest.raises(ObjectNotFoundError):
+            ContractService.update(
+                user.company, other_contract, {"notes": "Hack"}
+            )
+
 
 @pytest.mark.django_db
 class TestContractServiceDelete:

--- a/backend/apps/logistics/tests/items/test_services.py
+++ b/backend/apps/logistics/tests/items/test_services.py
@@ -296,6 +296,17 @@ class TestItemServiceDelete:
 
         assert Item.objects.filter(uuid=item.uuid).count() == 0
 
+    def test_delete_item_cross_tenant(self, user):
+        """Item de outro tenant não pode ser deletado."""
+        other_user = UserFactory()
+        other_wedding = WeddingFactory(company=other_user.company)
+        other_supplier = SupplierFactory(company=other_user.company)
+        other_contract = ContractFactory(wedding=other_wedding, supplier=other_supplier)
+        other_item = ItemFactory(contract=other_contract, wedding=other_wedding)
+
+        with pytest.raises(ObjectNotFoundError):
+            ItemService.delete(user.company, instance=other_item)
+
 
 @pytest.mark.django_db
 class TestItemServiceListAndGet:

--- a/backend/apps/logistics/tests/items/test_services.py
+++ b/backend/apps/logistics/tests/items/test_services.py
@@ -249,6 +249,21 @@ class TestItemServiceUpdate:
 
         assert updated.company == user.company
 
+    def test_update_item_cross_tenant(self, user):
+        """Item de outro tenant não pode ser atualizado."""
+        other_user = UserFactory()
+        other_wedding = WeddingFactory(company=other_user.company)
+        other_supplier = SupplierFactory(company=other_user.company)
+        other_contract = ContractFactory(
+            wedding=other_wedding, supplier=other_supplier
+        )
+        other_item = ItemFactory(contract=other_contract, wedding=other_wedding)
+
+        with pytest.raises(ObjectNotFoundError):
+            ItemService.update(
+                user.company, other_item, {"name": "Hack"}
+            )
+
     def test_update_item_clear_contract(self, user):
         """Item pode ser desvinculado do contrato (contract=None)."""
         wedding, contract = _setup_item_context(user)

--- a/backend/apps/logistics/tests/suppliers/test_services.py
+++ b/backend/apps/logistics/tests/suppliers/test_services.py
@@ -76,6 +76,16 @@ class TestSupplierServiceUpdate:
 
         assert updated.company == user.company
 
+    def test_update_supplier_cross_tenant(self, user):
+        """Fornecedor de outro tenant não pode ser atualizado."""
+        other_user = UserFactory()
+        other_supplier = SupplierFactory(company=other_user.company)
+
+        with pytest.raises(ObjectNotFoundError):
+            SupplierService.update(
+                user.company, other_supplier, {"name": "Hack"}
+            )
+
     def test_update_supplier_toggle_active(self, user):
         """Desativar/ativar fornecedor via is_active."""
         supplier = SupplierFactory(company=user.company, is_active=True)

--- a/backend/apps/logistics/tests/suppliers/test_services.py
+++ b/backend/apps/logistics/tests/suppliers/test_services.py
@@ -132,6 +132,14 @@ class TestSupplierServiceDelete:
         assert Supplier.objects.filter(uuid=supplier.uuid).count() == 0
         assert Contract.objects.filter(uuid=contract.uuid).count() == 0
 
+    def test_delete_supplier_cross_tenant(self, user):
+        """Fornecedor de outro tenant não pode ser deletado."""
+        other_user = UserFactory()
+        other_supplier = SupplierFactory(company=other_user.company)
+
+        with pytest.raises(ObjectNotFoundError):
+            SupplierService.delete(user.company, instance=other_supplier)
+
 
 @pytest.mark.django_db
 class TestSupplierServiceListAndGet:

--- a/backend/apps/scheduler/api/events.py
+++ b/backend/apps/scheduler/api/events.py
@@ -92,5 +92,6 @@ def delete_event(request: AuthRequest, uuid: UUID4) -> tuple[int, None]:
     Desativa também os alertas e lembretes associados a ela.
     """
     user = require_user(request.user)
-    EventService.delete(user.company, uuid)
+    instance = EventService.get(user.company, uuid)
+    EventService.delete(user.company, instance)
     return 204, None

--- a/backend/apps/scheduler/api/tasks.py
+++ b/backend/apps/scheduler/api/tasks.py
@@ -63,5 +63,6 @@ def delete_task(request: AuthRequest, uuid: UUID4) -> tuple[int, None]:
     Remove uma tarefa permanentemente.
     """
     user = require_user(request.user)
-    TaskService.delete(user.company, uuid)
+    instance = TaskService.get(user.company, uuid)
+    TaskService.delete(user.company, instance)
     return 204, None

--- a/backend/apps/scheduler/services/events.py
+++ b/backend/apps/scheduler/services/events.py
@@ -137,6 +137,11 @@ class EventService:
     @staticmethod
     @transaction.atomic
     def delete(company: Company, instance: Event) -> None:
+        if instance.company_id != company.id:
+            raise ObjectNotFoundError(
+                detail="Evento não encontrado ou acesso negado.",
+                code="event_not_found_or_denied",
+            )
         logger.info(
             f"Tentativa de deleção do Evento uuid={instance.uuid} por "
             f"company_id={company.id}"

--- a/backend/apps/scheduler/services/events.py
+++ b/backend/apps/scheduler/services/events.py
@@ -9,6 +9,7 @@ from apps.core.exceptions import (
     BusinessRuleViolation,
     ObjectNotFoundError,
 )
+from apps.core.tenant import validate_tenant_ownership
 from apps.scheduler.models import Event
 from apps.tenants.models import Company
 from apps.weddings.models import Wedding
@@ -99,11 +100,16 @@ class EventService:
     @staticmethod
     @transaction.atomic
     def update(company: Company, instance: Event, data: dict[str, Any]) -> Event:
+        validate_tenant_ownership(
+            company, instance,
+            detail="Evento não encontrado ou acesso negado.",
+            code="event_not_found_or_denied",
+        )
         logger.info(
             f"Atualizando Evento uuid={instance.uuid} por company_id={company.id}"
         )
 
-        # BR-S01: Eventos PAYMENT são read-only
+
         if instance.event_type == Event.TypeChoices.PAYMENT:
             raise BusinessRuleViolation(
                 detail=(
@@ -137,11 +143,11 @@ class EventService:
     @staticmethod
     @transaction.atomic
     def delete(company: Company, instance: Event) -> None:
-        if instance.company_id != company.id:
-            raise ObjectNotFoundError(
-                detail="Evento não encontrado ou acesso negado.",
-                code="event_not_found_or_denied",
-            )
+        validate_tenant_ownership(
+            company, instance,
+            detail="Evento não encontrado ou acesso negado.",
+            code="event_not_found_or_denied",
+        )
         logger.info(
             f"Tentativa de deleção do Evento uuid={instance.uuid} por "
             f"company_id={company.id}"

--- a/backend/apps/scheduler/services/events.py
+++ b/backend/apps/scheduler/services/events.py
@@ -101,14 +101,14 @@ class EventService:
     @transaction.atomic
     def update(company: Company, instance: Event, data: dict[str, Any]) -> Event:
         validate_tenant_ownership(
-            company, instance,
+            company,
+            instance,
             detail="Evento não encontrado ou acesso negado.",
             code="event_not_found_or_denied",
         )
         logger.info(
             f"Atualizando Evento uuid={instance.uuid} por company_id={company.id}"
         )
-
 
         if instance.event_type == Event.TypeChoices.PAYMENT:
             raise BusinessRuleViolation(
@@ -144,7 +144,8 @@ class EventService:
     @transaction.atomic
     def delete(company: Company, instance: Event) -> None:
         validate_tenant_ownership(
-            company, instance,
+            company,
+            instance,
             detail="Evento não encontrado ou acesso negado.",
             code="event_not_found_or_denied",
         )

--- a/backend/apps/scheduler/services/events.py
+++ b/backend/apps/scheduler/services/events.py
@@ -136,8 +136,7 @@ class EventService:
 
     @staticmethod
     @transaction.atomic
-    def delete(company: Company, uuid: UUID | str) -> None:
-        instance = EventService.get(company, uuid)
+    def delete(company: Company, instance: Event) -> None:
         logger.info(
             f"Tentativa de deleção do Evento uuid={instance.uuid} por "
             f"company_id={company.id}"

--- a/backend/apps/scheduler/services/tasks.py
+++ b/backend/apps/scheduler/services/tasks.py
@@ -6,6 +6,7 @@ from django.db import transaction
 from django.db.models import QuerySet
 
 from apps.core.exceptions import ObjectNotFoundError
+from apps.core.tenant import validate_tenant_ownership
 from apps.scheduler.models import Task
 from apps.tenants.models import Company
 from apps.weddings.models import Wedding
@@ -77,6 +78,11 @@ class TaskService:
     @staticmethod
     @transaction.atomic
     def update(company: Company, instance: Task, data: dict[str, Any]) -> Task:
+        validate_tenant_ownership(
+            company, instance,
+            detail="Tarefa não encontrada ou acesso negado.",
+            code="task_not_found_or_denied",
+        )
         logger.info(
             f"Atualizando Tarefa uuid={instance.uuid} por company_id={company.id}"
         )
@@ -95,11 +101,11 @@ class TaskService:
     @staticmethod
     @transaction.atomic
     def delete(company: Company, instance: Task) -> None:
-        if instance.company_id != company.id:
-            raise ObjectNotFoundError(
-                detail="Tarefa não encontrada ou acesso negado.",
-                code="task_not_found_or_denied",
-            )
+        validate_tenant_ownership(
+            company, instance,
+            detail="Tarefa não encontrada ou acesso negado.",
+            code="task_not_found_or_denied",
+        )
         logger.info(
             f"Tentativa de deleção da Tarefa uuid={instance.uuid} por "
             f"company_id={company.id}"

--- a/backend/apps/scheduler/services/tasks.py
+++ b/backend/apps/scheduler/services/tasks.py
@@ -79,7 +79,8 @@ class TaskService:
     @transaction.atomic
     def update(company: Company, instance: Task, data: dict[str, Any]) -> Task:
         validate_tenant_ownership(
-            company, instance,
+            company,
+            instance,
             detail="Tarefa não encontrada ou acesso negado.",
             code="task_not_found_or_denied",
         )
@@ -102,7 +103,8 @@ class TaskService:
     @transaction.atomic
     def delete(company: Company, instance: Task) -> None:
         validate_tenant_ownership(
-            company, instance,
+            company,
+            instance,
             detail="Tarefa não encontrada ou acesso negado.",
             code="task_not_found_or_denied",
         )

--- a/backend/apps/scheduler/services/tasks.py
+++ b/backend/apps/scheduler/services/tasks.py
@@ -95,6 +95,11 @@ class TaskService:
     @staticmethod
     @transaction.atomic
     def delete(company: Company, instance: Task) -> None:
+        if instance.company_id != company.id:
+            raise ObjectNotFoundError(
+                detail="Tarefa não encontrada ou acesso negado.",
+                code="task_not_found_or_denied",
+            )
         logger.info(
             f"Tentativa de deleção da Tarefa uuid={instance.uuid} por "
             f"company_id={company.id}"

--- a/backend/apps/scheduler/services/tasks.py
+++ b/backend/apps/scheduler/services/tasks.py
@@ -94,8 +94,7 @@ class TaskService:
 
     @staticmethod
     @transaction.atomic
-    def delete(company: Company, uuid: UUID | str) -> None:
-        instance = TaskService.get(company, uuid)
+    def delete(company: Company, instance: Task) -> None:
         logger.info(
             f"Tentativa de deleção da Tarefa uuid={instance.uuid} por "
             f"company_id={company.id}"

--- a/backend/apps/scheduler/tests/appointments/test_services.py
+++ b/backend/apps/scheduler/tests/appointments/test_services.py
@@ -215,14 +215,9 @@ class TestEventServiceDelete:
         wedding = WeddingFactory(user_context=user)
         event = EventFactory(wedding=wedding)
 
-        EventService.delete(user.company, event.uuid)
+        EventService.delete(user.company, instance=event)
 
         assert Event.objects.filter(uuid=event.uuid).count() == 0
-
-    def test_delete_event_not_found(self, user):
-        """UUID inexistente levanta ObjectNotFoundError."""
-        with pytest.raises(ObjectNotFoundError):
-            EventService.delete(user.company, uuid4())
 
     def test_delete_payment_event_blocked(self, user):
         """BR-S01: Eventos PAYMENT não podem ser deletados manualmente."""
@@ -234,7 +229,7 @@ class TestEventServiceDelete:
         )
 
         with pytest.raises(BusinessRuleViolation) as exc_info:
-            EventService.delete(user.company, event.uuid)
+            EventService.delete(user.company, instance=event)
 
         assert exc_info.value.code == "payment_event_readonly"
         assert Event.objects.filter(uuid=event.uuid).exists()
@@ -247,7 +242,7 @@ class TestEventServiceDelete:
             event_type=Event.TypeChoices.MEETING,
         )
 
-        EventService.delete(user.company, event.uuid)
+        EventService.delete(user.company, instance=event)
 
         assert Event.objects.filter(uuid=event.uuid).count() == 0
 

--- a/backend/apps/scheduler/tests/appointments/test_services.py
+++ b/backend/apps/scheduler/tests/appointments/test_services.py
@@ -205,6 +205,17 @@ class TestEventServiceUpdate:
 
         assert updated.title == "Reunião com Buffet Atualizada"
 
+    def test_update_event_cross_tenant(self, user):
+        """Evento de outro tenant não pode ser atualizado."""
+        other_user = UserFactory()
+        other_wedding = WeddingFactory(user_context=other_user)
+        other_event = EventFactory(wedding=other_wedding)
+
+        with pytest.raises(ObjectNotFoundError):
+            EventService.update(
+                user.company, other_event, {"title": "Hack"}
+            )
+
 
 @pytest.mark.django_db
 class TestEventServiceDelete:

--- a/backend/apps/scheduler/tests/appointments/test_services.py
+++ b/backend/apps/scheduler/tests/appointments/test_services.py
@@ -257,6 +257,15 @@ class TestEventServiceDelete:
 
         assert Event.objects.filter(uuid=event.uuid).count() == 0
 
+    def test_delete_event_cross_tenant(self, user):
+        """Evento de outro tenant não pode ser deletado."""
+        other_user = UserFactory()
+        other_wedding = WeddingFactory(user_context=other_user)
+        other_event = EventFactory(wedding=other_wedding)
+
+        with pytest.raises(ObjectNotFoundError):
+            EventService.delete(user.company, instance=other_event)
+
 
 @pytest.mark.django_db
 class TestEventServiceListAndGet:

--- a/backend/apps/scheduler/tests/tasks/test_services.py
+++ b/backend/apps/scheduler/tests/tasks/test_services.py
@@ -140,6 +140,15 @@ class TestTaskServiceDelete:
 
         assert Task.objects.filter(uuid=task.uuid).count() == 0
 
+    def test_delete_task_cross_tenant(self, user):
+        """Tarefa de outro tenant não pode ser deletada."""
+        other_user = UserFactory()
+        other_wedding = WeddingFactory(user_context=other_user)
+        other_task = TaskFactory(wedding=other_wedding)
+
+        with pytest.raises(ObjectNotFoundError):
+            TaskService.delete(user.company, instance=other_task)
+
 
 @pytest.mark.django_db
 class TestTaskServiceListAndGet:

--- a/backend/apps/scheduler/tests/tasks/test_services.py
+++ b/backend/apps/scheduler/tests/tasks/test_services.py
@@ -115,6 +115,17 @@ class TestTaskServiceUpdate:
 
         assert updated.company == user.company
 
+    def test_update_task_cross_tenant(self, user):
+        """Tarefa de outro tenant não pode ser atualizada."""
+        other_user = UserFactory()
+        other_wedding = WeddingFactory(user_context=other_user)
+        other_task = TaskFactory(wedding=other_wedding)
+
+        with pytest.raises(ObjectNotFoundError):
+            TaskService.update(
+                user.company, other_task, {"title": "Hack"}
+            )
+
 
 @pytest.mark.django_db
 class TestTaskServiceDelete:

--- a/backend/apps/scheduler/tests/tasks/test_services.py
+++ b/backend/apps/scheduler/tests/tasks/test_services.py
@@ -125,14 +125,9 @@ class TestTaskServiceDelete:
         wedding = WeddingFactory(user_context=user)
         task = TaskFactory(wedding=wedding)
 
-        TaskService.delete(user.company, task.uuid)
+        TaskService.delete(user.company, instance=task)
 
         assert Task.objects.filter(uuid=task.uuid).count() == 0
-
-    def test_delete_task_not_found(self, user):
-        """UUID inexistente levanta ObjectNotFoundError."""
-        with pytest.raises(ObjectNotFoundError):
-            TaskService.delete(user.company, uuid4())
 
 
 @pytest.mark.django_db

--- a/backend/apps/weddings/api/weddings.py
+++ b/backend/apps/weddings/api/weddings.py
@@ -72,5 +72,6 @@ def update_wedding(
 )
 def delete_wedding(request: AuthRequest, uuid: UUID4) -> tuple[int, None]:
     user = require_user(request.user)
-    WeddingService.delete(company=user.company, uuid=uuid)
+    instance = WeddingService.get(company=user.company, uuid=uuid)
+    WeddingService.delete(company=user.company, instance=instance)
     return 204, None

--- a/backend/apps/weddings/services/wedding_service.py
+++ b/backend/apps/weddings/services/wedding_service.py
@@ -146,6 +146,11 @@ class WeddingService:
         """
         Deleta um casamento.
         """
+        if instance.company_id != company.id:
+            raise ObjectNotFoundError(
+                detail="Casamento não encontrado ou acesso negado.",
+                code="wedding_not_found_or_denied",
+            )
         logger.info(
             f"Tentativa de deleção do casamento uuid={instance.uuid} pela "
             f"company_id={company.id}"

--- a/backend/apps/weddings/services/wedding_service.py
+++ b/backend/apps/weddings/services/wedding_service.py
@@ -12,6 +12,7 @@ from apps.core.exceptions import (
     DomainIntegrityError,
     ObjectNotFoundError,
 )
+from apps.core.tenant import validate_tenant_ownership
 from apps.finances.models import Budget
 from apps.tenants.models import Company
 
@@ -114,6 +115,11 @@ class WeddingService:
     @staticmethod
     @transaction.atomic
     def update(company: Company, instance: Wedding, data: dict[str, Any]) -> Wedding:
+        validate_tenant_ownership(
+            company, instance,
+            detail="Casamento não encontrado ou acesso negado.",
+            code="wedding_not_found_or_denied",
+        )
         logger.info(
             f"Atualizando casamento uuid={instance.uuid} pela company_id={company.id}"
         )
@@ -146,11 +152,11 @@ class WeddingService:
         """
         Deleta um casamento.
         """
-        if instance.company_id != company.id:
-            raise ObjectNotFoundError(
-                detail="Casamento não encontrado ou acesso negado.",
-                code="wedding_not_found_or_denied",
-            )
+        validate_tenant_ownership(
+            company, instance,
+            detail="Casamento não encontrado ou acesso negado.",
+            code="wedding_not_found_or_denied",
+        )
         logger.info(
             f"Tentativa de deleção do casamento uuid={instance.uuid} pela "
             f"company_id={company.id}"

--- a/backend/apps/weddings/services/wedding_service.py
+++ b/backend/apps/weddings/services/wedding_service.py
@@ -142,11 +142,10 @@ class WeddingService:
 
     @staticmethod
     @transaction.atomic
-    def delete(company: Company, uuid: UUID | str) -> None:
+    def delete(company: Company, instance: Wedding) -> None:
         """
         Deleta um casamento.
         """
-        instance = WeddingService.get(company, uuid)
         logger.info(
             f"Tentativa de deleção do casamento uuid={instance.uuid} pela "
             f"company_id={company.id}"

--- a/backend/apps/weddings/services/wedding_service.py
+++ b/backend/apps/weddings/services/wedding_service.py
@@ -116,7 +116,8 @@ class WeddingService:
     @transaction.atomic
     def update(company: Company, instance: Wedding, data: dict[str, Any]) -> Wedding:
         validate_tenant_ownership(
-            company, instance,
+            company,
+            instance,
             detail="Casamento não encontrado ou acesso negado.",
             code="wedding_not_found_or_denied",
         )
@@ -153,7 +154,8 @@ class WeddingService:
         Deleta um casamento.
         """
         validate_tenant_ownership(
-            company, instance,
+            company,
+            instance,
             detail="Casamento não encontrado ou acesso negado.",
             code="wedding_not_found_or_denied",
         )

--- a/backend/apps/weddings/tests/test_services.py
+++ b/backend/apps/weddings/tests/test_services.py
@@ -247,6 +247,14 @@ class TestWeddingService:
         assert Budget.objects.count() == 0
         assert BudgetCategory.objects.count() == 0
 
+    def test_delete_wedding_cross_tenant(self, user):
+        """Casamento de outro tenant não pode ser deletado."""
+        other_user = UserFactory()
+        other_wedding = WeddingFactory(company=other_user.company)
+
+        with pytest.raises(ObjectNotFoundError):
+            WeddingService.delete(company=user.company, instance=other_wedding)
+
 
 @pytest.mark.django_db
 class TestWeddingServiceListAnnotations:

--- a/backend/apps/weddings/tests/test_services.py
+++ b/backend/apps/weddings/tests/test_services.py
@@ -110,12 +110,15 @@ class TestWeddingService:
 
     def test_update_wedding_cross_tenant(self, user):
         """Casamento de outro tenant não pode ser atualizado."""
+        from apps.users.tests.factories import UserFactory
         other_user = UserFactory()
         other_wedding = WeddingFactory(company=other_user.company)
 
         with pytest.raises(ObjectNotFoundError):
             WeddingService.update(
-                company=user.company, instance=other_wedding, data={"bride_name": "Hack"}
+                company=user.company,
+                instance=other_wedding,
+                data={"bride_name": "Hack"},
             )
 
     def test_create_wedding_fail_fast_validation_error(self, user, wedding_payload):
@@ -249,6 +252,7 @@ class TestWeddingService:
 
     def test_delete_wedding_cross_tenant(self, user):
         """Casamento de outro tenant não pode ser deletado."""
+        from apps.users.tests.factories import UserFactory
         other_user = UserFactory()
         other_wedding = WeddingFactory(company=other_user.company)
 

--- a/backend/apps/weddings/tests/test_services.py
+++ b/backend/apps/weddings/tests/test_services.py
@@ -104,9 +104,19 @@ class TestWeddingService:
 
         # Asserção
         assert updated_wedding.bride_name == "Nova Maria"
-        # O valor do orçamento NÃO deve ter mudado se buscarmos no banco
+
         budget = Budget.objects.get(wedding=updated_wedding)
         assert budget.total_estimated == initial_value
+
+    def test_update_wedding_cross_tenant(self, user):
+        """Casamento de outro tenant não pode ser atualizado."""
+        other_user = UserFactory()
+        other_wedding = WeddingFactory(company=other_user.company)
+
+        with pytest.raises(ObjectNotFoundError):
+            WeddingService.update(
+                company=user.company, instance=other_wedding, data={"bride_name": "Hack"}
+            )
 
     def test_create_wedding_fail_fast_validation_error(self, user, wedding_payload):
         """

--- a/backend/apps/weddings/tests/test_services.py
+++ b/backend/apps/weddings/tests/test_services.py
@@ -214,7 +214,7 @@ class TestWeddingService:
         with pytest.raises(
             DomainIntegrityError, match="Não é possível apagar este casamento"
         ):
-            WeddingService.delete(company=user.company, uuid=wedding.uuid)
+            WeddingService.delete(company=user.company, instance=wedding)
 
         assert Wedding.objects.filter(uuid=wedding.uuid).exists()
 
@@ -230,7 +230,7 @@ class TestWeddingService:
         wedding = WeddingService.create(company=user.company, data=payload)
 
         # 2. Execução: Deletar o casamento
-        WeddingService.delete(company=user.company, uuid=wedding.uuid)
+        WeddingService.delete(company=user.company, instance=wedding)
 
         # 3. Asserções: O banco de dados deve estar limpo
         assert Wedding.objects.count() == 0

--- a/docs/ADR/019-tenant-validation-service-layer.md
+++ b/docs/ADR/019-tenant-validation-service-layer.md
@@ -1,0 +1,46 @@
+# ADR-019: Validação de Tenant na Camada de Serviço
+
+## Status
+Aceito
+
+## Contexto
+A arquitetura de multi-tenancy do sistema (ADR-009, ADR-016) isola os dados verticalmente por `Company` através do `TenantManager` com `.for_tenant(company)` nas queries do banco. No entanto, diversos métodos da camada de serviço (`update()`, `delete()`, `mark_as_paid()`, etc.) recebem uma instância do modelo já carregada — seja pela API (que faz `get()` antes de chamar o service) ou por chamadas internas entre services.
+
+Nesses métodos, o parâmetro `company` era recebido mas **nunca validado contra a instância**. Um chamador da API está protegido pelo `get()` na camada de API, mas uma chamada interna entre services (ou um erro na camada de API) poderia operar em uma instância de outro tenant silenciosamente.
+
+## Decisão
+Criar um helper centralizado `validate_tenant_ownership()` que verifica se `instance.company_id == company.id`, levantando `ObjectNotFoundError` (HTTP 404) em caso de mismatch. Aplicar em **todo método que recebe uma instância pré-carregada**.
+
+### Por que 404 e não 403?
+Retornar 403 ("acesso negado") revelaria ao atacante que o recurso existe em outro tenant. Com 404, os casos "recurso não existe" e "recurso existe em outro tenant" são indistinguíveis — prática padrão em SaaS multi-tenant.
+
+### Helper centralizado
+```python
+def validate_tenant_ownership(company, instance, *, detail, code):
+    if instance.company_id != company.id:
+        raise ObjectNotFoundError(detail=detail, code=code)
+```
+
+### Escopo de aplicação
+Todos os métodos dos 10 services que recebem `(company, instance, ...)`:
+- `delete()` — 10 services
+- `update()` — 8 services
+- `mark_as_paid()`, `unmark_as_paid()` — InstallmentService
+- `adjust()` — InstallmentService
+- `transition_status()` — ContractService, ItemService
+
+## Consequências
+- **Positivas**:
+  - Cross-tenant access silencioso é impossível em qualquer método de serviço
+  - Código mais explícito e defensivo
+  - Helper centralizado permite mudar o comportamento (ex: código do erro) em um único lugar
+- **Negativas**:
+  - O parâmetro `company` em métodos como `delete()` agora serve apenas para logging + validação, não mais para lookup
+  - Leve overhead de CPU por chamada (comparação de dois integers)
+- **Neutras**:
+  - Testes cross-tenant adicionados para todos os métodos validados
+
+## Arquivos Afetados
+- `backend/apps/core/tenant.py` (novo) — helper
+- `backend/apps/*/services/*.py` (23 métodos em 10 services)
+- `backend/apps/*/tests/*/test_services.py` (17 testes cross-tenant)


### PR DESCRIPTION
Closes #145

**Problem:** `WeddingService.delete`, `EventService.delete` and `TaskService.delete` received a raw `uuid` and performed internal `get()` lookups, while the other 7 services received an `instance` directly.

**Solution:** Moved the `get()` call to the API layer (which already does this for `update()`). The affected services now receive `instance` like all others.

**Changes:**
- `WeddingService.delete(company, uuid)` → `(company, instance: Wedding)`
- `EventService.delete(company, uuid)` → `(company, instance: Event)`
- `TaskService.delete(company, uuid)` → `(company, instance: Task)`
- API endpoints now perform `get()` before calling `delete()`
- Tests updated; `test_delete_*_not_found` tests removed (covered by `get()` and API tests)

**Verification:** 156 tests passing, ruff + mypy clean.