### PR TITLE
🧪 [test BudgetService.get error paths]

### DIFF
--- a/backend/apps/finances/tests/budgets/test_services.py
+++ b/backend/apps/finances/tests/budgets/test_services.py
@@ -187,7 +187,9 @@ class TestBudgetServiceCritical:
         with pytest.raises(ObjectNotFoundError) as exc_info:
             BudgetService.get(user.company, invalid_uuid)
 
-        assert "Orçamento não encontrado ou acesso negado." in str(exc_info.value.detail)
+        assert "Orçamento não encontrado ou acesso negado." in str(
+            exc_info.value.detail
+        )
 
     def test_get_budget_invalid_uuid_format(self, user):
         """get() lança ObjectNotFoundError para formato de UUID inválido."""
@@ -196,7 +198,9 @@ class TestBudgetServiceCritical:
         with pytest.raises(ObjectNotFoundError) as exc_info:
             BudgetService.get(user.company, invalid_format)
 
-        assert "Orçamento não encontrado ou acesso negado." in str(exc_info.value.detail)
+        assert "Orçamento não encontrado ou acesso negado." in str(
+            exc_info.value.detail
+        )
 
     def test_list_budgets_multi_tenancy(self):
         """

--- a/backend/apps/finances/tests/budgets/test_services.py
+++ b/backend/apps/finances/tests/budgets/test_services.py
@@ -10,6 +10,7 @@ Estes testes cobrem as áreas de maior risco identificadas na análise:
 
 from decimal import Decimal
 from unittest.mock import patch
+from uuid import uuid4
 
 import pytest
 
@@ -178,6 +179,24 @@ class TestBudgetServiceCritical:
             BudgetService.get(user_b.company, budget_a.uuid)
 
         assert "Orçamento não encontrado" in str(exc_info.value.detail)
+
+    def test_get_budget_not_found(self, user):
+        """get() lança ObjectNotFoundError para UUID inexistente."""
+        invalid_uuid = uuid4()
+
+        with pytest.raises(ObjectNotFoundError) as exc_info:
+            BudgetService.get(user.company, invalid_uuid)
+
+        assert "Orçamento não encontrado ou acesso negado." in str(exc_info.value.detail)
+
+    def test_get_budget_invalid_uuid_format(self, user):
+        """get() lança ObjectNotFoundError para formato de UUID inválido."""
+        invalid_format = "not-a-uuid"
+
+        with pytest.raises(ObjectNotFoundError) as exc_info:
+            BudgetService.get(user.company, invalid_format)
+
+        assert "Orçamento não encontrado ou acesso negado." in str(exc_info.value.detail)
 
     def test_list_budgets_multi_tenancy(self):
         """


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Implementação de testes para caminhos de erro no método `get` do `BudgetService`, que anteriormente não possuíam cobertura explícita.

📊 **Coverage:** What scenarios are now tested
- Tentativa de buscar um orçamento com um UUID que não existe no banco de dados (`test_get_budget_not_found`).
- Tentativa de buscar um orçamento fornecendo uma string em formato inválido para UUID (`test_get_budget_invalid_uuid_format`).

✨ **Result:** The improvement in test coverage
Garantia de que a camada de serviço captura corretamente exceções do Django (`DoesNotExist`, `ValidationError`, `ValueError`) e as mapeia para a exceção de domínio `ObjectNotFoundError`, evitando erros 500 inesperados na API e melhorando a robustez do sistema.

---
*PR created automatically by Jules for task [15492377634881942570](https://jules.google.com/task/15492377634881942570) started by @Rafaelp122*