### PR TITLE
🛡️ Sentinel: Implement rate limiting for auth endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,4 @@
-## 2025-05-15 - Validação de Complexidade de Senha no Registro
-**Vulnerability:** Usuários podiam registrar contas com senhas extremamente fracas (ex: "12345678", "password"), apesar de o Django possuir validadores configurados em `AUTH_PASSWORD_VALIDATORS`.
-**Learning:** No Django Ninja (ou qualquer fluxo customizado), o método `create_user` ou `set_password` do `UserManager` padrão NÃO invoca automaticamente os validadores de complexidade do Django. A validação do Pydantic no Schema apenas checava o tamanho mínimo (`min_length=8`).
-**Prevention:** Sempre chamar explicitamente `django.contrib.auth.password_validation.validate_password(password)` na Service Layer antes de criar o usuário.
+## 2026-04-04 - Ninja Extra Throttling Rate Format
+**Vulnerability:** N/A (Security Enhancement)
+**Learning:** Ao implementar throttling com `django-ninja-extra`, descobri que o parser de `RateThrottle` espera abreviações de uma única letra para unidades de tempo ('s', 'm', 'h', 'd'). O uso de palavras completas como 'minute' ou 'day' resulta em um `ValueError` durante a inicialização da API, impedindo que o servidor suba.
+**Prevention:** Sempre utilizar o formato abreviado nas configurações de `THROTTLE_RATES` (ex: '10/m' em vez de '10/minute').

--- a/backend/apps/users/api.py
+++ b/backend/apps/users/api.py
@@ -1,7 +1,8 @@
 from typing import Any
 
 from django.http import HttpRequest
-from ninja import Router
+from ninja_extra import Router
+from ninja_extra.throttling import AnonRateThrottle
 from ninja_jwt.schema import (
     TokenRefreshInputSchema,
     TokenRefreshOutputSchema,
@@ -19,11 +20,16 @@ from .services.token_service import TokenService
 router = Router(tags=["auth"])
 
 
+class AuthAnonRateThrottle(AnonRateThrottle):
+    scope = "auth_anon"
+
+
 @router.post(
     "/register/",
     response={201: UserOut, **MUTATION_ERROR_RESPONSES},
     auth=None,
     operation_id="auth_register_user",
+    throttle=[AuthAnonRateThrottle()],
 )
 def register_user(request: HttpRequest, payload: RegisterIn) -> tuple[int, Any]:
     """
@@ -44,6 +50,7 @@ def register_user(request: HttpRequest, payload: RegisterIn) -> tuple[int, Any]:
     response={200: TokenOut, 401: ErrorResponse, **MUTATION_ERROR_RESPONSES},
     auth=None,
     operation_id="auth_obtain_token",
+    throttle=[AuthAnonRateThrottle()],
 )
 def obtain_token(request: HttpRequest, payload: TokenPayloadIn) -> TokenOut:
     """
@@ -68,6 +75,7 @@ def obtain_token(request: HttpRequest, payload: TokenPayloadIn) -> TokenOut:
         **MUTATION_ERROR_RESPONSES,
     },
     operation_id="auth_refresh_token",
+    throttle=[AuthAnonRateThrottle()],
 )
 def refresh_token(
     request: HttpRequest, payload: TokenRefreshInputSchema
@@ -90,6 +98,7 @@ def refresh_token(
     },
     auth=None,
     operation_id="auth_verify_token",
+    throttle=[AuthAnonRateThrottle()],
 )
 def verify_token(
     request: HttpRequest, payload: TokenVerifyInputSchema

--- a/backend/apps/users/tests/test_throttling.py
+++ b/backend/apps/users/tests/test_throttling.py
@@ -1,18 +1,16 @@
 import pytest
 from django.test import Client
 
+
 @pytest.mark.django_db
 def test_auth_token_throttling():
     client = Client()
     url = "/api/v1/auth/token/"
-    payload = {
-        "email": "throttled@example.com",
-        "password": "password123"
-    }
+    payload = {"email": "throttled@example.com", "password": "password123"}
 
     # auth_anon rate is 10/minute.
     # Let's make 11 requests.
-    for i in range(10):
+    for _ in range(10):
         response = client.post(url, payload, content_type="application/json")
         # Credentials don't exist, so we expect 401, not 429 yet
         assert response.status_code == 401

--- a/backend/apps/users/tests/test_throttling.py
+++ b/backend/apps/users/tests/test_throttling.py
@@ -1,0 +1,23 @@
+import pytest
+from django.test import Client
+
+@pytest.mark.django_db
+def test_auth_token_throttling():
+    client = Client()
+    url = "/api/v1/auth/token/"
+    payload = {
+        "email": "throttled@example.com",
+        "password": "password123"
+    }
+
+    # auth_anon rate is 10/minute.
+    # Let's make 11 requests.
+    for i in range(10):
+        response = client.post(url, payload, content_type="application/json")
+        # Credentials don't exist, so we expect 401, not 429 yet
+        assert response.status_code == 401
+
+    # The 11th request should be throttled
+    response = client.post(url, payload, content_type="application/json")
+    assert response.status_code == 429
+    assert "Request was throttled" in response.json()["detail"]

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -143,3 +143,13 @@ MEDIA_URL = "/media/"
 MEDIA_ROOT = BASE_DIR / "media"
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+# Ninja Extra Throttling
+NINJA_EXTRA = {
+    "THROTTLE_RATES": {
+        "anon": "100/day",
+        "user": "1000/day",
+        "auth_anon": "10/m",
+        "auth_user": "20/m",
+    }
+}

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -4,6 +4,7 @@ Configuração Global de Testes (Pytest).
 
 import factory
 import pytest
+from django.core.cache import cache
 from django.test import Client
 from ninja_jwt.tokens import RefreshToken
 from pytest_factoryboy import register
@@ -48,6 +49,14 @@ class JWTClient(Client):
 def user(user_factory):
     """Cria e retorna um usuário ativo (Planner) para uso nos testes."""
     return user_factory.create(is_active=True)
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    """Limpa o cache do Django entre os testes para evitar falhas de throttling."""
+    cache.clear()
+    yield
+    cache.clear()
 
 
 @pytest.fixture


### PR DESCRIPTION
🛡️ **Sentinel: [High Priority] Implement Rate Limiting for Auth Endpoints**

🚨 **Severity:** HIGH
💡 **Vulnerability:** Lack of rate limiting on sensitive authentication endpoints (Login, Registration, Token Refresh/Verify).
🎯 **Impact:** Without rate limiting, the application is vulnerable to brute-force attacks and credential stuffing, which could lead to unauthorized account access.
🔧 **Fix:** 
- Integrated `django-ninja-extra` throttling.
- Defined specific rates for authentication (`auth_anon: 10/m`).
- Applied the `throttle` decorator to all endpoints in `apps.users.api`.
- Added a global `clear_cache` fixture in `conftest.py` to ensure test isolation.
✅ **Verification:**
- Created `backend/apps/users/tests/test_throttling.py` which confirms that the 11th request to `/auth/token/` within a minute returns a `429 Too Many Requests` status.
- Verified that the full backend test suite (629 tests) passes.

---
*PR created automatically by Jules for task [10453768409192132398](https://jules.google.com/task/10453768409192132398) started by @Rafaelp122*