### PR TITLE
🧪 [testing improvement] Refatoração e melhoria de testes de erro em InstallmentService

### DIFF
--- a/backend/apps/finances/services/installment_service.py
+++ b/backend/apps/finances/services/installment_service.py
@@ -13,6 +13,7 @@ from apps.core.exceptions import (
     DomainIntegrityError,
     ObjectNotFoundError,
 )
+from apps.core.shortcuts import get_object_or_404_for_tenant
 from apps.core.tenant import validate_tenant_ownership
 from apps.finances.models import Expense, Installment
 from apps.finances.schemas import InstallmentAdjustIn, InstallmentIn, InstallmentPatchIn
@@ -65,14 +66,13 @@ class InstallmentService:
 
     @staticmethod
     def get(company: Company, uuid: UUID | str) -> Installment:
-        try:
-            return (
-                Installment.objects.for_tenant(company)
-                .select_related("expense", "wedding")
-                .get(uuid=uuid)
-            )
-        except Installment.DoesNotExist as e:
-            raise ObjectNotFoundError(detail="Parcela não encontrada.") from e
+        return get_object_or_404_for_tenant(
+            Installment,
+            company,
+            uuid,
+            select_related=["expense", "wedding"],
+            detail="Parcela não encontrada.",
+        )
 
     @staticmethod
     @transaction.atomic

--- a/backend/apps/finances/tests/categories/test_services.py
+++ b/backend/apps/finances/tests/categories/test_services.py
@@ -317,8 +317,10 @@ class TestBudgetCategoryServiceListAndGet:
 
     def test_get_category_not_found(self, user):
         """UUID inexistente levanta ObjectNotFoundError."""
-        with pytest.raises(ObjectNotFoundError):
+        with pytest.raises(ObjectNotFoundError) as exc_info:
             BudgetCategoryService.get(user.company, uuid4())
+
+        assert str(exc_info.value.detail) == "Categoria de orçamento não encontrada."
 
     def test_get_category_multitenancy(self):
         """Usuário A não pode acessar categoria do Usuário B."""
@@ -330,8 +332,10 @@ class TestBudgetCategoryServiceListAndGet:
             wedding=budget_b.wedding,
         )
 
-        with pytest.raises(ObjectNotFoundError):
+        with pytest.raises(ObjectNotFoundError) as exc_info:
             BudgetCategoryService.get(user_a.company, category_b.uuid)
+
+        assert str(exc_info.value.detail) == "Categoria de orçamento não encontrada."
 
 
 @pytest.mark.django_db

--- a/backend/apps/finances/tests/installments/test_services.py
+++ b/backend/apps/finances/tests/installments/test_services.py
@@ -930,8 +930,10 @@ class TestInstallmentServiceListAndGet:
 
     def test_get_installment_not_found(self, user):
         """UUID inexistente levanta ObjectNotFoundError."""
-        with pytest.raises(ObjectNotFoundError):
+        with pytest.raises(ObjectNotFoundError) as exc_info:
             InstallmentService.get(user.company, uuid4())
+
+        assert str(exc_info.value.detail) == "Parcela não encontrada."
 
     def test_get_installment_multitenancy(self):
         """Usuário A não pode acessar parcela do Usuário B."""
@@ -940,5 +942,7 @@ class TestInstallmentServiceListAndGet:
         expense_b = _setup_expense(user_b)
         installment_b = InstallmentFactory(expense=expense_b)
 
-        with pytest.raises(ObjectNotFoundError):
+        with pytest.raises(ObjectNotFoundError) as exc_info:
             InstallmentService.get(user_a.company, installment_b.uuid)
+
+        assert str(exc_info.value.detail) == "Parcela não encontrada."


### PR DESCRIPTION
### 🧪 Melhoria nos Testes e Refatoração de Serviços

🎯 **O que:** Foi preenchida uma lacuna nos testes dos serviços de Finanças, garantindo que as falhas de busca de objetos (ID inexistente ou acesso negado entre tenants) não apenas lancem a exceção correta, mas também retornem a mensagem de erro esperada.

📊 **Cobertura:**
- **InstallmentService:** Os testes `test_get_installment_not_found` e `test_get_installment_multitenancy` agora validam o atributo `detail` da exceção.
- **BudgetCategoryService:** Os testes `test_get_category_not_found` e `test_get_category_multitenancy` também foram aprimorados para validar a mensagem de erro.

✨ **Resultado:**
- **Refatoração:** O método `InstallmentService.get` foi refatorado para utilizar o atalho centralizado `get_object_or_404_for_tenant`, eliminando blocos `try-except` manuais e garantindo consistência com outros serviços (como `BudgetCategoryService`).
- **Confiabilidade:** Os testes agora são mais rigorosos, prevenindo regressões nas mensagens de erro que são expostas aos usuários.

---
*PR created automatically by Jules for task [13721966043364481403](https://jules.google.com/task/13721966043364481403) started by @Rafaelp122*