### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing rate limiting on auth endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Usuários podiam registrar contas com senhas extremamente fracas (ex: "12345678", "password"), apesar de o Django possuir validadores configurados em `AUTH_PASSWORD_VALIDATORS`.
 **Learning:** No Django Ninja (ou qualquer fluxo customizado), o método `create_user` ou `set_password` do `UserManager` padrão NÃO invoca automaticamente os validadores de complexidade do Django. A validação do Pydantic no Schema apenas checava o tamanho mínimo (`min_length=8`).
 **Prevention:** Sempre chamar explicitamente `django.contrib.auth.password_validation.validate_password(password)` na Service Layer antes de criar o usuário.
+
+## 2026-07-05 - Implementação de Throttling no Django Ninja Extra
+**Vulnerability:** Endpoints sensíveis de autenticação (registro, login) estavam expostos a ataques de força bruta e DoS por falta de limite de taxa (rate limiting).
+**Learning:** Para implementar throttling no Django Ninja Extra, é obrigatório: 1) Usar `ninja_extra.Router` em vez de `ninja.Router`. 2) Configurar um backend de `CACHES` no Django. 3) Definir `THROTTLE_RATES` nas configurações de `NINJA_EXTRA`.
+**Prevention:** Sempre aplicar `AnonRateThrottle` em endpoints públicos e críticos e garantir que o ambiente de teste limpe o cache entre execuções para evitar falsos negativos (429 inesperados).

--- a/backend/apps/users/api.py
+++ b/backend/apps/users/api.py
@@ -1,7 +1,8 @@
 from typing import Any
 
 from django.http import HttpRequest
-from ninja import Router
+from ninja_extra import Router
+from ninja_extra.throttling import AnonRateThrottle
 from ninja_jwt.schema import (
     TokenRefreshInputSchema,
     TokenRefreshOutputSchema,
@@ -23,6 +24,7 @@ router = Router(tags=["auth"])
     "/register/",
     response={201: UserOut, **MUTATION_ERROR_RESPONSES},
     auth=None,
+    throttle=[AnonRateThrottle()],
     operation_id="auth_register_user",
 )
 def register_user(request: HttpRequest, payload: RegisterIn) -> tuple[int, Any]:
@@ -43,6 +45,7 @@ def register_user(request: HttpRequest, payload: RegisterIn) -> tuple[int, Any]:
     "/token/",
     response={200: TokenOut, 401: ErrorResponse, **MUTATION_ERROR_RESPONSES},
     auth=None,
+    throttle=[AnonRateThrottle()],
     operation_id="auth_obtain_token",
 )
 def obtain_token(request: HttpRequest, payload: TokenPayloadIn) -> TokenOut:
@@ -67,6 +70,7 @@ def obtain_token(request: HttpRequest, payload: TokenPayloadIn) -> TokenOut:
         401: ErrorResponse,
         **MUTATION_ERROR_RESPONSES,
     },
+    throttle=[AnonRateThrottle()],
     operation_id="auth_refresh_token",
 )
 def refresh_token(
@@ -89,6 +93,7 @@ def refresh_token(
         **MUTATION_ERROR_RESPONSES,
     },
     auth=None,
+    throttle=[AnonRateThrottle()],
     operation_id="auth_verify_token",
 )
 def verify_token(

--- a/backend/apps/users/tests/test_throttling.py
+++ b/backend/apps/users/tests/test_throttling.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 @pytest.mark.django_db
 def test_register_throttling(auth_client):
     """

--- a/backend/apps/users/tests/test_throttling.py
+++ b/backend/apps/users/tests/test_throttling.py
@@ -1,0 +1,35 @@
+import pytest
+
+@pytest.mark.django_db
+def test_register_throttling(auth_client):
+    """
+    Verify that the rate limit (5 requests per minute for anonymous users) is enforced.
+    """
+    payload = {
+        "email": "throttle@test.com",
+        "password": "StrongPassword123!",
+        "first_name": "Throttle",
+        "last_name": "Test",
+        "company_name": "Throttle Co",
+    }
+
+    # The first 5 requests should pass (status code 201)
+    for i in range(5):
+        payload["email"] = f"throttle_{i}@test.com"
+        response = auth_client.post(
+            "/api/v1/auth/register/",
+            payload,
+            content_type="application/json",
+        )
+        assert response.status_code == 201
+
+    # The 6th request should return 429
+    payload["email"] = "throttle_6@test.com"
+    response = auth_client.post(
+        "/api/v1/auth/register/",
+        payload,
+        content_type="application/json",
+    )
+
+    assert response.status_code == 429
+    assert "Request was throttled" in response.json()["detail"]

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -111,6 +111,20 @@ CORS_ALLOW_HEADERS = [
     "baggage",
 ]
 
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "unique-snowflake",
+    }
+}
+
+NINJA_EXTRA = {
+    "THROTTLE_RATES": {
+        "user": "1000/d",
+        "anon": "5/m",
+    }
+}
+
 NINJA_JWT = {
     "ACCESS_TOKEN_LIFETIME": timedelta(
         minutes=env.int("ACCESS_TOKEN_LIFETIME_MINUTES", default=15)

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -4,11 +4,11 @@ Configuração Global de Testes (Pytest).
 
 import factory
 import pytest
+from django.core.cache import cache
 from django.test import Client
 from ninja_jwt.tokens import RefreshToken
 from pytest_factoryboy import register
 
-from django.core.cache import cache
 from apps.users.tests.factories import AdminFactory, UserFactory
 
 

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -8,7 +8,14 @@ from django.test import Client
 from ninja_jwt.tokens import RefreshToken
 from pytest_factoryboy import register
 
+from django.core.cache import cache
 from apps.users.tests.factories import AdminFactory, UserFactory
+
+
+@pytest.fixture(autouse=True)
+def clear_cache_between_tests():
+    """Clears the cache between each test to avoid throttling interference."""
+    cache.clear()
 
 
 # 1. Registo Global de Factories


### PR DESCRIPTION
This PR implements rate limiting (throttling) on sensitive authentication endpoints to protect against brute-force attacks and denial-of-service (DoS) attempts.

### 🚨 Severity: HIGH
### 💡 Vulnerability: Missing Rate Limiting
Sensitive endpoints like `/auth/register/` and `/auth/token/` had no limit on the number of requests a user (or bot) could make in a short period.

### 🎯 Impact:
Attackers could perform brute-force attacks to guess passwords or overwhelm the server with registration requests, leading to account takeovers or resource exhaustion.

### 🔧 Fix:
1.  **Cache Configuration**: Added `LocMemCache` to `backend/config/settings/base.py` as a backend for storing request counts.
2.  **Throttling Configuration**: Defined default rates for anonymous users (`5/m`) and authenticated users (`1000/d`).
3.  **Router Upgrade**: Changed the authentication router from `ninja.Router` to `ninja_extra.Router` to enable the `throttle` decorator argument.
4.  **Applied Protection**: Added `throttle=[AnonRateThrottle()]` to all public authentication endpoints.
5.  **Test Isolation**: Added a global pytest fixture to clear the cache between tests, preventing 429 errors from leaking across test cases.

### ✅ Verification:
- Added `backend/apps/users/tests/test_throttling.py` which confirms that a 6th request within a minute to the registration endpoint returns a `429 Too Many Requests` status.
- Verified that all 694 existing backend tests pass.

---
*PR created automatically by Jules for task [15016677985284836766](https://jules.google.com/task/15016677985284836766) started by @Rafaelp122*