### PR TITLE
🧪 Melhoria nos testes do authStore (Persistência e Integridade)

### DIFF
--- a/frontend/src/stores/authStore.test.ts
+++ b/frontend/src/stores/authStore.test.ts
@@ -16,6 +16,7 @@ function resetStore() {
     user: null,
     isAuthenticated: false,
   });
+  localStorage.clear();
 }
 
 describe("useAuthStore", () => {
@@ -49,10 +50,22 @@ describe("useAuthStore", () => {
       expect(state.user).toEqual(mockUser);
       expect(state.isAuthenticated).toBe(true);
     });
+
+    it("persists state to localStorage", () => {
+      useAuthStore.getState().login("access-1", "refresh-1", mockUser);
+
+      const storedValue = localStorage.getItem("wedding-auth-storage");
+      expect(storedValue).not.toBeNull();
+
+      const parsed = JSON.parse(storedValue!);
+      expect(parsed.state.accessToken).toBe("access-1");
+      expect(parsed.state.user).toEqual(mockUser);
+      expect(parsed.state.isAuthenticated).toBe(true);
+    });
   });
 
   describe("logout", () => {
-    it("clears all auth data", () => {
+    it("clears all auth data from state and localStorage", () => {
       useAuthStore.getState().login("access-1", "refresh-1", mockUser);
       useAuthStore.getState().logout();
 
@@ -61,11 +74,43 @@ describe("useAuthStore", () => {
       expect(state.refreshToken).toBeNull();
       expect(state.user).toBeNull();
       expect(state.isAuthenticated).toBe(false);
+
+      const storedValue = localStorage.getItem("wedding-auth-storage");
+      const parsed = JSON.parse(storedValue!);
+      expect(parsed.state.accessToken).toBeNull();
+      expect(parsed.state.isAuthenticated).toBe(false);
+    });
+  });
+
+  describe("rehydration", () => {
+    it("initializes state from localStorage", async () => {
+      const persistedState = {
+        state: {
+          accessToken: "stored-access",
+          refreshToken: "stored-refresh",
+          user: mockUser,
+          isAuthenticated: true,
+        },
+        version: 0,
+      };
+      localStorage.setItem(
+        "wedding-auth-storage",
+        JSON.stringify(persistedState),
+      );
+
+      // We trigger a manual rehydration because the store is already initialized in the test environment
+      await useAuthStore.persist.rehydrate();
+
+      const state = useAuthStore.getState();
+      expect(state.accessToken).toBe("stored-access");
+      expect(state.refreshToken).toBe("stored-refresh");
+      expect(state.user).toEqual(mockUser);
+      expect(state.isAuthenticated).toBe(true);
     });
   });
 
   describe("updateTokens", () => {
-    it("updates access token", () => {
+    it("updates access token and keeps user", () => {
       useAuthStore.getState().login("access-1", "refresh-1", mockUser);
       useAuthStore.getState().updateTokens("access-2");
 
@@ -75,23 +120,27 @@ describe("useAuthStore", () => {
       expect(state.user).toEqual(mockUser);
     });
 
-    it("updates both tokens when refresh is provided", () => {
+    it("updates both tokens and keeps user", () => {
       useAuthStore.getState().login("access-1", "refresh-1", mockUser);
       useAuthStore.getState().updateTokens("access-3", "refresh-3");
 
       const state = useAuthStore.getState();
       expect(state.accessToken).toBe("access-3");
       expect(state.refreshToken).toBe("refresh-3");
+      expect(state.user).toEqual(mockUser);
     });
   });
 
   describe("updateUser", () => {
-    it("merges partial user data", () => {
+    it("merges partial user data and keeps tokens", () => {
       useAuthStore.getState().login("access-1", "refresh-1", mockUser);
       useAuthStore.getState().updateUser({ first_name: "Updated" });
+
       const state = useAuthStore.getState();
       expect(state.user?.first_name).toBe("Updated");
       expect(state.user?.email).toBe("test@email.com");
+      expect(state.accessToken).toBe("access-1");
+      expect(state.refreshToken).toBe("refresh-1");
     });
 
     it("does nothing when user is null", () => {


### PR DESCRIPTION
🎯 **O que:** Foi identificada uma lacuna nos testes da store de autenticação (`authStore.ts`), que embora tivesse cobertura de 100%, não validava a lógica de persistência e a integridade das transições de estado.

📊 **Cobertura:**
- **Persistência:** Validado que o `login` salva os dados no `localStorage` e o `logout` os remove.
- **Reidratação:** Adicionado teste que simula o carregamento da aplicação com dados pré-existentes no storage, garantindo que a sessão seja recuperada corretamente.
- **Integridade:** Testes garantindo que a atualização de tokens não afete os dados do usuário e vice-versa, prevenindo bugs de "merge raso" (shallow merge).
- **Isolamento:** Configurada limpeza automática do `localStorage` entre os testes para evitar efeitos colaterais.

✨ **Resultado:** Aumento na confiabilidade da gestão de estado de autenticação, garantindo que o mecanismo de persistência (crítico para a experiência do usuário) funcione conforme o esperado e esteja protegido contra regressões.

---
*PR created automatically by Jules for task [13823199950899155671](https://jules.google.com/task/13823199950899155671) started by @Rafaelp122*