### PR TITLE
⚡ Otimização de Performance: Eliminação de Queries N+1 em Finanças

### DIFF
--- a/backend/apps/finances/managers.py
+++ b/backend/apps/finances/managers.py
@@ -13,13 +13,38 @@ from apps.finances.models.installment import Installment
 from apps.tenants.managers import TenantManager, TenantQuerySet
 
 
+class BudgetQuerySet(TenantQuerySet):
+    """QuerySet customizado para Budget."""
+
+    def with_total_spent(self) -> BudgetQuerySet:
+        """Anota cada orçamento com o total geral pago."""
+        return self.annotate(
+            annotated_total_overall_spent=Coalesce(
+                Sum(
+                    "categories__expenses__installments__amount",
+                    filter=Q(
+                        categories__expenses__installments__status=Installment.StatusChoices.PAID
+                    ),
+                ),
+                Decimal("0.00"),
+            )
+        )
+
+
+class BudgetManager(TenantManager):
+    """Manager customizado para Budget."""
+
+    def get_queryset(self) -> BudgetQuerySet:
+        return BudgetQuerySet(self.model, using=self._db)
+
+
 class BudgetCategoryQuerySet(TenantQuerySet):
     """QuerySet customizado para BudgetCategory."""
 
     def with_total_spent(self) -> BudgetCategoryQuerySet:
         """Anota cada categoria com o total pago (soma de parcelas PAID)."""
         return self.annotate(
-            _total_spent=Coalesce(
+            annotated_total_spent=Coalesce(
                 Sum(
                     "expenses__installments__amount",
                     filter=Q(

--- a/backend/apps/finances/managers.py
+++ b/backend/apps/finances/managers.py
@@ -19,7 +19,7 @@ class BudgetQuerySet(TenantQuerySet):
     def with_total_spent(self) -> BudgetQuerySet:
         """Anota cada orçamento com o total geral pago."""
         return self.annotate(
-            annotated_total_overall_spent=Coalesce(
+            _total_overall_spent=Coalesce(
                 Sum(
                     "categories__expenses__installments__amount",
                     filter=Q(
@@ -44,7 +44,7 @@ class BudgetCategoryQuerySet(TenantQuerySet):
     def with_total_spent(self) -> BudgetCategoryQuerySet:
         """Anota cada categoria com o total pago (soma de parcelas PAID)."""
         return self.annotate(
-            annotated_total_spent=Coalesce(
+            _total_spent=Coalesce(
                 Sum(
                     "expenses__installments__amount",
                     filter=Q(

--- a/backend/apps/finances/models/budget.py
+++ b/backend/apps/finances/models/budget.py
@@ -13,6 +13,7 @@ from django.core.validators import MinValueValidator
 from django.db import models
 
 from apps.core.mixins import WeddingOwnedMixin
+from apps.finances.managers import BudgetManager
 from apps.tenants.models import TenantModel
 
 
@@ -31,6 +32,8 @@ class Budget(TenantModel, WeddingOwnedMixin):
        continua identificando o modelo como "pertencente a um casamento" e aplica
        automaticamente os filtros de Multitenancy (Segurança por Design).
     """
+
+    objects = BudgetManager()  # type: ignore[misc]
 
     wedding = models.OneToOneField(
         "weddings.Wedding",

--- a/backend/apps/finances/schemas.py
+++ b/backend/apps/finances/schemas.py
@@ -38,8 +38,9 @@ class BudgetOut(Schema):
     @staticmethod
     def resolve_total_overall_spent(obj: "Budget") -> Decimal:
         """Expõe o computed property ``Budget.total_overall_spent`` no payload JSON."""
-        if hasattr(obj, "_total_overall_spent"):
-            return obj._total_overall_spent
+        val = getattr(obj, "_total_overall_spent", None)
+        if val is not None:
+            return val
         return obj.total_overall_spent
 
 
@@ -77,8 +78,9 @@ class BudgetCategoryOut(Schema):
     @staticmethod
     def resolve_total_spent(obj: "BudgetCategory") -> Decimal:
         """Expõe o computed property ``BudgetCategory.total_spent`` no payload JSON."""
-        if hasattr(obj, "_total_spent"):
-            return obj._total_spent
+        val = getattr(obj, "_total_spent", None)
+        if val is not None:
+            return val
         return obj.total_spent
 
 
@@ -142,36 +144,36 @@ class ExpenseOut(Schema):
 
     @staticmethod
     def resolve_contract(obj: "Expense") -> UUID4 | None:
-        if obj.contract_id:
+        if obj.contract_id and obj.contract:
             return obj.contract.uuid
         return None
 
     @staticmethod
     def resolve_category_name(obj: "Expense") -> str:
-        if hasattr(obj, "category_name"):
-            return obj.category_name
-        return obj.category.name if hasattr(obj, "category") else ""
+        val = getattr(obj, "category_name", None)
+        if val is not None:
+            return str(val)
+        return obj.category.name
 
     @staticmethod
     def resolve_contract_description(obj: "Expense") -> str | None:
-        if hasattr(obj, "contract_description"):
-            return obj.contract_description
-        if obj.contract_id:
+        val = getattr(obj, "contract_description", None)
+        if val is not None:
+            return str(val)
+        if obj.contract_id and obj.contract:
             return obj.contract.description
         return None
 
     @staticmethod
     def resolve_status(obj: "Expense") -> str:
-        total = (
-            obj.installments_count
-            if hasattr(obj, "installments_count")
-            else obj.installments.count()
-        )
-        paid = (
-            obj.paid_installments_count
-            if hasattr(obj, "paid_installments_count")
-            else obj.installments.filter(status="PAID").count()
-        )
+        total = getattr(obj, "installments_count", None)
+        if total is None:
+            total = obj.installments.count()
+
+        paid = getattr(obj, "paid_installments_count", None)
+        if paid is None:
+            paid = obj.installments.filter(status="PAID").count()
+
         if total == 0:
             return "PENDING"
         if paid >= total:
@@ -182,14 +184,16 @@ class ExpenseOut(Schema):
 
     @staticmethod
     def resolve_installments_count(obj: "Expense") -> int:
-        if hasattr(obj, "installments_count"):
-            return obj.installments_count
+        val = getattr(obj, "installments_count", None)
+        if val is not None:
+            return int(val)
         return obj.installments.count()
 
     @staticmethod
     def resolve_paid_installments_count(obj: "Expense") -> int:
-        if hasattr(obj, "paid_installments_count"):
-            return obj.paid_installments_count
+        val = getattr(obj, "paid_installments_count", None)
+        if val is not None:
+            return int(val)
         return obj.installments.filter(status="PAID").count()
 
     @staticmethod

--- a/backend/apps/finances/schemas.py
+++ b/backend/apps/finances/schemas.py
@@ -27,20 +27,20 @@ class BudgetPatchIn(Schema):
 
 class BudgetOut(Schema):
     uuid: UUID4
-    wedding: UUID = Field(alias="wedding.uuid")
+    wedding: UUID4 = Field(alias="wedding.uuid")
     total_estimated: Decimal
     total_overall_spent: Decimal = Field(default=Decimal("0.00"))
     notes: str | None = None
 
     @staticmethod
-    def resolve_wedding(obj: "Budget") -> UUID:
+    def resolve_wedding(obj: "Budget") -> UUID4:
         return obj.wedding.uuid
 
     @staticmethod
     def resolve_total_overall_spent(obj: "Budget") -> Decimal:
         """Expõe o computed property ``Budget.total_overall_spent`` no payload JSON."""
-        if hasattr(obj, "annotated_total_overall_spent"):
-            return obj.annotated_total_overall_spent
+        if hasattr(obj, "_total_overall_spent"):
+            return obj._total_overall_spent
         return obj.total_overall_spent
 
 
@@ -60,26 +60,26 @@ class BudgetCategoryPatchIn(Schema):
 
 class BudgetCategoryOut(Schema):
     uuid: UUID4
-    wedding: UUID = Field(alias="wedding.uuid")
-    budget: UUID = Field(alias="budget.uuid")
+    wedding: UUID4 = Field(alias="wedding.uuid")
+    budget: UUID4 = Field(alias="budget.uuid")
     name: str
     description: str | None = None
     allocated_budget: Decimal
     total_spent: Decimal = Field(default=Decimal("0.00"))
 
     @staticmethod
-    def resolve_wedding(obj: "BudgetCategory") -> UUID:
+    def resolve_wedding(obj: "BudgetCategory") -> UUID4:
         return obj.wedding.uuid
 
     @staticmethod
-    def resolve_budget(obj: "BudgetCategory") -> UUID:
+    def resolve_budget(obj: "BudgetCategory") -> UUID4:
         return obj.budget.uuid
 
     @staticmethod
     def resolve_total_spent(obj: "BudgetCategory") -> Decimal:
         """Expõe o computed property ``BudgetCategory.total_spent`` no payload JSON."""
-        if hasattr(obj, "annotated_total_spent"):
-            return obj.annotated_total_spent
+        if hasattr(obj, "_total_spent"):
+            return obj._total_spent
         return obj.total_spent
 
 
@@ -117,16 +117,16 @@ class ExpenseFromDocumentOut(Schema):
 
 class ExpenseOut(Schema):
     uuid: UUID4
-    wedding: UUID = Field(alias="wedding.uuid")
-    category: UUID = Field(alias="category.uuid")
-    contract: UUID | None = None
+    wedding: UUID4 = Field(alias="wedding.uuid")
+    category: UUID4 = Field(alias="category.uuid")
+    contract: UUID4 | None = None
 
     @staticmethod
-    def resolve_wedding(obj: "Expense") -> UUID:
+    def resolve_wedding(obj: "Expense") -> UUID4:
         return obj.wedding.uuid
 
     @staticmethod
-    def resolve_category(obj: "Expense") -> UUID:
+    def resolve_category(obj: "Expense") -> UUID4:
         return obj.category.uuid
     name: str
     description: str = ""
@@ -141,7 +141,7 @@ class ExpenseOut(Schema):
     total_pending: Decimal = Decimal("0.00")
 
     @staticmethod
-    def resolve_contract(obj: "Expense") -> UUID | None:
+    def resolve_contract(obj: "Expense") -> UUID4 | None:
         if obj.contract_id:
             return obj.contract.uuid
         return None

--- a/backend/apps/finances/schemas.py
+++ b/backend/apps/finances/schemas.py
@@ -1,6 +1,7 @@
 from datetime import date
 from decimal import Decimal
 from typing import TYPE_CHECKING
+from uuid import UUID
 
 from ninja import Schema
 from pydantic import UUID4, Field
@@ -26,14 +27,20 @@ class BudgetPatchIn(Schema):
 
 class BudgetOut(Schema):
     uuid: UUID4
-    wedding: UUID4 = Field(alias="wedding.uuid")
+    wedding: UUID = Field(alias="wedding.uuid")
     total_estimated: Decimal
     total_overall_spent: Decimal = Field(default=Decimal("0.00"))
     notes: str | None = None
 
     @staticmethod
+    def resolve_wedding(obj: "Budget") -> UUID:
+        return obj.wedding.uuid
+
+    @staticmethod
     def resolve_total_overall_spent(obj: "Budget") -> Decimal:
         """Expõe o computed property ``Budget.total_overall_spent`` no payload JSON."""
+        if hasattr(obj, "annotated_total_overall_spent"):
+            return obj.annotated_total_overall_spent
         return obj.total_overall_spent
 
 
@@ -53,18 +60,26 @@ class BudgetCategoryPatchIn(Schema):
 
 class BudgetCategoryOut(Schema):
     uuid: UUID4
-    wedding: UUID4 = Field(
-        alias="wedding.uuid"
-    )  # Read-Only logic keeps it in the output
-    budget: UUID4 = Field(alias="budget.uuid")
+    wedding: UUID = Field(alias="wedding.uuid")
+    budget: UUID = Field(alias="budget.uuid")
     name: str
     description: str | None = None
     allocated_budget: Decimal
     total_spent: Decimal = Field(default=Decimal("0.00"))
 
     @staticmethod
+    def resolve_wedding(obj: "BudgetCategory") -> UUID:
+        return obj.wedding.uuid
+
+    @staticmethod
+    def resolve_budget(obj: "BudgetCategory") -> UUID:
+        return obj.budget.uuid
+
+    @staticmethod
     def resolve_total_spent(obj: "BudgetCategory") -> Decimal:
         """Expõe o computed property ``BudgetCategory.total_spent`` no payload JSON."""
+        if hasattr(obj, "annotated_total_spent"):
+            return obj.annotated_total_spent
         return obj.total_spent
 
 
@@ -102,9 +117,17 @@ class ExpenseFromDocumentOut(Schema):
 
 class ExpenseOut(Schema):
     uuid: UUID4
-    wedding: UUID4 = Field(alias="wedding.uuid")
-    category: UUID4 = Field(alias="category.uuid")
-    contract: UUID4 | None = None
+    wedding: UUID = Field(alias="wedding.uuid")
+    category: UUID = Field(alias="category.uuid")
+    contract: UUID | None = None
+
+    @staticmethod
+    def resolve_wedding(obj: "Expense") -> UUID:
+        return obj.wedding.uuid
+
+    @staticmethod
+    def resolve_category(obj: "Expense") -> UUID:
+        return obj.category.uuid
     name: str
     description: str = ""
     estimated_amount: Decimal
@@ -118,27 +141,36 @@ class ExpenseOut(Schema):
     total_pending: Decimal = Decimal("0.00")
 
     @staticmethod
-    def resolve_contract(obj: "Expense") -> UUID4 | None:
-        c = obj.contract
-        return c.uuid if c else None
+    def resolve_contract(obj: "Expense") -> UUID | None:
+        if obj.contract_id:
+            return obj.contract.uuid
+        return None
 
     @staticmethod
     def resolve_category_name(obj: "Expense") -> str:
-        return getattr(obj, "category_name", obj.category.name)
+        if hasattr(obj, "category_name"):
+            return obj.category_name
+        return obj.category.name if hasattr(obj, "category") else ""
 
     @staticmethod
     def resolve_contract_description(obj: "Expense") -> str | None:
-        if obj.contract:
-            return getattr(obj, "contract_description", obj.contract.description)
+        if hasattr(obj, "contract_description"):
+            return obj.contract_description
+        if obj.contract_id:
+            return obj.contract.description
         return None
 
     @staticmethod
     def resolve_status(obj: "Expense") -> str:
-        total = getattr(obj, "installments_count", obj.installments.count())
-        paid = getattr(
-            obj,
-            "paid_installments_count",
-            obj.installments.filter(status="PAID").count(),
+        total = (
+            obj.installments_count
+            if hasattr(obj, "installments_count")
+            else obj.installments.count()
+        )
+        paid = (
+            obj.paid_installments_count
+            if hasattr(obj, "paid_installments_count")
+            else obj.installments.filter(status="PAID").count()
         )
         if total == 0:
             return "PENDING"
@@ -150,15 +182,15 @@ class ExpenseOut(Schema):
 
     @staticmethod
     def resolve_installments_count(obj: "Expense") -> int:
-        return getattr(obj, "installments_count", obj.installments.count())
+        if hasattr(obj, "installments_count"):
+            return obj.installments_count
+        return obj.installments.count()
 
     @staticmethod
     def resolve_paid_installments_count(obj: "Expense") -> int:
-        return getattr(
-            obj,
-            "paid_installments_count",
-            obj.installments.filter(status="PAID").count(),
-        )
+        if hasattr(obj, "paid_installments_count"):
+            return obj.paid_installments_count
+        return obj.installments.filter(status="PAID").count()
 
     @staticmethod
     def resolve_total_paid(obj: "Expense") -> Decimal:

--- a/backend/apps/finances/schemas.py
+++ b/backend/apps/finances/schemas.py
@@ -1,7 +1,6 @@
 from datetime import date
 from decimal import Decimal
 from typing import TYPE_CHECKING
-from uuid import UUID
 
 from ninja import Schema
 from pydantic import UUID4, Field
@@ -128,6 +127,7 @@ class ExpenseOut(Schema):
     @staticmethod
     def resolve_category(obj: "Expense") -> UUID4:
         return obj.category.uuid
+
     name: str
     description: str = ""
     estimated_amount: Decimal

--- a/backend/apps/finances/services/budget_category_service.py
+++ b/backend/apps/finances/services/budget_category_service.py
@@ -1,5 +1,6 @@
 import logging
 from decimal import Decimal
+from typing import cast
 from uuid import UUID
 
 from django.db import transaction
@@ -11,6 +12,7 @@ from apps.core.exceptions import (
 )
 from apps.core.shortcuts import get_object_or_404_for_tenant
 from apps.core.tenant import validate_tenant_ownership
+from apps.finances.managers import BudgetCategoryQuerySet
 from apps.finances.models import Budget, BudgetCategory
 from apps.finances.schemas import BudgetCategoryIn, BudgetCategoryPatchIn
 from apps.tenants.models import Company
@@ -61,7 +63,7 @@ class BudgetCategoryService:
         Lista categorias de orçamento de uma empresa.
         """
         qs = (
-            BudgetCategory.objects.for_tenant(company)
+            cast(BudgetCategoryQuerySet, BudgetCategory.objects.for_tenant(company))
             .with_total_spent()
             .select_related("budget", "wedding")
         )
@@ -77,7 +79,7 @@ class BudgetCategoryService:
 
         try:
             return (
-                BudgetCategory.objects.for_tenant(company)
+                cast(BudgetCategoryQuerySet, BudgetCategory.objects.for_tenant(company))
                 .with_total_spent()
                 .select_related("budget", "wedding")
                 .get(uuid=uuid)

--- a/backend/apps/finances/services/budget_category_service.py
+++ b/backend/apps/finances/services/budget_category_service.py
@@ -60,8 +60,10 @@ class BudgetCategoryService:
         """
         Lista categorias de orçamento de uma empresa.
         """
-        qs = BudgetCategory.objects.for_tenant(company).select_related(
-            "budget", "wedding"
+        qs = (
+            BudgetCategory.objects.for_tenant(company)
+            .with_total_spent()
+            .select_related("budget", "wedding")
         )
         if wedding_id:
             qs = qs.filter(wedding__uuid=wedding_id)
@@ -69,13 +71,21 @@ class BudgetCategoryService:
 
     @staticmethod
     def get(company: Company, uuid: UUID | str) -> BudgetCategory:
-        return get_object_or_404_for_tenant(
-            BudgetCategory,
-            company,
-            uuid,
-            select_related=["budget", "wedding"],
-            detail="Categoria de orçamento não encontrada.",
-        )
+        from django.core.exceptions import ValidationError
+
+        from apps.core.exceptions import ObjectNotFoundError
+
+        try:
+            return (
+                BudgetCategory.objects.for_tenant(company)
+                .with_total_spent()
+                .select_related("budget", "wedding")
+                .get(uuid=uuid)
+            )
+        except (BudgetCategory.DoesNotExist, ValueError, ValidationError) as e:
+            raise ObjectNotFoundError(
+                detail="Categoria de orçamento não encontrada."
+            ) from e
 
     @staticmethod
     @transaction.atomic

--- a/backend/apps/finances/services/budget_service.py
+++ b/backend/apps/finances/services/budget_service.py
@@ -1,4 +1,5 @@
 import logging
+from typing import cast
 from uuid import UUID
 
 from django.core.exceptions import ValidationError
@@ -8,6 +9,7 @@ from django.db.models import ProtectedError, QuerySet
 from apps.core.exceptions import DomainIntegrityError
 from apps.core.shortcuts import get_object_or_404_for_tenant
 from apps.core.tenant import validate_tenant_ownership
+from apps.finances.managers import BudgetQuerySet
 from apps.finances.models import Budget
 from apps.finances.schemas import BudgetIn, BudgetPatchIn
 from apps.tenants.models import Company
@@ -26,7 +28,7 @@ class BudgetService:
     @staticmethod
     def list(company: Company) -> QuerySet[Budget]:
         return (
-            Budget.objects.for_tenant(company)
+            cast(BudgetQuerySet, Budget.objects.for_tenant(company))
             .with_total_spent()
             .select_related("wedding")
         )
@@ -35,7 +37,7 @@ class BudgetService:
     def get(company: Company, uuid: UUID | str) -> Budget:
         try:
             return (
-                Budget.objects.for_tenant(company)
+                cast(BudgetQuerySet, Budget.objects.for_tenant(company))
                 .with_total_spent()
                 .select_related("wedding")
                 .get(uuid=uuid)

--- a/backend/apps/finances/services/budget_service.py
+++ b/backend/apps/finances/services/budget_service.py
@@ -25,17 +25,27 @@ class BudgetService:
 
     @staticmethod
     def list(company: Company) -> QuerySet[Budget]:
-        return Budget.objects.for_tenant(company).select_related("wedding")
+        return (
+            Budget.objects.for_tenant(company)
+            .with_total_spent()
+            .select_related("wedding")
+        )
 
     @staticmethod
     def get(company: Company, uuid: UUID | str) -> Budget:
-        return get_object_or_404_for_tenant(
-            Budget,
-            company,
-            uuid,
-            select_related=["wedding"],
-            detail="Orçamento não encontrado ou acesso negado.",
-        )
+        try:
+            return (
+                Budget.objects.for_tenant(company)
+                .with_total_spent()
+                .select_related("wedding")
+                .get(uuid=uuid)
+            )
+        except (Budget.DoesNotExist, ValueError, ValidationError) as e:
+            from apps.core.exceptions import ObjectNotFoundError
+
+            raise ObjectNotFoundError(
+                detail="Orçamento não encontrado ou acesso negado."
+            ) from e
 
     @staticmethod
     @transaction.atomic

--- a/backend/apps/finances/tests/test_performance.py
+++ b/backend/apps/finances/tests/test_performance.py
@@ -1,13 +1,22 @@
-import pytest
-from uuid import UUID
 from decimal import Decimal
-from django.test.utils import CaptureQueriesContext
+from uuid import UUID
+
+import pytest
 from django.db import connection
-from apps.finances.models import Expense, Budget, BudgetCategory, Installment
-from apps.finances.schemas import ExpenseOut, BudgetOut, BudgetCategoryOut
-from apps.finances.tests.factories import ExpenseFactory, InstallmentFactory, BudgetCategoryFactory, BudgetFactory
+from django.test.utils import CaptureQueriesContext
+from django.utils import timezone
+
+from apps.finances.models import Budget, BudgetCategory, Expense, Installment
+from apps.finances.schemas import BudgetCategoryOut, BudgetOut, ExpenseOut
+from apps.finances.tests.factories import (
+    BudgetCategoryFactory,
+    BudgetFactory,
+    ExpenseFactory,
+    InstallmentFactory,
+)
 from apps.tenants.models import Company
 from apps.weddings.tests.factories import WeddingFactory
+
 
 @pytest.mark.django_db
 def test_benchmark_n_plus_one_resolved():
@@ -18,13 +27,19 @@ def test_benchmark_n_plus_one_resolved():
     wedding = WeddingFactory(company=company)
     budget = BudgetFactory(wedding=wedding, company=company)
 
-    categories = BudgetCategoryFactory.create_batch(5, budget=budget, wedding=wedding, company=company)
+    categories = BudgetCategoryFactory.create_batch(
+        5, budget=budget, wedding=wedding, company=company
+    )
 
     # Criar 10 despesas, cada uma com 3 parcelas (2 pagas)
     expenses = []
-    from django.utils import timezone
     for i in range(10):
-        exp = ExpenseFactory(wedding=wedding, company=company, category=categories[i % 5], actual_amount=Decimal("300.00"))
+        exp = ExpenseFactory(
+            wedding=wedding,
+            company=company,
+            category=categories[i % 5],
+            actual_amount=Decimal("300.00"),
+        )
         # Force create installments
         exp.installments.all().delete()
         InstallmentFactory.create_batch(
@@ -32,18 +47,28 @@ def test_benchmark_n_plus_one_resolved():
             expense=exp,
             status=Installment.StatusChoices.PAID,
             amount=Decimal("100.00"),
-            paid_date=timezone.now().date()
+            paid_date=timezone.now().date(),
         )
-        InstallmentFactory.create_batch(1, expense=exp, status=Installment.StatusChoices.PENDING, amount=Decimal("100.00"))
+        InstallmentFactory.create_batch(
+            1,
+            expense=exp,
+            status=Installment.StatusChoices.PENDING,
+            amount=Decimal("100.00"),
+        )
         expenses.append(exp)
 
-    print(f"Dados criados: 1 Budget, {len(categories)} Categorias, {len(expenses)} Despesas.")
+    print(
+        f"Dados criados: 1 Budget, {len(categories)} Categorias, "
+        f"{len(expenses)} Despesas."
+    )
 
     # 2. Verificar ExpenseOut
     print("\n--- Verificando ExpenseOut ---")
 
     # Caso Otimizado: COM with_details()
-    expenses_optimized = Expense.objects.filter(id__in=[e.id for e in expenses]).with_details()
+    expenses_optimized = Expense.objects.filter(
+        id__in=[e.id for e in expenses]
+    ).with_details()
 
     with CaptureQueriesContext(connection) as ctx:
         list_optimized = list(expenses_optimized)
@@ -54,13 +79,22 @@ def test_benchmark_n_plus_one_resolved():
 
     total_queries = len(ctx)
     extra_queries = total_queries - queries_before_resolve
-    print(f"Queries para 10 ExpenseOut (COM with_details): {total_queries} (Sendo {extra_queries} extras)")
+    print(
+        f"Queries para 10 ExpenseOut (COM with_details): {total_queries} "
+        f"(Sendo {extra_queries} extras)"
+    )
 
-    assert extra_queries == 0, f"Deveria haver 0 queries extras, mas houve {extra_queries}!"
+    assert extra_queries == 0, (
+        f"Deveria haver 0 queries extras, mas houve {extra_queries}!"
+    )
 
     # 3. Verificar BudgetCategoryOut
     print("\n--- Verificando BudgetCategoryOut ---")
-    categories_optimized = BudgetCategory.objects.filter(id__in=[c.id for c in categories]).with_total_spent().select_related("wedding", "budget")
+    categories_optimized = (
+        BudgetCategory.objects.filter(id__in=[c.id for c in categories])
+        .with_total_spent()
+        .select_related("wedding", "budget")
+    )
 
     with CaptureQueriesContext(connection) as ctx:
         list_cats = list(categories_optimized)
@@ -68,30 +102,38 @@ def test_benchmark_n_plus_one_resolved():
         for cat in list_cats:
             print(f"Resolvendo categoria: {cat.name}")
             BudgetCategoryOut.from_orm(cat)
-        for query in ctx.captured_queries[queries_before_resolve:]:
-            print(f"QUERY EXTRA: {query['sql']}")
 
     extra_queries_cat = len(ctx) - queries_before_resolve
-    print(f"Queries para {len(categories)} Categorias (COM with_total_spent): {len(ctx)} (Sendo {extra_queries_cat} extras)")
+    print(
+        f"Queries para {len(categories)} Categorias (COM with_total_spent): "
+        f"{len(ctx)} (Sendo {extra_queries_cat} extras)"
+    )
     assert extra_queries_cat == 0, "N+1 detectado em BudgetCategoryOut!"
 
     # 4. Verificar BudgetOut
     print("\n--- Verificando BudgetOut ---")
-    budget_optimized = Budget.objects.filter(id=budget.id).with_total_spent().select_related("wedding")
+    budget_optimized = (
+        Budget.objects.filter(id=budget.id).with_total_spent().select_related("wedding")
+    )
 
     with CaptureQueriesContext(connection) as ctx:
-        b_inst = list(budget_optimized)[0]
+        b_inst = next(iter(budget_optimized))
         queries_before_resolve = len(ctx)
         BudgetOut.from_orm(b_inst)
 
     extra_queries_budget = len(ctx) - queries_before_resolve
-    print(f"Queries para 1 Budget (COM with_total_spent): {len(ctx)} (Sendo {extra_queries_budget} extras)")
+    print(
+        f"Queries para 1 Budget (COM with_total_spent): {len(ctx)} "
+        f"(Sendo {extra_queries_budget} extras)"
+    )
     assert extra_queries_budget == 0, "N+1 detectado em BudgetOut!"
 
     # 5. Verificação de Integridade de Dados (UUIDs)
     print("\n--- Verificando Integridade de Dados (UUIDs) ---")
     expense_data = ExpenseOut.from_orm(expenses[0])
-    assert isinstance(expense_data.wedding, UUID), f"Wedding deve ser UUID, veio {type(expense_data.wedding)}"
+    assert isinstance(expense_data.wedding, UUID), (
+        f"Wedding deve ser UUID, veio {type(expense_data.wedding)}"
+    )
     assert expense_data.wedding == wedding.uuid
 
     if expenses[0].contract_id:

--- a/backend/apps/finances/tests/test_performance.py
+++ b/backend/apps/finances/tests/test_performance.py
@@ -1,0 +1,102 @@
+import pytest
+from uuid import UUID
+from decimal import Decimal
+from django.test.utils import CaptureQueriesContext
+from django.db import connection
+from apps.finances.models import Expense, Budget, BudgetCategory, Installment
+from apps.finances.schemas import ExpenseOut, BudgetOut, BudgetCategoryOut
+from apps.finances.tests.factories import ExpenseFactory, InstallmentFactory, BudgetCategoryFactory, BudgetFactory
+from apps.tenants.models import Company
+from apps.weddings.tests.factories import WeddingFactory
+
+@pytest.mark.django_db
+def test_benchmark_n_plus_one_resolved():
+    print("\n--- ⚡ Iniciando Benchmark de Performance (Verificação de Correção) ---")
+
+    # 1. Setup Data
+    company = Company.objects.create(name="Benchmarking Co", slug="benchmarking-co")
+    wedding = WeddingFactory(company=company)
+    budget = BudgetFactory(wedding=wedding, company=company)
+
+    categories = BudgetCategoryFactory.create_batch(5, budget=budget, wedding=wedding, company=company)
+
+    # Criar 10 despesas, cada uma com 3 parcelas (2 pagas)
+    expenses = []
+    from django.utils import timezone
+    for i in range(10):
+        exp = ExpenseFactory(wedding=wedding, company=company, category=categories[i % 5], actual_amount=Decimal("300.00"))
+        # Force create installments
+        exp.installments.all().delete()
+        InstallmentFactory.create_batch(
+            2,
+            expense=exp,
+            status=Installment.StatusChoices.PAID,
+            amount=Decimal("100.00"),
+            paid_date=timezone.now().date()
+        )
+        InstallmentFactory.create_batch(1, expense=exp, status=Installment.StatusChoices.PENDING, amount=Decimal("100.00"))
+        expenses.append(exp)
+
+    print(f"Dados criados: 1 Budget, {len(categories)} Categorias, {len(expenses)} Despesas.")
+
+    # 2. Verificar ExpenseOut
+    print("\n--- Verificando ExpenseOut ---")
+
+    # Caso Otimizado: COM with_details()
+    expenses_optimized = Expense.objects.filter(id__in=[e.id for e in expenses]).with_details()
+
+    with CaptureQueriesContext(connection) as ctx:
+        list_optimized = list(expenses_optimized)
+        queries_before_resolve = len(ctx)
+
+        for exp in list_optimized:
+            ExpenseOut.from_orm(exp)
+
+    total_queries = len(ctx)
+    extra_queries = total_queries - queries_before_resolve
+    print(f"Queries para 10 ExpenseOut (COM with_details): {total_queries} (Sendo {extra_queries} extras)")
+
+    assert extra_queries == 0, f"Deveria haver 0 queries extras, mas houve {extra_queries}!"
+
+    # 3. Verificar BudgetCategoryOut
+    print("\n--- Verificando BudgetCategoryOut ---")
+    categories_optimized = BudgetCategory.objects.filter(id__in=[c.id for c in categories]).with_total_spent().select_related("wedding", "budget")
+
+    with CaptureQueriesContext(connection) as ctx:
+        list_cats = list(categories_optimized)
+        queries_before_resolve = len(ctx)
+        for cat in list_cats:
+            print(f"Resolvendo categoria: {cat.name}")
+            BudgetCategoryOut.from_orm(cat)
+        for query in ctx.captured_queries[queries_before_resolve:]:
+            print(f"QUERY EXTRA: {query['sql']}")
+
+    extra_queries_cat = len(ctx) - queries_before_resolve
+    print(f"Queries para {len(categories)} Categorias (COM with_total_spent): {len(ctx)} (Sendo {extra_queries_cat} extras)")
+    assert extra_queries_cat == 0, "N+1 detectado em BudgetCategoryOut!"
+
+    # 4. Verificar BudgetOut
+    print("\n--- Verificando BudgetOut ---")
+    budget_optimized = Budget.objects.filter(id=budget.id).with_total_spent().select_related("wedding")
+
+    with CaptureQueriesContext(connection) as ctx:
+        b_inst = list(budget_optimized)[0]
+        queries_before_resolve = len(ctx)
+        BudgetOut.from_orm(b_inst)
+
+    extra_queries_budget = len(ctx) - queries_before_resolve
+    print(f"Queries para 1 Budget (COM with_total_spent): {len(ctx)} (Sendo {extra_queries_budget} extras)")
+    assert extra_queries_budget == 0, "N+1 detectado em BudgetOut!"
+
+    # 5. Verificação de Integridade de Dados (UUIDs)
+    print("\n--- Verificando Integridade de Dados (UUIDs) ---")
+    expense_data = ExpenseOut.from_orm(expenses[0])
+    assert isinstance(expense_data.wedding, UUID), f"Wedding deve ser UUID, veio {type(expense_data.wedding)}"
+    assert expense_data.wedding == wedding.uuid
+
+    if expenses[0].contract_id:
+        assert isinstance(expense_data.contract, UUID)
+
+    print("✅ Integridade de dados (UUIDs) confirmada!")
+
+    print("\n--- Verificação Finalizada com Sucesso! ---")


### PR DESCRIPTION
Otimização dos resolvers de schema no módulo de finanças para eliminar consultas N+1 ao banco de dados. 

As principais mudanças incluem:
1. Substituição de `getattr(obj, 'attr', query.count())` por lógica preguiçosa (`hasattr`) para evitar execução imediata de queries de fallback.
2. Implementação e uso de métodos de anotação nos QuerySets de `Budget`, `BudgetCategory` e `Expense` para pré-calcular totais e contagens.
3. Garantia de que os UUIDs públicos sejam retornados sem disparar novas consultas ao banco de dados através do uso correto de `select_related`.
4. Adição de um teste de performance (`test_performance.py`) para servir como trava de segurança contra regressões de N+1.

---
*PR created automatically by Jules for task [8920292073422206894](https://jules.google.com/task/8920292073422206894) started by @Rafaelp122*