### PR TITLE
🎨 Palette: Improve PasswordInput accessibility and UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-05-15 - [Acessibilidade em Inputs de Senha]
 **Learning:** Elementos interativos apenas com ícones (como o alternador de visibilidade de senha) frequentemente são ignorados na acessibilidade. A remoção de `tabIndex={-1}` aliada a `aria-label` dinâmicos e Tooltips é essencial para garantir que usuários de teclado e leitores de tela tenham a mesma experiência. Além disso, o `TooltipProvider` deve estar no nível global (App e TestUtils) para evitar erros de contexto do Radix UI.
 **Action:** Sempre que adicionar um botão de ícone, verificar se ele possui `aria-label`, se é focável via teclado e se possui uma dica visual (Tooltip).
+
+## 2025-05-15 - [Padronização de Props em Componentes de UI]
+**Learning:** Ao criar componentes que envolvem elementos nativos do HTML (como inputs), deve-se sempre estender `React.ComponentPropsWithoutRef<"elemento">` em vez de criar uma interface manual limitada. Isso garante que o componente suporte todas as props padrão (id, name, value, handlers, etc.) e siga as convenções do ecossistema React.
+**Action:** Usar `extends React.ComponentPropsWithoutRef<...>` em componentes base de UI.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - [Acessibilidade em Inputs de Senha]
+**Learning:** Elementos interativos apenas com ícones (como o alternador de visibilidade de senha) frequentemente são ignorados na acessibilidade. A remoção de `tabIndex={-1}` aliada a `aria-label` dinâmicos e Tooltips é essencial para garantir que usuários de teclado e leitores de tela tenham a mesma experiência. Além disso, o `TooltipProvider` deve estar no nível global (App e TestUtils) para evitar erros de contexto do Radix UI.
+**Action:** Sempre que adicionar um botão de ícone, verificar se ele possui `aria-label`, se é focável via teclado e se possui uma dica visual (Tooltip).

--- a/frontend/src/features/auth/components/PasswordInput.test.tsx
+++ b/frontend/src/features/auth/components/PasswordInput.test.tsx
@@ -18,10 +18,13 @@ describe("PasswordInput", () => {
     const input = screen.getByPlaceholderText("Digite a senha");
     expect(input).toHaveAttribute("type", "password");
 
-    const toggleBtn = screen.getByRole("button");
+    const toggleBtn = screen.getByRole("button", { name: /mostrar senha/i });
+    expect(toggleBtn).toBeInTheDocument();
+
     await user.click(toggleBtn);
 
     expect(input).toHaveAttribute("type", "text");
+    expect(toggleBtn).toHaveAttribute("aria-label", "Ocultar senha");
   });
 
   it("toggles back to password on second click", async () => {
@@ -29,13 +32,15 @@ describe("PasswordInput", () => {
     render(<PasswordInput id="test-pw" placeholder="Digite a senha" />);
 
     const input = screen.getByPlaceholderText("Digite a senha");
-    const toggleBtn = screen.getByRole("button");
+    const toggleBtn = screen.getByRole("button", { name: /mostrar senha/i });
 
     await user.click(toggleBtn);
     expect(input).toHaveAttribute("type", "text");
+    expect(toggleBtn).toHaveAttribute("aria-label", "Ocultar senha");
 
     await user.click(toggleBtn);
     expect(input).toHaveAttribute("type", "password");
+    expect(toggleBtn).toHaveAttribute("aria-label", "Mostrar senha");
   });
 
   it("accepts value and onChange props", async () => {
@@ -46,5 +51,19 @@ describe("PasswordInput", () => {
     await user.type(input, "mypassword");
 
     expect(input).toHaveValue("mypassword");
+  });
+
+  it("is keyboard accessible", async () => {
+    const user = userEvent.setup();
+    render(<PasswordInput id="test-pw" placeholder="Digite a senha" />);
+
+    const input = screen.getByPlaceholderText("Digite a senha");
+    const toggleBtn = screen.getByRole("button", { name: /mostrar senha/i });
+
+    await user.tab();
+    expect(input).toHaveFocus();
+
+    await user.tab();
+    expect(toggleBtn).toHaveFocus();
   });
 });

--- a/frontend/src/features/auth/components/PasswordInput.tsx
+++ b/frontend/src/features/auth/components/PasswordInput.tsx
@@ -1,6 +1,11 @@
 import { Eye, EyeOff } from "lucide-react";
 import { forwardRef, useState } from "react";
 import { Input } from "@/components/ui/input";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface PasswordInputProps {
   id?: string;
@@ -26,18 +31,25 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
           placeholder={placeholder}
           {...props}
         />
-        <button
-          type="button"
-          onClick={() => setVisible(!visible)}
-          className="absolute right-3.5 top-1/2 -translate-y-1/2 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-200 transition-colors"
-          tabIndex={-1}
-        >
-          {visible ? (
-            <EyeOff className="w-4 h-4" />
-          ) : (
-            <Eye className="w-4 h-4" />
-          )}
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={() => setVisible(!visible)}
+              className="absolute right-3 top-1/2 -translate-y-1/2 h-7 w-7 flex items-center justify-center text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-200 transition-colors focus-visible:ring-2 focus-visible:ring-aura-500 outline-none rounded-sm"
+              aria-label={visible ? "Ocultar senha" : "Mostrar senha"}
+            >
+              {visible ? (
+                <EyeOff className="w-4 h-4" />
+              ) : (
+                <Eye className="w-4 h-4" />
+              )}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top" align="center">
+            {visible ? "Ocultar senha" : "Mostrar senha"}
+          </TooltipContent>
+        </Tooltip>
       </div>
     );
   },

--- a/frontend/src/features/auth/components/PasswordInput.tsx
+++ b/frontend/src/features/auth/components/PasswordInput.tsx
@@ -7,15 +7,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 
-interface PasswordInputProps {
-  id?: string;
-  placeholder: string;
-  className?: string;
-  value?: string;
-  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
-  name?: string;
-}
+interface PasswordInputProps extends React.ComponentPropsWithoutRef<"input"> {}
 
 export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
   function PasswordInput({ id, placeholder, className = "", ...props }, ref) {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -16,6 +16,7 @@ import { ThemeProvider } from "next-themes";
 import { getApiErrorInfo } from "@/api/error-utils";
 import { router } from "./router"; // Importando sua nova configuração
 import { Toaster } from "@/components/ui/sonner";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import "./index.css";
 
 const queryClient = new QueryClient({
@@ -58,9 +59,11 @@ ReactDOM.createRoot(document.getElementById("root")!, {
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
       <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-        <RouterProvider router={router} />
-        <Toaster />
-        <ReactQueryDevtools initialIsOpen={false} />
+        <TooltipProvider>
+          <RouterProvider router={router} />
+          <Toaster />
+          <ReactQueryDevtools initialIsOpen={false} />
+        </TooltipProvider>
       </ThemeProvider>
     </QueryClientProvider>
   </React.StrictMode>,

--- a/frontend/src/test-utils/index.tsx
+++ b/frontend/src/test-utils/index.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from "next-themes";
 import type { ReactElement, ReactNode } from "react";
 import { createMemoryRouter, RouterProvider } from "react-router-dom";
 import { Toaster } from "@/components/ui/sonner";
+import { TooltipProvider } from "@/components/ui/tooltip";
 
 function createTestQueryClient() {
   return new QueryClient({
@@ -36,8 +37,10 @@ function createWrapper(options: WrapperOptions = {}) {
     return (
       <QueryClientProvider client={queryClient}>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-          <RouterProvider router={router} />
-          <Toaster />
+          <TooltipProvider>
+            <RouterProvider router={router} />
+            <Toaster />
+          </TooltipProvider>
         </ThemeProvider>
       </QueryClientProvider>
     );


### PR DESCRIPTION
This micro-UX improvement focuses on the accessibility and usability of the `PasswordInput` component.

Key changes:
- **Accessibility**: Removed `tabIndex={-1}` from the visibility toggle button, making it keyboard-accessible. Added dynamic `aria-label` ("Mostrar senha" / "Ocultar senha") to support screen readers.
- **Visual Feedback**: Wrapped the toggle button in a `Tooltip` to provide clear visual cues. Added explicit focus-visible styles (`focus-visible:ring-2`) to ensure users navigating by keyboard have a clear focus indicator.
- **Infrastructure**: Added `TooltipProvider` to `frontend/src/main.tsx` and `frontend/src/test-utils/index.tsx` to ensure global support for Tooltips across the application and in test environments.
- **Verification**: Updated `PasswordInput.test.tsx` to assert new accessibility features and verified the changes visually using Playwright screenshots and video.

---
*PR created automatically by Jules for task [9966641093978027759](https://jules.google.com/task/9966641093978027759) started by @Rafaelp122*