### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix weak password validation in registration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Validação de Complexidade de Senha no Registro
+**Vulnerability:** Usuários podiam registrar contas com senhas extremamente fracas (ex: "12345678", "password"), apesar de o Django possuir validadores configurados em `AUTH_PASSWORD_VALIDATORS`.
+**Learning:** No Django Ninja (ou qualquer fluxo customizado), o método `create_user` ou `set_password` do `UserManager` padrão NÃO invoca automaticamente os validadores de complexidade do Django. A validação do Pydantic no Schema apenas checava o tamanho mínimo (`min_length=8`).
+**Prevention:** Sempre chamar explicitamente `django.contrib.auth.password_validation.validate_password(password)` na Service Layer antes de criar o usuário.

--- a/backend/apps/users/services/registration_service.py
+++ b/backend/apps/users/services/registration_service.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.contrib.auth.password_validation import validate_password
 from django.db import IntegrityError, transaction
 
 from apps.core.exceptions import DomainIntegrityError
@@ -33,7 +34,12 @@ class RegistrationService:
         """
         logger.info(f"Iniciando registro de novo proprietário: {email}")
 
-        # 1. Validação Preventiva
+        # 1. Validação de Senha (Segurança)
+        # O User.objects.create_user já chama validate_password?
+        # Não por padrão no Django, e queremos falhar cedo.
+        validate_password(password)
+
+        # 2. Validação Preventiva de E-mail
         if User.objects.filter(email=email).exists():
             raise DomainIntegrityError(
                 detail="Este e-mail já está cadastrado em outra conta.",

--- a/backend/apps/users/tests/test_password_security.py
+++ b/backend/apps/users/tests/test_password_security.py
@@ -1,0 +1,26 @@
+import pytest
+from django.core.exceptions import ValidationError
+
+from apps.users.services.registration_service import RegistrationService
+
+
+@pytest.mark.django_db
+class TestRegistrationPasswordSecurity:
+    """Testes de segurança para validação de senha no registro."""
+
+    def test_register_new_owner_with_weak_password_fails(self):
+        """
+        Garante que senhas fracas (comuns) são rejeitadas durante o registro.
+        """
+        email = "weak-password@example.com"
+        # 'password' deve ser bloqueada pelo CommonPasswordValidator
+        weak_password = "password"
+
+        # Este teste deve levantar ValidationError após a correção
+        with pytest.raises(ValidationError):
+            RegistrationService.register_new_owner(
+                email=email,
+                password=weak_password,
+                first_name="Weak",
+                last_name="Password"
+            )

--- a/backend/apps/users/tests/test_password_security.py
+++ b/backend/apps/users/tests/test_password_security.py
@@ -22,5 +22,5 @@ class TestRegistrationPasswordSecurity:
                 email=email,
                 password=weak_password,
                 first_name="Weak",
-                last_name="Password"
+                last_name="Password",
             )

--- a/backend/apps/users/tests/test_register_api_security.py
+++ b/backend/apps/users/tests/test_register_api_security.py
@@ -14,9 +14,9 @@ def test_register_user_weak_password_api_response(auth_client):
             "password": "password",
             "first_name": "Weak",
             "last_name": "API",
-            "company_name": "Test Co"
+            "company_name": "Test Co",
         },
-        content_type="application/json"
+        content_type="application/json",
     )
 
     assert response.status_code == 400

--- a/backend/apps/users/tests/test_register_api_security.py
+++ b/backend/apps/users/tests/test_register_api_security.py
@@ -1,0 +1,28 @@
+import pytest
+
+
+@pytest.mark.django_db
+def test_register_user_weak_password_api_response(auth_client):
+    """
+    Testa se o endpoint de registro retorna uma mensagem de erro amigável (400)
+    quando a validação de senha falha.
+    """
+    response = auth_client.post(
+        "/api/v1/auth/register/",
+        {
+            "email": "weak-api@example.com",
+            "password": "password",
+            "first_name": "Weak",
+            "last_name": "API",
+            "company_name": "Test Co"
+        },
+        content_type="application/json"
+    )
+
+    assert response.status_code == 400
+    data = response.json()
+    assert "detail" in data
+    assert "code" in data
+    assert data["code"] == "validation_error"
+    # A mensagem vem do CommonPasswordValidator do Django
+    assert "Esta senha é muito comum." in str(data["detail"])

--- a/backend/apps/users/tests/test_services.py
+++ b/backend/apps/users/tests/test_services.py
@@ -15,7 +15,7 @@ class TestRegistrationService:
     def test_register_new_owner_success(self):
         """Garante que um novo usuário e empresa são criados corretamente."""
         email = "novo@exemplo.com"
-        password = "password123"
+        password = "SecurePassword123!"
         first_name = "Novo"
         last_name = "Usuário"
 
@@ -63,7 +63,7 @@ class TestRegistrationService:
     def test_register_new_owner_with_company_name(self):
         """Garante que o nome da empresa é usado quando fornecido."""
         email = "agencia@exemplo.com"
-        password = "password123"
+        password = "SecurePassword123!"
         first_name = "Helena"
         last_name = "Costa"
         company_name = "Aura Eventos"


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Senhas fracas (comuns) eram permitidas no fluxo de registro de usuários.
🎯 Impact: Contas de usuários poderiam ser facilmente comprometidas via ataques de dicionário ou força bruta, ignorando as políticas de segurança `AUTH_PASSWORD_VALIDATORS` do Django.
🔧 Fix: Integração da função `validate_password()` do Django no `RegistrationService`. Isso garante que qualquer senha submetida passe pelos validadores de complexidade (senhas comuns, similaridade com atributos, etc) antes da criação da conta.
✅ Verification:
- `apps/users/tests/test_password_security.py`: Valida que o serviço lança `ValidationError` para senhas fracas.
- `apps/users/tests/test_register_api_security.py`: Valida que a API retorna `400 Bad Request` com o detalhe do erro amigável para o usuário.
- Atualização dos testes existentes para conformidade com a nova política de segurança.

---
*PR created automatically by Jules for task [2735418124871730863](https://jules.google.com/task/2735418124871730863) started by @Rafaelp122*