### PR TITLE
fix(logistics): remove redundant select_related in SupplierService.list

### DIFF
--- a/backend/apps/logistics/services/supplier_service.py
+++ b/backend/apps/logistics/services/supplier_service.py
@@ -28,7 +28,7 @@ class SupplierService:
         search: str = "",
         is_active: bool | None = None,
     ) -> QuerySet[Supplier]:
-        qs = Supplier.objects.for_tenant(company).select_related("company")
+        qs = Supplier.objects.for_tenant(company)
         if search:
             qs = qs.filter(
                 Q(name__icontains=search)


### PR DESCRIPTION
## 📝 Resumo do Pull Request

Remove a cláusula `.select_related("company")` redundante no método `list()` da classe `SupplierService`.

### O que muda

- Remoção do `select_related("company")` em `SupplierService.list()` no arquivo `backend/apps/logistics/services/supplier_service.py`.
- Essa remoção elimina um `JOIN` redundante/extra na tabela `tenants_company` a cada requisição de listagem de fornecedores, otimizando as consultas ao banco de dados.
- O campo `company_id` já é acessível diretamente pelo próprio modelo `Supplier` (que herda de `TenantModel`), e o serializer `SupplierOut` não inclui dados do objeto `Company`.

### Como testar

- Executar a suíte de testes do backend para garantir que não há regressões:
  `make test`
- Ou rodar testes específicos do logistics/suppliers:
  `docker compose run --rm backend python -m pytest apps/logistics/tests/suppliers/`