### PR TITLE
fix(budgets): preserve ValidationError when non-wedding fields are invalid

### DIFF
--- a/backend/apps/finances/services/budget_service.py
+++ b/backend/apps/finances/services/budget_service.py
@@ -69,13 +69,11 @@ class BudgetService:
         try:
             budget.save()
         except (IntegrityError, ValidationError) as e:
-            # full_clean() ou o banco apitam se já existir um Budget (OneToOne)
-
-            # Se for ValidationError, verificamos se é o erro de unicidade
-            if isinstance(e, ValidationError) and "wedding" not in getattr(
-                e, "message_dict", {}
-            ):
-                raise e
+            if isinstance(e, ValidationError):
+                message_dict = getattr(e, "message_dict", {})
+                other_fields = [k for k in message_dict if k != "wedding"]
+                if other_fields:
+                    raise e
 
             logger.exception(
                 f"Conflito de integridade: Casamento uuid={wedding.uuid} já possui "

--- a/backend/apps/finances/tests/budgets/test_services.py
+++ b/backend/apps/finances/tests/budgets/test_services.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 
 import pytest
 from django.core.exceptions import ValidationError
+from django.db import IntegrityError
 
 from apps.core.exceptions import DomainIntegrityError, ObjectNotFoundError
 from apps.finances.models import Budget, BudgetCategory
@@ -472,6 +473,27 @@ class TestBudgetServiceIntegration:
                     "wedding": ["Budget with this Wedding already exists."],
                 }
             )
+
+        budget_data = {
+            "wedding": wedding.uuid,
+            "total_estimated": Decimal("50000.00"),
+        }
+
+        with patch.object(Budget, "save", mock_save):
+            with pytest.raises(DomainIntegrityError) as exc_info:
+                BudgetService.create(user.company, budget_data)
+
+        assert "já possui um orçamento definido" in str(exc_info.value.detail)
+
+    def test_create_budget_integrity_error_path(self, user):
+        """
+        IntegrityError puro (sem ValidationError) deve ser convertido
+        para DomainIntegrityError.
+        """
+        wedding = WeddingFactory(company=user.company)
+
+        def mock_save(*args, **kwargs):
+            raise IntegrityError("UNIQUE constraint failed: wedding_id")
 
         budget_data = {
             "wedding": wedding.uuid,

--- a/backend/apps/finances/tests/budgets/test_services.py
+++ b/backend/apps/finances/tests/budgets/test_services.py
@@ -12,6 +12,7 @@ from decimal import Decimal
 from unittest.mock import patch
 
 import pytest
+from django.core.exceptions import ValidationError
 
 from apps.core.exceptions import DomainIntegrityError, ObjectNotFoundError
 from apps.finances.models import Budget, BudgetCategory
@@ -374,9 +375,7 @@ class TestBudgetServiceIntegration:
         other_budget = BudgetFactory(wedding=other_wedding)
 
         with pytest.raises(ObjectNotFoundError):
-            BudgetService.update(
-                user.company, other_budget, {"notes": "Hack"}
-            )
+            BudgetService.update(user.company, other_budget, {"notes": "Hack"})
 
     def test_budget_delete_success(self, user):
         """
@@ -429,3 +428,58 @@ class TestBudgetServiceIntegration:
 
         with pytest.raises(ObjectNotFoundError):
             BudgetService.delete(user.company, instance=other_budget)
+
+    def test_create_budget_validation_error_with_other_fields(self, user):
+        """
+        ValidationError com campos além de 'wedding' NÃO deve ser engolido
+        pelo DomainIntegrityError.
+        """
+        wedding = WeddingFactory(company=user.company)
+
+        def mock_save(*args, **kwargs):
+            raise ValidationError(
+                {
+                    "wedding": ["Budget with this Wedding already exists."],
+                    "total_estimated": [
+                        "Ensure this value is greater than or equal to 0."
+                    ],
+                }
+            )
+
+        budget_data = {
+            "wedding": wedding.uuid,
+            "total_estimated": Decimal("50000.00"),
+        }
+
+        with patch.object(Budget, "save", mock_save):
+            with pytest.raises(ValidationError) as exc_info:
+                BudgetService.create(user.company, budget_data)
+
+        message_dict = exc_info.value.message_dict
+        assert "total_estimated" in message_dict
+        assert "wedding" in message_dict
+
+    def test_create_budget_validation_error_wedding_only(self, user):
+        """
+        ValidationError APENAS com 'wedding' no message_dict deve ser
+        convertido para DomainIntegrityError.
+        """
+        wedding = WeddingFactory(company=user.company)
+
+        def mock_save(*args, **kwargs):
+            raise ValidationError(
+                {
+                    "wedding": ["Budget with this Wedding already exists."],
+                }
+            )
+
+        budget_data = {
+            "wedding": wedding.uuid,
+            "total_estimated": Decimal("50000.00"),
+        }
+
+        with patch.object(Budget, "save", mock_save):
+            with pytest.raises(DomainIntegrityError) as exc_info:
+                BudgetService.create(user.company, budget_data)
+
+        assert "já possui um orçamento definido" in str(exc_info.value.detail)


### PR DESCRIPTION
Closes #146

## Problem

`BudgetService.create` was swallowing `ValidationError`s that contained `"wedding"` in `message_dict` along with other invalid fields, replacing them with a generic `DomainIntegrityError(budget_already_exists)`.

## Solution

Refined the condition in `budget_service.py` to check whether `message_dict` contains fields `other than wedding`:
- If **only** `"wedding"` → raise `DomainIntegrityError` (pure duplicate)
- If **other fields present** → re-raise original `ValidationError`

## Changes

- `backend/apps/finances/services/budget_service.py` — fix condition
- `backend/apps/finances/tests/budgets/test_services.py` — 2 new tests covering both scenarios

## Tests

```
✅ 23 passed (all budget service tests)
```