### PR TITLE
🧪 test(scheduler): add tests for constants mapping

### DIFF
--- a/frontend/src/features/scheduler/components/SchedulerEventsTable.tsx
+++ b/frontend/src/features/scheduler/components/SchedulerEventsTable.tsx
@@ -20,13 +20,7 @@ import {
 } from "@/components/ui/table";
 import { formatDateTimeBR } from "@/lib/formatters";
 
-const EVENT_LABELS: Record<string, string> = {
-  reuniao: "Reunião",
-  pagamento: "Pagamento",
-  visita: "Visita Técnica",
-  degustacao: "Degustação",
-  outro: "Outro",
-};
+import { EVENT_LABELS } from "../constants";
 
 interface SchedulerEventsTableProps {
   events: EventOut[];

--- a/frontend/src/features/scheduler/constants.test.ts
+++ b/frontend/src/features/scheduler/constants.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  EVENT_TYPE_OPTIONS,
+  RECURRENCE_OPTIONS,
+  EVENT_LABELS,
+  EVENT_COLORS,
+} from "./constants";
+
+describe("Scheduler Constants", () => {
+  describe("EVENT_TYPE_OPTIONS", () => {
+    it("should be defined and not empty", () => {
+      expect(EVENT_TYPE_OPTIONS).toBeDefined();
+      expect(EVENT_TYPE_OPTIONS.length).toBeGreaterThan(0);
+    });
+
+    it("should have correct structure and values", () => {
+      expect(EVENT_TYPE_OPTIONS).toEqual([
+        { value: "reuniao", label: "Reunião" },
+        { value: "visita", label: "Visita Técnica" },
+        { value: "degustacao", label: "Degustação" },
+        { value: "outro", label: "Outro" },
+      ]);
+    });
+  });
+
+  describe("RECURRENCE_OPTIONS", () => {
+    it("should be defined and not empty", () => {
+      expect(RECURRENCE_OPTIONS).toBeDefined();
+      expect(RECURRENCE_OPTIONS.length).toBeGreaterThan(0);
+    });
+
+    it("should have correct structure and values", () => {
+      expect(RECURRENCE_OPTIONS).toEqual([
+        { value: "none", label: "Nenhuma" },
+        { value: "semanal", label: "Semanal" },
+        { value: "quinzenal", label: "Quinzenal" },
+        { value: "mensal", label: "Mensal" },
+      ]);
+    });
+  });
+
+  describe("EVENT_LABELS", () => {
+    it("should be defined and not empty", () => {
+      expect(EVENT_LABELS).toBeDefined();
+      expect(Object.keys(EVENT_LABELS).length).toBeGreaterThan(0);
+    });
+
+    it("should have correct labels", () => {
+      expect(EVENT_LABELS).toEqual({
+        reuniao: "Reunião",
+        pagamento: "Pagamento",
+        visita: "Visita Técnica",
+        degustacao: "Degustação",
+        outro: "Outro",
+      });
+    });
+  });
+
+  describe("EVENT_COLORS", () => {
+    it("should be defined and not empty", () => {
+      expect(EVENT_COLORS).toBeDefined();
+      expect(Object.keys(EVENT_COLORS).length).toBeGreaterThan(0);
+    });
+
+    it("should have correct colors", () => {
+      expect(EVENT_COLORS).toEqual({
+        reuniao: "#3B82F6",
+        pagamento: "#22C55E",
+        visita: "#A855F7",
+        degustacao: "#F97316",
+        outro: "#6B7280",
+      });
+    });
+  });
+
+  describe("Consistency", () => {
+    it("every event type option should have a label and color mapping", () => {
+      EVENT_TYPE_OPTIONS.forEach((option) => {
+        expect(EVENT_LABELS[option.value]).toBeDefined();
+        expect(EVENT_COLORS[option.value]).toBeDefined();
+      });
+    });
+
+    it("event labels and colors should have matching keys", () => {
+      const labelKeys = Object.keys(EVENT_LABELS).sort();
+      const colorKeys = Object.keys(EVENT_COLORS).sort();
+      expect(labelKeys).toEqual(colorKeys);
+    });
+  });
+});


### PR DESCRIPTION
This PR adds unit tests for the scheduler constants to ensure they are correctly defined, non-empty, and consistent across different mappings.

### 🎯 What:
The testing gap addressed is the lack of verification for core configuration constants in the scheduler feature.

### 📊 Coverage:
- `EVENT_TYPE_OPTIONS`: Verified as non-empty array with specific `{ value, label }` structure and current values.
- `RECURRENCE_OPTIONS`: Verified as non-empty array with specific `{ value, label }` structure and current values.
- `EVENT_LABELS`: Verified as non-empty object with specific key-value pairs.
- `EVENT_COLORS`: Verified as non-empty object with specific key-value pairs.
- **Consistency**: Verified that every `value` in `EVENT_TYPE_OPTIONS` has a corresponding label and color, and that `EVENT_LABELS` and `EVENT_COLORS` have identical keys.

### ✨ Result:
Improved reliability and maintainability of the scheduler feature by ensuring its configuration constants are stable and consistent.

---
*PR created automatically by Jules for task [16555211463602191131](https://jules.google.com/task/16555211463602191131) started by @Rafaelp122*