### PR TITLE
🛡️ Sentinel: [HIGH] Fix brute-force vulnerability with API Throttling

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Usuários podiam registrar contas com senhas extremamente fracas (ex: "12345678", "password"), apesar de o Django possuir validadores configurados em `AUTH_PASSWORD_VALIDATORS`.
 **Learning:** No Django Ninja (ou qualquer fluxo customizado), o método `create_user` ou `set_password` do `UserManager` padrão NÃO invoca automaticamente os validadores de complexidade do Django. A validação do Pydantic no Schema apenas checava o tamanho mínimo (`min_length=8`).
 **Prevention:** Sempre chamar explicitamente `django.contrib.auth.password_validation.validate_password(password)` na Service Layer antes de criar o usuário.
+
+## 2025-05-22 - Throttling de API no Django Ninja Extra
+**Vulnerability:** Endpoints sensíveis (registro e login) estavam expostos a ataques de força bruta e enumeração de contas por falta de limitação de taxa (rate limiting).
+**Learning:** O `django-ninja` padrão não possui throttling embutido nos decorators. É necessário usar `ninja_extra.Router` e configurar `THROTTLE_RATES` no `settings.py`. Testes automatizados de endpoints com throttling falham se o cache não for limpo entre as execuções.
+**Prevention:** Utilizar `ninja_extra.Router` e o parâmetro `throttle` nos decorators de endpoints críticos. Adicionar um fixture `autouse` no `conftest.py` para limpar o cache durante os testes.

--- a/backend/apps/users/api.py
+++ b/backend/apps/users/api.py
@@ -1,7 +1,8 @@
 from typing import Any
 
 from django.http import HttpRequest
-from ninja import Router
+from ninja_extra import Router
+from ninja_extra.throttling import AnonRateThrottle
 from ninja_jwt.schema import (
     TokenRefreshInputSchema,
     TokenRefreshOutputSchema,
@@ -24,6 +25,7 @@ router = Router(tags=["auth"])
     response={201: UserOut, **MUTATION_ERROR_RESPONSES},
     auth=None,
     operation_id="auth_register_user",
+    throttle=[AnonRateThrottle()],
 )
 def register_user(request: HttpRequest, payload: RegisterIn) -> tuple[int, Any]:
     """
@@ -44,6 +46,7 @@ def register_user(request: HttpRequest, payload: RegisterIn) -> tuple[int, Any]:
     response={200: TokenOut, 401: ErrorResponse, **MUTATION_ERROR_RESPONSES},
     auth=None,
     operation_id="auth_obtain_token",
+    throttle=[AnonRateThrottle()],
 )
 def obtain_token(request: HttpRequest, payload: TokenPayloadIn) -> TokenOut:
     """

--- a/backend/apps/users/tests/test_throttling.py
+++ b/backend/apps/users/tests/test_throttling.py
@@ -1,0 +1,70 @@
+import pytest
+
+
+@pytest.mark.django_db
+class TestThrottling:
+    """
+    Testes para garantir que o rate limiting (throttling) está funcionando.
+    """
+
+    def test_register_throttling(self, client):
+        """
+        Garante que após 5 requisições de registro, a 6ª retorna 429.
+        """
+        payload = {
+            "email": "throttle-test@example.com",
+            "password": "valid_password_123",
+            "first_name": "Throttle",
+            "last_name": "Test",
+            "company_name": "Test Co",
+        }
+
+        # Realiza 5 requisições (limite configurado como 5/m)
+        for i in range(5):
+            response = client.post(
+                "/api/v1/auth/register/",
+                data={**payload, "email": f"user{i}@example.com"},
+                content_type="application/json"
+            )
+            assert response.status_code == 201
+
+        # A 6ª requisição deve falhar com 429
+        response = client.post(
+            "/api/v1/auth/register/",
+            data={**payload, "email": "user6@example.com"},
+            content_type="application/json"
+        )
+        assert response.status_code == 429
+        data = response.json()
+        assert "detail" in data
+        assert "Request was throttled" in data["detail"]
+
+    def test_obtain_token_throttling(self, client, user_factory):
+        """
+        Garante que após 5 requisições de login, a 6ª retorna 429.
+        """
+        user_factory.create(email="login-throttle@example.com", password="password123")
+        payload = {
+            "email": "login-throttle@example.com",
+            "password": "password123",
+        }
+
+        # Realiza 5 requisições
+        for _ in range(5):
+            response = client.post(
+                "/api/v1/auth/token/",
+                data=payload,
+                content_type="application/json"
+            )
+            assert response.status_code == 200
+
+        # A 6ª requisição deve falhar com 429
+        response = client.post(
+            "/api/v1/auth/token/",
+            data=payload,
+            content_type="application/json"
+        )
+        assert response.status_code == 429
+        data = response.json()
+        assert "detail" in data
+        assert "Request was throttled" in data["detail"]

--- a/backend/apps/users/tests/test_throttling.py
+++ b/backend/apps/users/tests/test_throttling.py
@@ -24,7 +24,7 @@ class TestThrottling:
             response = client.post(
                 "/api/v1/auth/register/",
                 data={**payload, "email": f"user{i}@example.com"},
-                content_type="application/json"
+                content_type="application/json",
             )
             assert response.status_code == 201
 
@@ -32,7 +32,7 @@ class TestThrottling:
         response = client.post(
             "/api/v1/auth/register/",
             data={**payload, "email": "user6@example.com"},
-            content_type="application/json"
+            content_type="application/json",
         )
         assert response.status_code == 429
         data = response.json()
@@ -52,17 +52,13 @@ class TestThrottling:
         # Realiza 5 requisições
         for _ in range(5):
             response = client.post(
-                "/api/v1/auth/token/",
-                data=payload,
-                content_type="application/json"
+                "/api/v1/auth/token/", data=payload, content_type="application/json"
             )
             assert response.status_code == 200
 
         # A 6ª requisição deve falhar com 429
         response = client.post(
-            "/api/v1/auth/token/",
-            data=payload,
-            content_type="application/json"
+            "/api/v1/auth/token/", data=payload, content_type="application/json"
         )
         assert response.status_code == 429
         data = response.json()

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -128,6 +128,13 @@ NINJA_JWT = {
     "USER_ID_CLAIM": "user_id",
 }
 
+NINJA_EXTRA = {
+    "THROTTLE_RATES": {
+        "user": "1000/d",
+        "anon": "5/m",
+    }
+}
+
 LANGUAGE_CODE = "pt-br"
 TIME_ZONE = "America/Sao_Paulo"
 USE_I18N = True

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -4,6 +4,7 @@ Configuração Global de Testes (Pytest).
 
 import factory
 import pytest
+from django.core.cache import cache
 from django.test import Client
 from ninja_jwt.tokens import RefreshToken
 from pytest_factoryboy import register
@@ -58,3 +59,12 @@ def auth_client(user):
     c = JWTClient(user=user)
     c.user = user
     return c
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    """
+    Limpa o cache do Django antes de cada teste.
+    Necessário para evitar que o throttling persista entre os testes.
+    """
+    cache.clear()


### PR DESCRIPTION
### 🛡️ Sentinel: [HIGH] Fix brute-force vulnerability with API Throttling

🚨 **Severity:** HIGH

💡 **Vulnerability:**
The authentication endpoints (`/api/v1/auth/register/` and `/api/v1/auth/token/`) lacked rate limiting (throttling), leaving the application vulnerable to brute-force attacks, automated account creation, and credential stuffing.

🎯 **Impact:**
An attacker could perform unlimited requests to guess passwords or flood the database with fake accounts, potentially leading to unauthorized access or service degradation.

🔧 **Fix:**
- Implemented API throttling using `django-ninja-extra`.
- Configured default rates in `backend/config/settings/base.py`:
  - `anon`: 5 requests per minute.
  - `user`: 1000 requests per day.
- Migrated `backend/apps/users/api.py` to use `ninja_extra.Router` (a compatible drop-in replacement that supports throttling).
- Applied `AnonRateThrottle` to the sensitive endpoints.
- Added a global `autouse` fixture in `backend/conftest.py` to clear the Django cache before every test, preventing rate-limit leakage between test cases.

✅ **Verification:**
- Created a new test suite `backend/apps/users/tests/test_throttling.py` specifically to verify that the 6th request within a minute returns a `429 Too Many Requests` status code.
- Ran all existing 695 backend tests to ensure no regressions.
- Verified that `ninja_extra` was already available in the environment (as a dependency of `ninja-jwt`).

---
*PR created automatically by Jules for task [7904600688904041953](https://jules.google.com/task/7904600688904041953) started by @Rafaelp122*