### PR TITLE
test(backend): cobrir ultimos cenarios do integrity-ci (fix #205)

### DIFF
--- a/backend/apps/finances/tests/installments/test_services.py
+++ b/backend/apps/finances/tests/installments/test_services.py
@@ -238,9 +238,24 @@ class TestInstallmentServiceAutoGeneration:
         events = Event.objects.filter(wedding=expense.wedding).order_by("start_time")
         assert len(events) == 2
 
-        # Verificar que o valor R$ aparece na descrição
+
         assert "125.00" in events[0].description
         assert "Flores" in events[0].description
+
+    def test_auto_generate_single_installment(self, user):
+        """num_installments=1 cria uma unica parcela com o valor total."""
+        expense = _setup_expense(user, actual_amount=Decimal("500.00"))
+        first_date = date.today() + timedelta(days=30)
+
+        installments = InstallmentService.auto_generate_installments(
+            user.company, expense, 1, first_date
+        )
+
+        assert len(installments) == 1
+        assert installments[0].amount == Decimal("500.00")
+        assert installments[0].installment_number == 1
+        assert installments[0].due_date == first_date
+        assert installments[0].status == Installment.StatusChoices.PENDING
 
 
 @pytest.mark.django_db

--- a/backend/apps/weddings/tests/test_services.py
+++ b/backend/apps/weddings/tests/test_services.py
@@ -718,6 +718,17 @@ class TestDashboardService:
             for call in mock_logger.info.call_args_list
         )
 
+    def test_get_summary_empty_company(self, user):
+        """Dashboard sem casamentos deve retornar zeros."""
+        summary = DashboardService.get_summary(company=user.company)
+
+        assert summary["pending_installments_7d"] == "0.00"
+        assert summary["urgent_tasks_count"] == 0
+        assert summary["overdue_installments_amount"] == "0.00"
+        assert summary["overdue_installments_count"] == 0
+        assert summary["pending_contracts_count"] == 0
+        assert summary["critical_weddings"] == []
+
 
 @pytest.mark.django_db
 class TestFinancialSummaryService:


### PR DESCRIPTION
## Descrição

Adiciona os 2 ultimos cenarios de teste que estavam pendentes na issue #205.

## Cenarios cobertos

### installment_service.py
- `auto_generate_installments` com `num_installments=1`: edge case onde o loop `range(1, 1)` nao itera e a parcela unica recebe o valor total da despesa

### DashboardService
- `get_summary` com 0 weddings: empresa sem casamentos deve retornar todos os KPIs como zero

## Testes
- 670 testes passando (up from 668)
- Ruff: 0 erros
- Mypy: 0 erros novos

Closes #205