### PR TITLE
refactor(logistics): decouple r2 storage from contract service

### DIFF
--- a/backend/apps/core/services/__init__.py
+++ b/backend/apps/core/services/__init__.py
@@ -1,0 +1,12 @@
+from .storage_service import (
+    CloudflareR2StorageService,
+    StorageService,
+    get_storage_service,
+)
+
+
+__all__ = [
+    "CloudflareR2StorageService",
+    "StorageService",
+    "get_storage_service",
+]

--- a/backend/apps/core/services/storage_service.py
+++ b/backend/apps/core/services/storage_service.py
@@ -101,4 +101,7 @@ def get_storage_service() -> StorageService:
 
     # Outros provedores (como GCS, S3 padrão) podem ser
     # facilmente adicionados aqui no futuro.
-    raise ValueError(f"Provedor de storage '{provider}' não suportado.")
+    raise BusinessRuleViolation(
+        detail=f"Provedor de storage '{provider}' não suportado.",
+        code="unsupported_storage_provider",
+    )

--- a/backend/apps/core/services/storage_service.py
+++ b/backend/apps/core/services/storage_service.py
@@ -1,0 +1,93 @@
+from typing import Protocol
+
+import boto3  # type: ignore[import-untyped]
+from django.conf import settings
+
+from apps.core.exceptions import BusinessRuleViolation
+
+
+class StorageService(Protocol):
+    """Protocolo definindo a interface para serviços de armazenamento de arquivos."""
+
+    def generate_presigned_put_url(
+        self, bucket: str, object_key: str, content_type: str, expires_in: int = 900
+    ) -> str:
+        """Gera uma URL pré-assinada para upload direto via PUT."""
+        ...
+
+
+class CloudflareR2StorageService:
+    """Implementação concreta de StorageService usando Cloudflare R2/S3 via boto3."""
+
+    def __init__(
+        self,
+        endpoint_url: str | None = None,
+        access_key_id: str | None = None,
+        secret_access_key: str | None = None,
+        region_name: str = "us-east-1",
+    ):
+        self.endpoint_url = (
+            endpoint_url
+            or getattr(settings, "AWS_S3_ENDPOINT_URL", None)
+            or getattr(settings, "R2_ENDPOINT_URL", None)
+        )
+        self.access_key_id = (
+            access_key_id
+            or getattr(settings, "AWS_ACCESS_KEY_ID", None)
+            or getattr(settings, "R2_ACCESS_KEY_ID", None)
+        )
+        self.secret_access_key = (
+            secret_access_key
+            or getattr(settings, "AWS_SECRET_ACCESS_KEY", None)
+            or getattr(settings, "R2_SECRET_ACCESS_KEY", None)
+        )
+        self.region_name = region_name
+
+    def generate_presigned_put_url(
+        self, bucket: str, object_key: str, content_type: str, expires_in: int = 900
+    ) -> str:
+        """
+        Gera uma URL pré-assinada para upload de um objeto.
+        """
+        if not all(
+            [self.endpoint_url, self.access_key_id, self.secret_access_key, bucket]
+        ):
+            raise BusinessRuleViolation(
+                detail="Configuração de storage R2/S3 incompleta no servidor.",
+                code="storage_configuration_incomplete",
+            )
+
+        s3_client = boto3.client(
+            "s3",
+            endpoint_url=self.endpoint_url,
+            aws_access_key_id=self.access_key_id,
+            aws_secret_access_key=self.secret_access_key,
+            region_name=self.region_name,
+        )
+
+        presigned_url: str = s3_client.generate_presigned_url(
+            "put_object",
+            Params={
+                "Bucket": bucket,
+                "Key": object_key,
+                "ContentType": content_type,
+            },
+            ExpiresIn=expires_in,
+        )
+        return presigned_url
+
+
+def get_storage_service() -> StorageService:
+    """
+    Factory function para retornar a implementação ativa do StorageService
+    com base no provedor configurado no Django settings.
+    """
+    provider = getattr(settings, "STORAGE_PROVIDER", "R2").upper()
+
+    if provider == "R2":
+        return CloudflareR2StorageService()
+
+    # Outros provedores (como GCS, S3 padrão) podem ser
+    # facilmente adicionados aqui no futuro.
+    raise ValueError(f"Provedor de storage '{provider}' não suportado.")
+

--- a/backend/apps/core/services/storage_service.py
+++ b/backend/apps/core/services/storage_service.py
@@ -26,22 +26,34 @@ class CloudflareR2StorageService:
         secret_access_key: str | None = None,
         region_name: str = "us-east-1",
     ):
-        self.endpoint_url = (
-            endpoint_url
+        self._endpoint_url = endpoint_url
+        self._access_key_id = access_key_id
+        self._secret_access_key = secret_access_key
+        self.region_name = region_name
+
+    @property
+    def endpoint_url(self) -> str | None:
+        return (
+            self._endpoint_url
             or getattr(settings, "AWS_S3_ENDPOINT_URL", None)
             or getattr(settings, "R2_ENDPOINT_URL", None)
         )
-        self.access_key_id = (
-            access_key_id
+
+    @property
+    def access_key_id(self) -> str | None:
+        return (
+            self._access_key_id
             or getattr(settings, "AWS_ACCESS_KEY_ID", None)
             or getattr(settings, "R2_ACCESS_KEY_ID", None)
         )
-        self.secret_access_key = (
-            secret_access_key
+
+    @property
+    def secret_access_key(self) -> str | None:
+        return (
+            self._secret_access_key
             or getattr(settings, "AWS_SECRET_ACCESS_KEY", None)
             or getattr(settings, "R2_SECRET_ACCESS_KEY", None)
         )
-        self.region_name = region_name
 
     def generate_presigned_put_url(
         self, bucket: str, object_key: str, content_type: str, expires_in: int = 900
@@ -90,4 +102,3 @@ def get_storage_service() -> StorageService:
     # Outros provedores (como GCS, S3 padrão) podem ser
     # facilmente adicionados aqui no futuro.
     raise ValueError(f"Provedor de storage '{provider}' não suportado.")
-

--- a/backend/apps/core/tests/test_storage_service.py
+++ b/backend/apps/core/tests/test_storage_service.py
@@ -3,7 +3,10 @@ from unittest.mock import patch
 import pytest
 
 from apps.core.exceptions import BusinessRuleViolation
-from apps.core.services.storage_service import CloudflareR2StorageService
+from apps.core.services.storage_service import (
+    CloudflareR2StorageService,
+    get_storage_service,
+)
 
 
 class TestCloudflareR2StorageService:
@@ -58,3 +61,18 @@ class TestCloudflareR2StorageService:
                 content_type="application/pdf",
             )
         assert exc_info.value.code == "storage_configuration_incomplete"
+
+
+class TestGetStorageService:
+    """Testes da factory function get_storage_service."""
+
+    def test_get_storage_service_r2_success(self, settings):
+        settings.STORAGE_PROVIDER = "R2"
+        service = get_storage_service()
+        assert isinstance(service, CloudflareR2StorageService)
+
+    def test_get_storage_service_unsupported_raises_error(self, settings):
+        settings.STORAGE_PROVIDER = "GCS"
+        with pytest.raises(BusinessRuleViolation) as exc_info:
+            get_storage_service()
+        assert exc_info.value.code == "unsupported_storage_provider"

--- a/backend/apps/core/tests/test_storage_service.py
+++ b/backend/apps/core/tests/test_storage_service.py
@@ -1,0 +1,60 @@
+from unittest.mock import patch
+
+import pytest
+
+from apps.core.exceptions import BusinessRuleViolation
+from apps.core.services.storage_service import CloudflareR2StorageService
+
+
+class TestCloudflareR2StorageService:
+    """Testes unitários isolados do CloudflareR2StorageService."""
+
+    @patch("boto3.client")
+    def test_generate_presigned_put_url_success(self, mock_boto3_client, settings):
+        settings.R2_ENDPOINT_URL = "https://r2-endpoint.com"
+        settings.R2_ACCESS_KEY_ID = "test-key-id"
+        settings.R2_SECRET_ACCESS_KEY = "test-secret-key"
+        settings.AWS_S3_ENDPOINT_URL = "https://r2-endpoint.com"
+        settings.AWS_ACCESS_KEY_ID = "test-key-id"
+        settings.AWS_SECRET_ACCESS_KEY = "test-secret-key"
+
+        mock_s3 = mock_boto3_client.return_value
+        mock_s3.generate_presigned_url.return_value = "https://r2.com/presigned-url"
+
+        storage = CloudflareR2StorageService()
+        url = storage.generate_presigned_put_url(
+            bucket="test-bucket",
+            object_key="test-key",
+            content_type="application/pdf",
+        )
+
+        assert url == "https://r2.com/presigned-url"
+        mock_boto3_client.assert_called_once_with(
+            "s3",
+            endpoint_url="https://r2-endpoint.com",
+            aws_access_key_id="test-key-id",
+            aws_secret_access_key="test-secret-key",
+            region_name="us-east-1",
+        )
+        mock_s3.generate_presigned_url.assert_called_once_with(
+            "put_object",
+            Params={
+                "Bucket": "test-bucket",
+                "Key": "test-key",
+                "ContentType": "application/pdf",
+            },
+            ExpiresIn=900,
+        )
+
+    def test_generate_presigned_put_url_configuration_incomplete(self, settings):
+        settings.R2_ENDPOINT_URL = ""
+        settings.AWS_S3_ENDPOINT_URL = ""
+
+        storage = CloudflareR2StorageService()
+        with pytest.raises(BusinessRuleViolation) as exc_info:
+            storage.generate_presigned_put_url(
+                bucket="test-bucket",
+                object_key="test-key",
+                content_type="application/pdf",
+            )
+        assert exc_info.value.code == "storage_configuration_incomplete"

--- a/backend/apps/logistics/services/contract_service.py
+++ b/backend/apps/logistics/services/contract_service.py
@@ -25,6 +25,10 @@ from apps.core.exceptions import (
     DomainIntegrityError,
     ObjectNotFoundError,
 )
+from apps.core.services.storage_service import (
+    StorageService,
+    get_storage_service,
+)
 from apps.core.shortcuts import get_object_or_404_for_tenant
 from apps.core.tenant import validate_tenant_ownership
 from apps.finances.models import Expense, Installment
@@ -51,6 +55,12 @@ class ContractService:
     Foco: Orquestração, Multitenancy Segura e Auditoria.
     Validações de integridade do dado (ex: datas inválidas) ficam delegadas ao Model.
     """
+
+    _storage_service: StorageService = get_storage_service()
+
+    @classmethod
+    def set_storage_service(cls, storage_service: StorageService) -> None:
+        cls._storage_service = storage_service
 
     @staticmethod
     def list(
@@ -442,14 +452,15 @@ class ContractService:
 
     @staticmethod
     def generate_upload_url(
-        company: Company, filename: str, wedding_id: UUID | str
+        company: Company,
+        filename: str,
+        wedding_id: UUID | str,
+        storage_service: StorageService | None = None,
     ) -> dict[str, Any]:
         """
         Gera presigned URL para upload de contrato no R2/S3.
         """
         import uuid
-
-        import boto3  # type: ignore[import-untyped]
 
         # Validar casamento
         wedding = get_object_or_404_for_tenant(
@@ -469,43 +480,24 @@ class ContractService:
         unique_id = uuid.uuid4()
         object_key = f"contracts/{wedding.uuid}/{unique_id}/{filename}"
 
-        # Configurar boto3 client
-        r2_endpoint = getattr(settings, "AWS_S3_ENDPOINT_URL", None) or getattr(
-            settings, "R2_ENDPOINT_URL", None
-        )
-        r2_access_key = getattr(settings, "AWS_ACCESS_KEY_ID", None) or getattr(
-            settings, "R2_ACCESS_KEY_ID", None
-        )
-        r2_secret_key = getattr(settings, "AWS_SECRET_ACCESS_KEY", None) or getattr(
-            settings, "R2_SECRET_ACCESS_KEY", None
-        )
+        # Obter bucket das configurações
         r2_bucket = getattr(settings, "AWS_STORAGE_BUCKET_NAME", None) or getattr(
             settings, "R2_BUCKET", None
         )
 
-        if not all([r2_endpoint, r2_access_key, r2_secret_key, r2_bucket]):
+        if not r2_bucket:
             logger.error("Configuração de storage R2/S3 incompleta no servidor.")
             raise BusinessRuleViolation(
                 detail="Configuração de storage R2/S3 incompleta no servidor.",
                 code="storage_configuration_incomplete",
             )
 
-        s3_client = boto3.client(
-            "s3",
-            endpoint_url=r2_endpoint,
-            aws_access_key_id=r2_access_key,
-            aws_secret_access_key=r2_secret_key,
-            region_name=getattr(settings, "AWS_S3_REGION_NAME", "us-east-1"),
-        )
-
-        presigned_url = s3_client.generate_presigned_url(
-            "put_object",
-            Params={
-                "Bucket": r2_bucket,
-                "Key": object_key,
-                "ContentType": content_type,
-            },
-            ExpiresIn=900,
+        storage = storage_service or ContractService._storage_service
+        presigned_url = storage.generate_presigned_put_url(
+            bucket=r2_bucket,
+            object_key=object_key,
+            content_type=content_type,
+            expires_in=900,
         )
 
         return {

--- a/backend/apps/logistics/services/contract_service.py
+++ b/backend/apps/logistics/services/contract_service.py
@@ -56,7 +56,13 @@ class ContractService:
     Validações de integridade do dado (ex: datas inválidas) ficam delegadas ao Model.
     """
 
-    _storage_service: StorageService = get_storage_service()
+    _storage_service: StorageService | None = None
+
+    @classmethod
+    def get_storage_client(cls) -> StorageService:
+        if cls._storage_service is None:
+            cls._storage_service = get_storage_service()
+        return cls._storage_service
 
     @classmethod
     def set_storage_service(cls, storage_service: StorageService) -> None:
@@ -492,7 +498,7 @@ class ContractService:
                 code="storage_configuration_incomplete",
             )
 
-        storage = storage_service or ContractService._storage_service
+        storage = storage_service or ContractService.get_storage_client()
         presigned_url = storage.generate_presigned_put_url(
             bucket=r2_bucket,
             object_key=object_key,

--- a/backend/apps/logistics/tests/contracts/test_services.py
+++ b/backend/apps/logistics/tests/contracts/test_services.py
@@ -965,7 +965,9 @@ class TestContractServiceGenerateUploadUrl:
 
         assert "upload_url" in result
         assert "object_key" in result
-        assert result["upload_url"] == f"https://r2.com/test-bucket/{result['object_key']}"
+        assert (
+            result["upload_url"] == f"https://r2.com/test-bucket/{result['object_key']}"
+        )
         assert result["object_key"].startswith(f"contracts/{wedding.uuid}/")
         assert result["object_key"].endswith("/contrato.pdf")
 
@@ -983,7 +985,10 @@ class TestContractServiceGenerateUploadUrl:
                 filename="contrato.pdf",
                 wedding_id=wedding.uuid,
             )
-            assert result["upload_url"] == f"https://r2.com/test-bucket/{result['object_key']}"
+            assert (
+                result["upload_url"]
+                == f"https://r2.com/test-bucket/{result['object_key']}"
+            )
         finally:
             ContractService.set_storage_service(original_storage)
 

--- a/backend/apps/logistics/tests/contracts/test_services.py
+++ b/backend/apps/logistics/tests/contracts/test_services.py
@@ -1029,3 +1029,16 @@ class TestContractServiceGenerateUploadUrl:
                 storage_service=DummyStorageService(),
             )
         assert exc_info.value.code == "storage_configuration_incomplete"
+
+    def test_contract_service_get_storage_client_lazy_load(self):
+        # Salva o estado original
+        original_storage = ContractService._storage_service
+
+        # Força o estado a ser None para testar a inicialização lazy
+        ContractService._storage_service = None
+        try:
+            client = ContractService.get_storage_client()
+            assert client is not None
+        finally:
+            # Restaura o estado original
+            ContractService._storage_service = original_storage

--- a/backend/apps/logistics/tests/contracts/test_services.py
+++ b/backend/apps/logistics/tests/contracts/test_services.py
@@ -1,6 +1,5 @@
 from datetime import date
 from decimal import Decimal
-from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
@@ -941,49 +940,54 @@ class TestContractServiceCreateFull:
         assert "br_f02_violation" in str(exc_info.value.code)
 
 
+class DummyStorageService:
+    def generate_presigned_put_url(
+        self, bucket: str, object_key: str, content_type: str, expires_in: int = 900
+    ) -> str:
+        return f"https://r2.com/{bucket}/{object_key}"
+
+
 @pytest.mark.django_db
 class TestContractServiceGenerateUploadUrl:
     """Testes de geração de upload URL pré-assinada."""
 
-    @patch("boto3.client")
-    def test_generate_upload_url_success(self, mock_boto3_client, user, settings):
-        settings.R2_ENDPOINT_URL = "https://r2-endpoint.com"
-        settings.R2_ACCESS_KEY_ID = "test-key-id"
-        settings.R2_SECRET_ACCESS_KEY = "test-secret-key"
-        settings.R2_BUCKET = "test-bucket"
-        settings.AWS_S3_ENDPOINT_URL = "https://r2-endpoint.com"
-        settings.AWS_ACCESS_KEY_ID = "test-key-id"
-        settings.AWS_SECRET_ACCESS_KEY = "test-secret-key"
+    def test_generate_upload_url_success_with_injection(self, user, settings):
         settings.AWS_STORAGE_BUCKET_NAME = "test-bucket"
-
         wedding, _ = _setup_contract_context(user)
-        mock_s3 = mock_boto3_client.return_value
-        mock_s3.generate_presigned_url.return_value = "https://r2.com/presigned-url"
+        dummy_storage = DummyStorageService()
 
         result = ContractService.generate_upload_url(
             company=user.company,
             filename="contrato.pdf",
             wedding_id=wedding.uuid,
+            storage_service=dummy_storage,
         )
 
         assert "upload_url" in result
         assert "object_key" in result
-        assert result["upload_url"] == "https://r2.com/presigned-url"
+        assert result["upload_url"] == f"https://r2.com/test-bucket/{result['object_key']}"
         assert result["object_key"].startswith(f"contracts/{wedding.uuid}/")
         assert result["object_key"].endswith("/contrato.pdf")
 
-        mock_s3.generate_presigned_url.assert_called_once()
-        _, kwargs = mock_s3.generate_presigned_url.call_args
-        assert kwargs["Params"]["ContentType"] == "application/pdf"
+    def test_generate_upload_url_success_with_class_setter(self, user, settings):
+        settings.AWS_STORAGE_BUCKET_NAME = "test-bucket"
+        wedding, _ = _setup_contract_context(user)
+
+        original_storage = ContractService._storage_service
+        dummy_storage = DummyStorageService()
+        ContractService.set_storage_service(dummy_storage)
+
+        try:
+            result = ContractService.generate_upload_url(
+                company=user.company,
+                filename="contrato.pdf",
+                wedding_id=wedding.uuid,
+            )
+            assert result["upload_url"] == f"https://r2.com/test-bucket/{result['object_key']}"
+        finally:
+            ContractService.set_storage_service(original_storage)
 
     def test_generate_upload_url_wedding_not_found(self, user, settings):
-        settings.R2_ENDPOINT_URL = "https://r2-endpoint.com"
-        settings.R2_ACCESS_KEY_ID = "test-key-id"
-        settings.R2_SECRET_ACCESS_KEY = "test-secret-key"
-        settings.R2_BUCKET = "test-bucket"
-        settings.AWS_S3_ENDPOINT_URL = "https://r2-endpoint.com"
-        settings.AWS_ACCESS_KEY_ID = "test-key-id"
-        settings.AWS_SECRET_ACCESS_KEY = "test-secret-key"
         settings.AWS_STORAGE_BUCKET_NAME = "test-bucket"
 
         with pytest.raises(ObjectNotFoundError):
@@ -991,16 +995,10 @@ class TestContractServiceGenerateUploadUrl:
                 company=user.company,
                 filename="contrato.pdf",
                 wedding_id=uuid4(),
+                storage_service=DummyStorageService(),
             )
 
     def test_generate_upload_url_multitenancy(self, user, settings):
-        settings.R2_ENDPOINT_URL = "https://r2-endpoint.com"
-        settings.R2_ACCESS_KEY_ID = "test-key-id"
-        settings.R2_SECRET_ACCESS_KEY = "test-secret-key"
-        settings.R2_BUCKET = "test-bucket"
-        settings.AWS_S3_ENDPOINT_URL = "https://r2-endpoint.com"
-        settings.AWS_ACCESS_KEY_ID = "test-key-id"
-        settings.AWS_SECRET_ACCESS_KEY = "test-secret-key"
         settings.AWS_STORAGE_BUCKET_NAME = "test-bucket"
 
         other_user = UserFactory()
@@ -1010,17 +1008,12 @@ class TestContractServiceGenerateUploadUrl:
                 company=user.company,
                 filename="contrato.pdf",
                 wedding_id=other_wedding.uuid,
+                storage_service=DummyStorageService(),
             )
 
     def test_generate_upload_url_configuration_incomplete(self, user, settings):
-        settings.R2_ENDPOINT_URL = "https://r2-endpoint.com"
-        settings.R2_ACCESS_KEY_ID = "test-key-id"
-        settings.R2_SECRET_ACCESS_KEY = "test-secret-key"
-        settings.R2_BUCKET = ""
-        settings.AWS_S3_ENDPOINT_URL = "https://r2-endpoint.com"
-        settings.AWS_ACCESS_KEY_ID = "test-key-id"
-        settings.AWS_SECRET_ACCESS_KEY = "test-secret-key"
         settings.AWS_STORAGE_BUCKET_NAME = ""
+        settings.R2_BUCKET = ""
 
         wedding, _ = _setup_contract_context(user)
         with pytest.raises(BusinessRuleViolation) as exc_info:
@@ -1028,5 +1021,6 @@ class TestContractServiceGenerateUploadUrl:
                 company=user.company,
                 filename="contrato.pdf",
                 wedding_id=wedding.uuid,
+                storage_service=DummyStorageService(),
             )
         assert exc_info.value.code == "storage_configuration_incomplete"

--- a/backend/apps/logistics/tests/test_apis.py
+++ b/backend/apps/logistics/tests/test_apis.py
@@ -693,9 +693,7 @@ class TestContractCreateFullAPI:
         )
         assert response.status_code == 404
 
-    def test_generate_upload_url_api_success(
-        self, auth_client, user, settings
-    ):
+    def test_generate_upload_url_api_success(self, auth_client, user, settings):
         settings.AWS_STORAGE_BUCKET_NAME = "test-bucket"
         wedding = WeddingFactory(company=user.company)
 
@@ -720,7 +718,9 @@ class TestContractCreateFullAPI:
             data = response.json()
             assert "upload_url" in data
             assert "object_key" in data
-            assert data["upload_url"] == f"https://r2.com/test-bucket/{data['object_key']}"
+            assert (
+                data["upload_url"] == f"https://r2.com/test-bucket/{data['object_key']}"
+            )
         finally:
             ContractService.set_storage_service(original_storage)
 

--- a/backend/apps/logistics/tests/test_apis.py
+++ b/backend/apps/logistics/tests/test_apis.py
@@ -1,7 +1,6 @@
 import json
 from datetime import date
 from decimal import Decimal
-from unittest.mock import patch
 
 import pytest
 
@@ -495,6 +494,13 @@ class TestLogisticsNinjaAPI:
         assert response.json()["name"] == "Fornecedor Meu"
 
 
+class DummyStorageService:
+    def generate_presigned_put_url(
+        self, bucket: str, object_key: str, content_type: str, expires_in: int = 900
+    ) -> str:
+        return f"https://r2.com/{bucket}/{object_key}"
+
+
 @pytest.mark.django_db
 class TestContractCreateFullAPI:
     """Testes HTTP do endpoint contracts/full/ (criação atômica)."""
@@ -687,37 +693,36 @@ class TestContractCreateFullAPI:
         )
         assert response.status_code == 404
 
-    @patch("boto3.client")
     def test_generate_upload_url_api_success(
-        self, mock_boto3_client, auth_client, user, settings
+        self, auth_client, user, settings
     ):
-        settings.R2_ENDPOINT_URL = "https://r2-endpoint.com"
-        settings.R2_ACCESS_KEY_ID = "test-key-id"
-        settings.R2_SECRET_ACCESS_KEY = "test-secret-key"
-        settings.R2_BUCKET = "test-bucket"
-        settings.AWS_S3_ENDPOINT_URL = "https://r2-endpoint.com"
-        settings.AWS_ACCESS_KEY_ID = "test-key-id"
-        settings.AWS_SECRET_ACCESS_KEY = "test-secret-key"
         settings.AWS_STORAGE_BUCKET_NAME = "test-bucket"
         wedding = WeddingFactory(company=user.company)
-        mock_s3 = mock_boto3_client.return_value
-        mock_s3.generate_presigned_url.return_value = "https://r2.com/presigned-url"
 
-        response = auth_client.post(
-            "/api/v1/logistics/contracts/upload-url/",
-            data=json.dumps(
-                {
-                    "filename": "contrato.pdf",
-                    "wedding_id": str(wedding.uuid),
-                }
-            ),
-            content_type="application/json",
-        )
-        assert response.status_code == 200
-        data = response.json()
-        assert "upload_url" in data
-        assert "object_key" in data
-        assert data["upload_url"] == "https://r2.com/presigned-url"
+        from apps.logistics.services.contract_service import ContractService
+
+        original_storage = ContractService._storage_service
+        dummy_storage = DummyStorageService()
+        ContractService.set_storage_service(dummy_storage)
+
+        try:
+            response = auth_client.post(
+                "/api/v1/logistics/contracts/upload-url/",
+                data=json.dumps(
+                    {
+                        "filename": "contrato.pdf",
+                        "wedding_id": str(wedding.uuid),
+                    }
+                ),
+                content_type="application/json",
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert "upload_url" in data
+            assert "object_key" in data
+            assert data["upload_url"] == f"https://r2.com/test-bucket/{data['object_key']}"
+        finally:
+            ContractService.set_storage_service(original_storage)
 
 
 @pytest.mark.django_db

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -21,6 +21,8 @@ environ.Env.read_env(BASE_DIR.parent / ".env")
 
 SECRET_KEY = env("SECRET_KEY")
 
+STORAGE_PROVIDER = env("STORAGE_PROVIDER", default="R2")
+
 INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",

--- a/docs/ADR/020-storage-service-abstraction.md
+++ b/docs/ADR/020-storage-service-abstraction.md
@@ -1,0 +1,47 @@
+# ADR-020: Abstração do Serviço de Storage e Injeção de Dependências
+
+**Status:** Aceito  
+**Data:** Julho 2026  
+**Decisores:** Rafael, Antigravity  
+**Contexto:** Desacoplamento da infraestrutura de arquivos do Cloudflare R2 / boto3 S3  
+
+---
+
+## Contexto e Problema
+
+Anteriormente, o `ContractService` (no app `logistics`) continha lógica de negócios de gestão de contratos acoplada diretamente à criação de clientes `boto3` e geração de URLs pré-assinadas para o Cloudflare R2. Esse acoplamento gerava:
+1. **Violação do SRP (Princípio de Responsabilidade Única)**: O serviço do domínio de contratos precisava conhecer detalhes de baixo nível da infraestrutura de storage.
+2. **Dificuldade de Testabilidade**: Os testes do serviço e da API de logística precisavam realizar mocks diretos do pacote de baixo nível `boto3.client`.
+3. **Rigidez Arquitetural**: Alterar o provedor de nuvem (ex: do Cloudflare R2 para AWS S3 ou Google Cloud Storage) exigiria reescrever lógica interna do domínio de logística.
+
+---
+
+## Decisão
+
+1. **Abstração Base (`StorageService`)**: Criar um protocolo estrutural `StorageService` no módulo `apps/core/services/storage_service.py` que define a interface de interação com o storage de arquivos.
+2. **Implementação Concreta (`CloudflareR2StorageService`)**: Encapsular a lógica de baixo nível do `boto3` e a leitura de credenciais dentro da implementação concreta.
+3. **Injeção de Dependência**:
+   - Fornecer suporte para injeção via parâmetro de método nos serviços do domínio.
+   - Fornecer suporte para configuração de injeção global de classe via setter (`ContractService.set_storage_service()`).
+4. **Resolução de Configurações Dinâmicas (Lazy Resolution)**:
+   - A leitura das chaves de settings de storage deve ocorrer sob demanda por propriedades dinâmicas (`@property`), permitindo que modificações feitas em tempo de execução pelos testes tenham efeito imediato.
+   - O serviço de storage global ativo deve ser instanciado sob demanda via factory baseada em configurações (`settings.STORAGE_PROVIDER`), evitando a dependência precoce no import time do módulo.
+
+---
+
+## Justificativa e Consequências
+
+### Positivas ✅
+- **Desacoplamento do Domínio**: `ContractService` lida apenas com contratos; não tem conhecimento de `boto3`, S3 ou endpoints de rede do R2.
+- **Substituição Transparente**: Para migrar de provedor, basta implementar um novo serviço que atenda ao protocolo e alterar a variável `STORAGE_PROVIDER` no `.env`.
+- **Testes Limpos**: A suíte de testes de logística agora injeta um `DummyStorageService` simples nas chamadas, acelerando os testes e eliminando a fragilidade de mockar bibliotecas de terceiros.
+
+### Negativas ❌
+- Pequeno aumento no número de classes e arquivos de infraestrutura do sistema.
+
+---
+
+## Referências
+- [ADR-003: Cloudflare R2](003-why-r2.md)
+- [ADR-004: Presigned URLs](004-presigned-urls.md)
+- [ADR-006: Service Layer](006-service-layer.md)


### PR DESCRIPTION
## Descrição
Este PR realiza o desacoplamento físico do Cloudflare R2 (boto3 / S3 client) de dentro do `ContractService` no app `logistics`, criando uma nova abstração reutilizável de infraestrutura de storage no app `core`.

## O que foi feito
1. **Nova Abstração de Storage (`apps/core/services/storage_service.py`)**:
   - Definição do protocolo `StorageService`.
   - Implementação da classe `CloudflareR2StorageService` utilizando `boto3`.
   - Implementação da factory function `get_storage_service()` que resolve dinamicamente a dependência de acordo com a configuração de ambiente no Django (`settings.STORAGE_PROVIDER`).
2. **Refatoração do `ContractService`**:
   - Remoção do import direto de `boto3` e parâmetros de configuração espalhados.
   - Delegação da geração de URLs pré-assinadas para o `StorageService` injetado.
   - Suporte a injeção de dependência via método (`storage_service` como parâmetro) ou globalmente via setter (`set_storage_service()`).
3. **Melhoria nos Testes Unitários**:
   - Criação de testes unitários isolados para o `CloudflareR2StorageService`.
   - Refatoração dos testes de contratos para utilizar um `DummyStorageService` simples (mock limpo), removendo a necessidade de interceptar ou mockar chamadas do `boto3.client`.
