### PR TITLE
docs(comments): padronizar comentários e docstrings do backend e registrar ADR-021

### DIFF
--- a/.agents/skills/wedding-backend/SKILL.md
+++ b/.agents/skills/wedding-backend/SKILL.md
@@ -176,10 +176,13 @@ def handle_validation_error(request, exc):
 - Raise domain exceptions (`ApplicationError` subclasses) — never return error codes/dicts. See [Exception Handling](#8-exception-handling).
 - Returning `None` is acceptable — always type it explicitly (`User | None`). Let `mypy` enforce null-checks.
 
-### Comments
-- Prefer self-explanatory code over comments.
-- Keep comments for: complex business rules (formulas), regex/DB workarounds, `TODO` notes.
-- Never: `# save the user` followed by `user.save()`.
+### Comments & Docstrings
+- Prefer self-explanatory code over redundant comments (e.g. never write `# save the user` followed by `user.save()`).
+- Comments and docstrings must follow the guidelines in [COMMENTING_STANDARDS.md](file:///home/rafael/.gemini/antigravity/worktrees/wedding_management/review-service-documentation-comments/docs/COMMENTING_STANDARDS.md).
+- Use **Português (PT-BR)** for business rules, model validations, and logic explanations. Keep technical terms in English.
+- Code comments must focus on the "why" (business rules, workarounds, performance optimizations), never on the "what".
+- Enforce **Google Style** docstrings for complex or public methods, detailing `Args`, `Returns`, and `Raises`.
+- **CRITICAL**: Never reference AI coding assistants, code generation tools, or development environments in code comments (such as "Bolt", "Jules", "Copilot"). Focus comments strictly on technical explanation.
 
 ---
 

--- a/.agents/skills/wedding-backend/SKILL.md
+++ b/.agents/skills/wedding-backend/SKILL.md
@@ -178,7 +178,7 @@ def handle_validation_error(request, exc):
 
 ### Comments & Docstrings
 - Prefer self-explanatory code over redundant comments (e.g. never write `# save the user` followed by `user.save()`).
-- Comments and docstrings must follow the guidelines in [COMMENTING_STANDARDS.md](file:///home/rafael/.gemini/antigravity/worktrees/wedding_management/review-service-documentation-comments/docs/COMMENTING_STANDARDS.md).
+- Comments and docstrings must follow the guidelines in [COMMENTING_STANDARDS.md](../../../docs/COMMENTING_STANDARDS.md).
 - Use **Português (PT-BR)** for business rules, model validations, and logic explanations. Keep technical terms in English.
 - Code comments must focus on the "why" (business rules, workarounds, performance optimizations), never on the "what".
 - Enforce **Google Style** docstrings for complex or public methods, detailing `Args`, `Returns`, and `Raises`.

--- a/.github/workflows/integrity-ci.yml
+++ b/.github/workflows/integrity-ci.yml
@@ -639,12 +639,14 @@ jobs:
               - Backend (Pytest, factories, mocks): `.agents/skills/wedding-backend-testing/SKILL.md`
               - Frontend (Vitest, RTL, MSW): `.agents/skills/wedding-frontend-testing/SKILL.md`
             6. Padrões de Documentação:
-              - Código autoexplicativo dispensa comentários.
-              - Backend (apps/): endpoints em api.py precisam de operation_id. Funções em services.py
-                e modelos precisam de docstring. Campos de modelo precisam de help_text.
-                Mudanças que envolvem trade-offs arquiteturais (nova app, mudança de framework,
-                refactor grande com impacto em múltiplos apps) precisam de ADR em docs/ADR/.
-                Limpeza de código, otimização de CI e refactors pontuais NÃO precisam de ADR.
+              - Seguir estritamente as diretrizes de `docs/COMMENTING_STANDARDS.md`.
+              - Idioma: Comentários inline e docstrings devem ser escritos em Português (PT-BR).
+              - Backend (apps/):
+                - Métodos públicos/complexos em services.py exigem docstrings em estilo Google Style.
+                - Endpoints em api.py precisam de operation_id e docstrings curtas (1-2 linhas).
+                - Modelos precisam de docstring de classe descritiva e campos com help_text.
+                - Mudanças estruturais importantes ou novos padrões exigem ADR em docs/ADR/ (ver ADR-021).
+                - É terminantemente PROIBIDO incluir referências a assistentes de codificação ou geradores nos comentários (ex: Bolt, Jules, Copilot).
               - Frontend (src/): hooks, tipos e utils exportados em features/ precisam de JSDoc.
                 Stores Zustand precisam de comentário descrevendo o estado gerenciado.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@
 
 - **Read `docs/DESIGN.md`** before UI work.
 - **Load skills on demand** (not proactively).
-- **Docstrings and Comments**: Must follow the standard defined in [COMMENTING_STANDARDS.md](file:///home/rafael/.gemini/antigravity/worktrees/wedding_management/review-service-documentation-comments/docs/COMMENTING_STANDARDS.md). Write in Portuguese (PT-BR) for business explanations, use Google Style for docstrings, and never include references to AI/generation tools (like "Bolt", "Jules", "Copilot").
+- **Docstrings and Comments**: Must follow the standard defined in [COMMENTING_STANDARDS.md](docs/COMMENTING_STANDARDS.md). Write in Portuguese (PT-BR) for business explanations, use Google Style for docstrings, and never include references to AI/generation tools (like "Bolt", "Jules", "Copilot").
 
 ## Subagents
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@
 
 - **Read `docs/DESIGN.md`** before UI work.
 - **Load skills on demand** (not proactively).
+- **Docstrings and Comments**: Must follow the standard defined in [COMMENTING_STANDARDS.md](file:///home/rafael/.gemini/antigravity/worktrees/wedding_management/review-service-documentation-comments/docs/COMMENTING_STANDARDS.md). Write in Portuguese (PT-BR) for business explanations, use Google Style for docstrings, and never include references to AI/generation tools (like "Bolt", "Jules", "Copilot").
 
 ## Subagents
 

--- a/backend/apps/core/services/storage_service.py
+++ b/backend/apps/core/services/storage_service.py
@@ -7,17 +7,32 @@ from apps.core.exceptions import BusinessRuleViolation
 
 
 class StorageService(Protocol):
-    """Protocolo definindo a interface para serviços de armazenamento de arquivos."""
+    """
+    Protocolo definindo a interface para serviços de armazenamento de arquivos.
+    """
 
     def generate_presigned_put_url(
         self, bucket: str, object_key: str, content_type: str, expires_in: int = 900
     ) -> str:
-        """Gera uma URL pré-assinada para upload direto via PUT."""
+        """
+        Gera uma URL pré-assinada para upload direto via PUT.
+
+        Args:
+            bucket: O nome do bucket de destino no storage.
+            object_key: O caminho/nome único do objeto no bucket.
+            content_type: O tipo MIME do arquivo (ex: application/pdf).
+            expires_in: O tempo de expiração da URL em segundos.
+
+        Returns:
+            A URL pré-assinada em formato de string.
+        """
         ...
 
 
 class CloudflareR2StorageService:
-    """Implementação concreta de StorageService usando Cloudflare R2/S3 via boto3."""
+    """
+    Implementação concreta de StorageService usando Cloudflare R2/S3 via boto3.
+    """
 
     def __init__(
         self,
@@ -26,6 +41,15 @@ class CloudflareR2StorageService:
         secret_access_key: str | None = None,
         region_name: str = "us-east-1",
     ):
+        """
+        Inicializa o serviço com credenciais explícitas ou defaults.
+
+        Args:
+            endpoint_url: URL de endpoint do R2 ou S3 compatível.
+            access_key_id: ID da chave de acesso do serviço de nuvem.
+            secret_access_key: Chave secreta de acesso do serviço.
+            region_name: O nome da região (default: us-east-1).
+        """
         self._endpoint_url = endpoint_url
         self._access_key_id = access_key_id
         self._secret_access_key = secret_access_key
@@ -33,6 +57,12 @@ class CloudflareR2StorageService:
 
     @property
     def endpoint_url(self) -> str | None:
+        """
+        Obtém a URL do endpoint a partir do settings do Django ou inicialização.
+
+        Returns:
+            A URL do endpoint ou None.
+        """
         return (
             self._endpoint_url
             or getattr(settings, "AWS_S3_ENDPOINT_URL", None)
@@ -41,6 +71,12 @@ class CloudflareR2StorageService:
 
     @property
     def access_key_id(self) -> str | None:
+        """
+        Obtém o ID da chave de acesso configurada.
+
+        Returns:
+            O ID da chave de acesso ou None.
+        """
         return (
             self._access_key_id
             or getattr(settings, "AWS_ACCESS_KEY_ID", None)
@@ -49,6 +85,12 @@ class CloudflareR2StorageService:
 
     @property
     def secret_access_key(self) -> str | None:
+        """
+        Obtém a chave de acesso secreta configurada.
+
+        Returns:
+            A chave de acesso secreta ou None.
+        """
         return (
             self._secret_access_key
             or getattr(settings, "AWS_SECRET_ACCESS_KEY", None)
@@ -59,7 +101,20 @@ class CloudflareR2StorageService:
         self, bucket: str, object_key: str, content_type: str, expires_in: int = 900
     ) -> str:
         """
-        Gera uma URL pré-assinada para upload de um objeto.
+        Gera uma URL pré-assinada para upload de um objeto no Cloudflare R2.
+
+        Args:
+            bucket: O nome do bucket de destino no storage.
+            object_key: O caminho/nome único do objeto no bucket.
+            content_type: O tipo MIME do arquivo (ex: image/png).
+            expires_in: Tempo em segundos para a URL expirar.
+
+        Returns:
+            A URL gerada para upload direto de arquivos via PUT.
+
+        Raises:
+            BusinessRuleViolation: Se as credenciais ou o bucket não
+                estiverem devidamente configurados no servidor.
         """
         if not all(
             [self.endpoint_url, self.access_key_id, self.secret_access_key, bucket]
@@ -91,8 +146,16 @@ class CloudflareR2StorageService:
 
 def get_storage_service() -> StorageService:
     """
-    Factory function para retornar a implementação ativa do StorageService
-    com base no provedor configurado no Django settings.
+    Retorna a implementação ativa do StorageService.
+
+    A escolha do provedor é feita com base no settings do Django.
+
+    Returns:
+        Uma instância concreta de StorageService correspondente.
+
+    Raises:
+        BusinessRuleViolation: Se o provedor configurado no settings
+            não for suportado.
     """
     provider = getattr(settings, "STORAGE_PROVIDER", "R2").upper()
 

--- a/backend/apps/finances/services/budget_category_service.py
+++ b/backend/apps/finances/services/budget_category_service.py
@@ -25,10 +25,17 @@ logger = logging.getLogger(__name__)
 def _validate_budget_cap(
     company: Company, category: BudgetCategory, budget: Budget
 ) -> None:
-    """
-    Valida que a soma do allocated_budget de todas as categorias não excede
-    o teto do orçamento mestre.
-    Executada DENTRO de um ``select_for_update()`` para evitar TOCTOU.
+    """Valida se a soma do allocated_budget das categorias não excede o teto.
+
+    Executada dentro de um select_for_update() para evitar TOCTOU.
+
+    Args:
+        company: O tenant atual para isolamento de dados.
+        category: A categoria de orçamento sendo validada.
+        budget: O orçamento mestre associado.
+
+    Raises:
+        BusinessRuleViolation: Se o limite do orçamento estimado for excedido.
     """
     siblings_agg = (
         BudgetCategory.objects.for_tenant(company)
@@ -49,18 +56,24 @@ def _validate_budget_cap(
 
 
 class BudgetCategoryService:
-    """
-    Camada de serviço para gestão de categorias de orçamento.
+    """Camada de serviço para gestão de categorias de orçamento.
+
     Validação de teto financeiro (_validate_budget_cap) executada com
-    select_for_update() para evitar TOCTOU.
+    select_for_update() para evitar TOCTOU (Time-of-Check to Time-of-Use).
     """
 
     @staticmethod
     def list(
         company: Company, wedding_id: UUID | None = None
     ) -> QuerySet[BudgetCategory]:
-        """
-        Lista categorias de orçamento de uma empresa.
+        """Lista categorias de orçamento de uma empresa.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            wedding_id: UUID do casamento para filtragem opcional.
+
+        Returns:
+            QuerySet[BudgetCategory]: QuerySet com as categorias de orçamento.
         """
         qs = (
             cast(BudgetCategoryQuerySet, BudgetCategory.objects.for_tenant(company))
@@ -73,6 +86,18 @@ class BudgetCategoryService:
 
     @staticmethod
     def get(company: Company, uuid: UUID | str) -> BudgetCategory:
+        """Obtém uma categoria de orçamento pelo seu UUID.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            uuid: O UUID da categoria de orçamento desejada.
+
+        Returns:
+            BudgetCategory: A instância da categoria encontrada.
+
+        Raises:
+            ObjectNotFoundError: Se a categoria não for encontrada.
+        """
         from django.core.exceptions import ValidationError
 
         from apps.core.exceptions import ObjectNotFoundError
@@ -92,6 +117,22 @@ class BudgetCategoryService:
     @staticmethod
     @transaction.atomic
     def create(company: Company, payload: BudgetCategoryIn) -> BudgetCategory:
+        """Cria uma nova categoria de orçamento.
+
+        Realiza o bloqueio do orçamento mestre correspondente para evitar
+        condições de corrida (TOCTOU) ao validar o teto.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            payload: Dados de entrada para criação da categoria.
+
+        Returns:
+            BudgetCategory: A instância da categoria criada.
+
+        Raises:
+            BusinessRuleViolation: Se exceder o teto do orçamento mestre.
+            ObjectNotFoundError: Se o orçamento mestre não for encontrado.
+        """
         logger.info(
             f"Iniciando criação de Categoria de Orçamento para company_id={company.id}"
         )
@@ -135,6 +176,22 @@ class BudgetCategoryService:
         instance: BudgetCategory,
         payload: BudgetCategoryPatchIn,
     ) -> BudgetCategory:
+        """Atualiza uma categoria de orçamento existente.
+
+        Garante o isolamento do tenant e re-valida o teto do orçamento mestre
+        sob lock (select_for_update).
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            instance: A instância da categoria de orçamento a ser atualizada.
+            payload: Dados parciais para atualização da categoria.
+
+        Returns:
+            BudgetCategory: A instância da categoria atualizada.
+
+        Raises:
+            BusinessRuleViolation: Se exceder o teto do orçamento mestre.
+        """
         validate_tenant_ownership(
             company,
             instance,
@@ -168,6 +225,18 @@ class BudgetCategoryService:
     @staticmethod
     @transaction.atomic
     def delete(company: Company, instance: BudgetCategory) -> None:
+        """Exclui uma categoria de orçamento existente.
+
+        Verifica se a categoria pertence ao tenant e se não possui despesas
+        ativas vinculadas, prevenindo quebras de integridade.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            instance: A instância da categoria de orçamento a ser excluída.
+
+        Raises:
+            DomainIntegrityError: Se a categoria possuir despesas vinculadas.
+        """
         validate_tenant_ownership(
             company,
             instance,
@@ -201,14 +270,15 @@ class BudgetCategoryService:
     @staticmethod
     @transaction.atomic
     def setup_defaults(company: Company, wedding: Wedding, budget: Budget) -> None:
-        """
-        Cria as categorias iniciais obrigatórias para um novo casamento.
-        É idempotente: se as categorias já existirem, não duplica.
+        """Cria as categorias iniciais obrigatórias para um novo casamento.
 
-        Nota de segurança (TOCTOU): espera-se que o budget esteja protegido
-        por ``select_for_update()`` no chamador (ex: get_or_create_for_wedding).
-        O ``ignore_conflicts=True`` no bulk_create protege contra o cenário
-        residual de chamada direta sem lock.
+        Método idempotente. Espera-se que o budget esteja protegido por
+        select_for_update() no chamador para evitar condições de corrida.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            wedding: A instância do casamento correspondente.
+            budget: A instância do orçamento mestre associado.
         """
         DEFAULT_CATEGORIES = [
             "Espaço e Buffet",

--- a/backend/apps/finances/services/budget_service.py
+++ b/backend/apps/finances/services/budget_service.py
@@ -20,13 +20,22 @@ logger = logging.getLogger(__name__)
 
 
 class BudgetService:
-    """
-    Camada de serviço para gestão do orçamento mestre.
-    Garante que cada casamento tenha exatamente UM teto financeiro (OneToOne).
+    """Camada de serviço para gestão do orçamento mestre.
+
+    Garante que cada casamento tenha exatamente um teto financeiro (OneToOne)
+    e isola a lógica de negócio por tenant.
     """
 
     @staticmethod
     def list(company: Company) -> QuerySet[Budget]:
+        """Lista os orçamentos de uma empresa.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+
+        Returns:
+            QuerySet[Budget]: QuerySet com os orçamentos contendo o gasto total.
+        """
         return (
             cast(BudgetQuerySet, Budget.objects.for_tenant(company))
             .with_total_spent()
@@ -35,6 +44,18 @@ class BudgetService:
 
     @staticmethod
     def get(company: Company, uuid: UUID | str) -> Budget:
+        """Obtém um orçamento específico pelo seu UUID.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            uuid: O UUID do orçamento desejado.
+
+        Returns:
+            Budget: A instância do orçamento encontrada.
+
+        Raises:
+            ObjectNotFoundError: Se o orçamento não for encontrado.
+        """
         try:
             return (
                 cast(BudgetQuerySet, Budget.objects.for_tenant(company))
@@ -52,6 +73,21 @@ class BudgetService:
     @staticmethod
     @transaction.atomic
     def create(company: Company, payload: BudgetIn) -> Budget:
+        """Cria um novo orçamento mestre para um casamento.
+
+        Garante que casamentos não tenham orçamentos duplicados (restrição
+        OneToOne).
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            payload: Dados de entrada para criação do orçamento.
+
+        Returns:
+            Budget: A instância do orçamento criada.
+
+        Raises:
+            DomainIntegrityError: Se o casamento já possuir um orçamento.
+        """
         logger.info(
             f"Iniciando criação de Orçamento Mestre para company_id={company.id}"
         )
@@ -99,6 +135,19 @@ class BudgetService:
     @staticmethod
     @transaction.atomic
     def update(company: Company, instance: Budget, payload: BudgetPatchIn) -> Budget:
+        """Atualiza um orçamento existente.
+
+        Garante o isolamento do tenant e valida as regras de negócios como
+        o validador de valor mínimo.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            instance: A instância do orçamento a ser atualizada.
+            payload: Dados parciais para atualização do orçamento.
+
+        Returns:
+            Budget: A instância do orçamento atualizada.
+        """
         validate_tenant_ownership(
             company,
             instance,
@@ -125,6 +174,18 @@ class BudgetService:
     @staticmethod
     @transaction.atomic
     def delete(company: Company, instance: Budget) -> None:
+        """Exclui um orçamento existente.
+
+        Verifica a propriedade do tenant e se o orçamento está protegido por
+        categorias ou despesas filhas antes de prosseguir com a exclusão.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            instance: A instância do orçamento a ser excluída.
+
+        Raises:
+            DomainIntegrityError: Se o orçamento possuir categorias ou despesas.
+        """
         validate_tenant_ownership(
             company,
             instance,
@@ -156,8 +217,17 @@ class BudgetService:
     @staticmethod
     @transaction.atomic
     def get_or_create_for_wedding(company: Company, wedding_uuid: UUID | str) -> Budget:
-        """
-        Retorna o Budget existente ou cria um novo para o Wedding especificado.
+        """Retorna o orçamento existente ou cria um novo para o casamento.
+
+        Se for criado, também gera automaticamente as categorias padrão
+        do orçamento sob lock (select_for_update) para evitar condições de corrida.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            wedding_uuid: O UUID do casamento associado.
+
+        Returns:
+            Budget: A instância do orçamento (existente ou recém-criado).
         """
         from apps.weddings.models import Wedding
 

--- a/backend/apps/finances/services/expense_service.py
+++ b/backend/apps/finances/services/expense_service.py
@@ -26,8 +26,8 @@ logger = logging.getLogger(__name__)
 
 
 class ExpenseService:
-    """
-    Camada de serviço para orquestração de Despesas.
+    """Camada de serviço para orquestração de Despesas.
+
     Garante que gastos reais respeitem o contexto do casamento, os contratos
     e assegura a rastreabilidade estrita da operação.
     """
@@ -36,6 +36,15 @@ class ExpenseService:
     def list(
         company: Company, wedding_id: UUID | str | None = None
     ) -> QuerySet[Expense]:
+        """Lista despesas de uma empresa.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            wedding_id: UUID ou string do casamento para filtragem opcional.
+
+        Returns:
+            QuerySet[Expense]: QuerySet com as despesas filtradas e detalhadas.
+        """
         qs = cast(ExpenseQuerySet, Expense.objects.for_tenant(company)).with_details()
         if wedding_id:
             qs = qs.filter(wedding__uuid=wedding_id)
@@ -43,6 +52,18 @@ class ExpenseService:
 
     @staticmethod
     def get(company: Company, uuid: UUID | str) -> Expense:
+        """Obtém uma despesa específica pelo seu UUID.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            uuid: O UUID da despesa desejada.
+
+        Returns:
+            Expense: A instância da despesa encontrada com detalhes.
+
+        Raises:
+            ObjectNotFoundError: Se a despesa não for encontrada.
+        """
         # Nota: with_details() é um método do manager customizado.
         # get_object_or_404_for_tenant usa objects.for_tenant(company).
         # Para manter with_details(), vamos fazer manualmente ou garantir que
@@ -60,6 +81,21 @@ class ExpenseService:
 
     @staticmethod
     def from_document(company: Company, contract_uuid: UUID | str) -> dict[str, Any]:
+        """Prepara dados para criar despesa a partir de um contrato.
+
+        Garante o preenchimento de campos obrigatórios com base nos valores
+        do contrato.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            contract_uuid: O UUID do contrato de origem.
+
+        Returns:
+            dict[str, Any]: Dicionário formatado contendo os dados sugeridos.
+
+        Raises:
+            ObjectNotFoundError: Se o contrato não for encontrado.
+        """
         contract = get_object_or_404_for_tenant(
             Contract,
             company,
@@ -85,6 +121,22 @@ class ExpenseService:
     @staticmethod
     @transaction.atomic
     def create(company: Company, payload: ExpenseIn) -> Expense:
+        """Cria uma nova despesa e gera suas parcelas correspondentes.
+
+        Valida se o valor total da despesa é idêntico ao total do contrato
+        associado (Regra BR-F02) e auto-gera pelo menos 1 parcela de pagamento.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            payload: Dados de entrada para criação da despesa.
+
+        Returns:
+            Expense: A instância da despesa criada.
+
+        Raises:
+            BusinessRuleViolation: Se infringir a regra BR-F02 ou as parcelas
+                forem inválidas.
+        """
         logger.info(f"Iniciando criação de Despesa para company_id={company.id}")
 
         data = payload.model_dump(exclude_unset=True)
@@ -175,7 +227,18 @@ class ExpenseService:
 
     @staticmethod
     def _validate_br_f02(instance: Expense, data: dict[str, Any]) -> None:
-        """BR-F02: despesa vinculada a contrato deve ter mesmo valor."""
+        """Valida a conformidade com a regra de negócio BR-F02.
+
+        Garante que o valor da despesa vinculada a um contrato seja exatamente
+        igual ao total do contrato.
+
+        Args:
+            instance: A instância da despesa sendo validada.
+            data: Dicionário contendo os dados atualizados para validação.
+
+        Raises:
+            BusinessRuleViolation: Se o valor da despesa diferir do valor do contrato.
+        """
         effective_contract = instance.contract
         effective_amount = data.get("actual_amount", instance.actual_amount)
         if effective_contract and effective_amount != effective_contract.total_amount:
@@ -192,7 +255,16 @@ class ExpenseService:
     def _resolve_contract(
         company: Company, instance: Expense, contract_input: Any
     ) -> None:
-        """Resolve contrato no update e atribui à instância."""
+        """Resolve e vincula um contrato a uma despesa no update.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            instance: A despesa que receberá a vinculação do contrato.
+            contract_input: Instância, UUID ou ID do contrato a ser resolvido.
+
+        Raises:
+            ObjectNotFoundError: Se o contrato especificado não for encontrado.
+        """
         if contract_input:
             if isinstance(contract_input, Contract):
                 instance.contract = contract_input
@@ -210,6 +282,23 @@ class ExpenseService:
     @staticmethod
     @transaction.atomic
     def update(company: Company, instance: Expense, payload: ExpensePatchIn) -> Expense:
+        """Atualiza os dados de uma despesa existente.
+
+        Trata a re-distribuição de parcelas caso o valor total ou a quantidade de
+        parcelas sejam alterados, validando a regra BR-F02 quando aplicável.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            instance: A instância da despesa a ser atualizada.
+            payload: Dados parciais de atualização da despesa.
+
+        Returns:
+            Expense: A instância da despesa atualizada.
+
+        Raises:
+            BusinessRuleViolation: Se a alteração de valor for bloqueada por parcelas
+                já pagas ou se violar a consistência do model.
+        """
         validate_tenant_ownership(
             company,
             instance,
@@ -288,6 +377,15 @@ class ExpenseService:
     @staticmethod
     @transaction.atomic
     def delete(company: Company, instance: Expense) -> None:
+        """Exclui uma despesa existente.
+
+        Previamente valida a propriedade pelo tenant. Exclui a despesa e remove
+        todas as parcelas vinculadas em cascata.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            instance: A instância da despesa a ser excluída.
+        """
         validate_tenant_ownership(
             company,
             instance,
@@ -311,6 +409,17 @@ class ExpenseService:
         num_installments: int,
         first_due_date: date | None,
     ) -> None:
+        """Gerencia o processo de redistribuição de parcelas de uma despesa.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            expense: A despesa associada que terá as parcelas redistribuídas.
+            num_installments: Novo número total de parcelas.
+            first_due_date: Data de vencimento da primeira parcela.
+
+        Raises:
+            BusinessRuleViolation: Se o número de parcelas for menor que 1.
+        """
         if num_installments < 1:
             raise BusinessRuleViolation(
                 detail="O número de parcelas deve ser pelo menos 1.",

--- a/backend/apps/finances/services/installment_service.py
+++ b/backend/apps/finances/services/installment_service.py
@@ -24,8 +24,8 @@ logger = logging.getLogger(__name__)
 
 
 class InstallmentService:
-    """
-    Camada de serviço para orquestração de Parcelas.
+    """Camada de serviço para orquestração de Parcelas.
+
     Garante o isolamento multitenant e a integridade da Tolerância Zero (ADR-010)
     nas despesas pai.
     """
@@ -42,12 +42,15 @@ class InstallmentService:
         """Lista parcelas com filtros opcionais.
 
         Args:
-            company: Tenant para isolamento multitenancy.
-            wedding_id: Filtra por casamento.
-            expense_id: Filtra por despesa.
-            status: Filtra por status (PENDING, PAID, OVERDUE).
-            due_date_gte: Filtra por data de vencimento >= este valor.
-            due_date_lte: Filtra por data de vencimento <= este valor.
+            company: O tenant atual para isolamento multitenancy.
+            wedding_id: UUID ou string do casamento para filtragem opcional.
+            expense_id: UUID ou string da despesa para filtragem opcional.
+            status: Status das parcelas (PENDING, PAID, OVERDUE).
+            due_date_gte: Data de vencimento inicial para intervalo de busca.
+            due_date_lte: Data de vencimento final para intervalo de busca.
+
+        Returns:
+            QuerySet[Installment]: QuerySet com as parcelas encontradas.
         """
         qs = Installment.objects.for_tenant(company).select_related(
             "expense", "wedding"
@@ -66,6 +69,18 @@ class InstallmentService:
 
     @staticmethod
     def get(company: Company, uuid: UUID | str) -> Installment:
+        """Obtém uma parcela específica pelo seu UUID.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            uuid: O UUID da parcela desejada.
+
+        Returns:
+            Installment: A instância da parcela encontrada.
+
+        Raises:
+            ObjectNotFoundError: Se a parcela não for encontrada.
+        """
         return get_object_or_404_for_tenant(
             Installment,
             company,
@@ -82,17 +97,29 @@ class InstallmentService:
         num_installments: int,
         first_due_date: date,
     ) -> list[Installment]:  # type: ignore[valid-type]
-        """
-        Gera automaticamente as parcelas de uma despesa com ajuste na última
-        parcela (Tolerância Zero).
+        """Gera parcelas de despesa com ajuste na última (Tolerância Zero).
 
-        Para cada parcela gerada, também cria um evento PAYMENT no scheduler
-        (BR-S01) para que o casal visualize os compromissos de pagamento no
-        calendário.
+        Para cada parcela gerada, cria um evento PAYMENT no scheduler (BR-S01)
+        para visualização dos compromissos de pagamento no calendário.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            expense: A despesa pai que receberá o parcelamento.
+            num_installments: Número total de parcelas (> 0).
+            first_due_date: Data de vencimento da primeira parcela.
+
+        Returns:
+            list[Installment]: Lista com as instâncias de parcelas salvas no
+                banco.
+
+        Raises:
+            BusinessRuleViolation: Se a despesa já possuir parcelas, se o
+                número de parcelas for <= 0, ou se o valor total da despesa for
+                inválido.
         """
         from datetime import timedelta
 
-        # Bloqueio de reentrada/duplicação (Copilot Review Fix)
+        # Bloqueio preventivo contra reentrada e duplicação de parcelas na despesa.
         if expense.installments.exists():
             raise BusinessRuleViolation(
                 detail=(
@@ -165,6 +192,24 @@ class InstallmentService:
         num_installments: int,
         first_due_date: date,
     ) -> list[Installment]:  # type: ignore[valid-type]
+        """Redistribui as parcelas de uma despesa.
+
+        Remove as parcelas anteriores (e seus respectivos eventos de pagamento)
+        e gera novas parcelas com novos valores e datas.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            expense: A despesa associada que terá as parcelas redistribuídas.
+            num_installments: Novo número total de parcelas.
+            first_due_date: Data de vencimento da primeira parcela.
+
+        Returns:
+            list[Installment]: Lista com as novas parcelas geradas.
+
+        Raises:
+            BusinessRuleViolation: Se existirem parcelas já pagas (status PAID)
+                na despesa.
+        """
         if expense.installments.filter(status="PAID").exists():
             raise BusinessRuleViolation(
                 detail=(
@@ -186,6 +231,22 @@ class InstallmentService:
     @staticmethod
     @transaction.atomic
     def create(company: Company, payload: InstallmentIn) -> Installment:
+        """Cria uma parcela individual avulsa.
+
+        Valida se a adição da nova parcela respeita a integridade matemática
+        da despesa (Tolerância Zero / ADR-010).
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            payload: Dados de entrada para a criação da parcela.
+
+        Returns:
+            Installment: A parcela criada.
+
+        Raises:
+            ObjectNotFoundError: Se a despesa correspondente não for encontrada.
+            BusinessRuleViolation: Se a criação violar o total da despesa pai.
+        """
         logger.info(f"Iniciando criação de Parcela para company_id={company.id}")
 
         data = payload.model_dump(exclude_unset=True)
@@ -240,6 +301,23 @@ class InstallmentService:
         instance: Installment,
         payload: InstallmentPatchIn,
     ) -> Installment:
+        """Atualiza os dados de uma parcela.
+
+        Revalida se as alterações mantêm a consistência matemática da despesa
+        pai.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            instance: A instância da parcela a ser atualizada.
+            payload: Dados parciais de atualização da parcela.
+
+        Returns:
+            Installment: A instância da parcela atualizada.
+
+        Raises:
+            BusinessRuleViolation: Se a alteração violar a regra Tolerância
+                Zero.
+        """
         validate_tenant_ownership(
             company,
             instance,
@@ -277,6 +355,22 @@ class InstallmentService:
     @staticmethod
     @transaction.atomic
     def mark_as_paid(company: Company, instance: Installment) -> Installment:
+        """Marca uma parcela como paga.
+
+        Garante a atualização de status para PAID e define a data de pagamento
+        como o dia corrente, revalidando a despesa pai.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            instance: A instância da parcela a ser paga.
+
+        Returns:
+            Installment: A parcela atualizada.
+
+        Raises:
+            BusinessRuleViolation: Se a parcela já estiver paga ou se a
+                transação violar a consistência matemática da despesa.
+        """
         validate_tenant_ownership(
             company,
             instance,
@@ -312,6 +406,22 @@ class InstallmentService:
     @staticmethod
     @transaction.atomic
     def unmark_as_paid(company: Company, instance: Installment) -> Installment:
+        """Desmarca uma parcela que foi definida como paga.
+
+        Remove a data de pagamento e redefine o status apropriado dependendo
+        da data de vencimento (PENDING ou OVERDUE).
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            instance: A instância da parcela a ser revertida.
+
+        Returns:
+            Installment: A parcela com status atualizado.
+
+        Raises:
+            BusinessRuleViolation: Se a parcela não estiver paga ou violar as
+                regras matemáticas da despesa pai.
+        """
         validate_tenant_ownership(
             company,
             instance,
@@ -352,6 +462,23 @@ class InstallmentService:
     def adjust(
         company: Company, instance: Installment, payload: InstallmentAdjustIn
     ) -> Installment:
+        """Ajusta o valor ou data de vencimento de uma parcela.
+
+        Garante que a nova data de vencimento respeite a sequência cronológica
+        das parcelas anterior e posterior, além de revalidar a despesa pai.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            instance: A instância da parcela a ser ajustada.
+            payload: Dados de ajuste da parcela.
+
+        Returns:
+            Installment: A instância da parcela ajustada.
+
+        Raises:
+            BusinessRuleViolation: Se a parcela estiver paga, se a data estiver
+                fora da cronologia sequencial ou se violar a soma da despesa pai.
+        """
         validate_tenant_ownership(
             company,
             instance,
@@ -429,6 +556,19 @@ class InstallmentService:
     @staticmethod
     @transaction.atomic
     def delete(company: Company, instance: Installment) -> None:
+        """Exclui uma parcela individual.
+
+        Remove o evento de pagamento associado no scheduler e revalida a
+        despesa pai.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            instance: A instância da parcela a ser excluída.
+
+        Raises:
+            DomainIntegrityError: Se a exclusão violar a integridade
+                matemática da despesa pai.
+        """
         validate_tenant_ownership(
             company,
             instance,
@@ -469,7 +609,12 @@ class InstallmentService:
 
 @transaction.atomic
 def _delete_payment_events_for_expense(company: Company, expense: Expense) -> None:
-    """Remove todos os eventos PAYMENT do scheduler vinculados a esta despesa."""
+    """Remove todos os eventos PAYMENT do scheduler vinculados a esta despesa.
+
+    Args:
+        company: O tenant atual para isolamento de dados.
+        expense: A despesa cujos eventos de pagamento serão removidos.
+    """
     from apps.scheduler.models import Event as SchedulerEvent
 
     SchedulerEvent.objects.for_tenant(company).filter(
@@ -481,7 +626,13 @@ def _delete_payment_events_for_expense(company: Company, expense: Expense) -> No
 
 @transaction.atomic
 def _delete_payment_event_for_single(company: Company, instance: Installment) -> None:
-    """Remove o evento PAYMENT vinculado a uma parcela específica."""
+    """Remove o evento PAYMENT vinculado a uma parcela específica.
+
+    Args:
+        company: O tenant atual para isolamento de dados.
+        instance: A parcela cujo evento de pagamento correspondente será
+            removido.
+    """
     from apps.scheduler.models import Event as SchedulerEvent
 
     SchedulerEvent.objects.for_tenant(company).filter(
@@ -497,11 +648,15 @@ def _create_payment_events(
     expense: Expense,
     installments: list[Installment],
 ) -> None:
-    """
-    Cria eventos PAYMENT no scheduler para cada parcela gerada.
+    """Cria eventos PAYMENT no scheduler para cada parcela gerada.
 
     Importação lazy do EventService para evitar circular imports.
     Ref: BR-S01 — Eventos PAYMENT são read-only no calendário.
+
+    Args:
+        company: O tenant atual para isolamento de dados.
+        expense: A despesa pai associada.
+        installments: Lista de parcelas que receberão eventos de pagamento.
     """
     from datetime import datetime, time
 

--- a/backend/apps/logistics/schemas.py
+++ b/backend/apps/logistics/schemas.py
@@ -144,8 +144,8 @@ class ContractOut(Schema):
 
     @staticmethod
     def resolve_expense_uuid(obj: "Contract") -> UUID4 | None:
-        # Bolt Optimization: Avoid eager getattr default evaluation and reverse O2O
-        # queries
+        # Otimização de performance: Evita a avaliação eager de getattr e queries
+        # reversas OneToOne.
         if hasattr(obj, "expense_id"):
             return obj.expense_id
 
@@ -160,7 +160,7 @@ class ContractOut(Schema):
 
     @staticmethod
     def resolve_supplier_name(obj: "Contract") -> str:
-        # Bolt Optimization: Use conditional to avoid eager default evaluation
+        # Otimização: Evita a avaliação eager do valor padrão usando getattr.
         val = getattr(obj, "supplier_name", None)
         if val is not None:
             return str(val)
@@ -182,7 +182,7 @@ class ContractOut(Schema):
 
     @staticmethod
     def resolve_has_linked_expense(obj: "Contract") -> bool:
-        # Bolt Optimization: Avoid reverse O2O query
+        # Otimização de performance: Evita a query reversa OneToOne.
         if hasattr(obj, "expense_id"):
             return bool(obj.expense_id)
 
@@ -208,7 +208,7 @@ class ContractOut(Schema):
 
     @staticmethod
     def resolve_addendums_count(obj: "Contract") -> int:
-        # Bolt Optimization: Avoid eager count query if annotated
+        # Otimização de performance: Evita a query de contagem se já estiver anotada.
         val = getattr(obj, "addendums_count", None)
         if val is not None:
             return int(val)

--- a/backend/apps/logistics/services/contract_service.py
+++ b/backend/apps/logistics/services/contract_service.py
@@ -43,7 +43,6 @@ from apps.weddings.models import Wedding
 
 _ItemInList = list[ItemIn]
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -220,7 +219,7 @@ class ContractService:
             A instância criada do Contract.
 
         Raises:
-            Http404: Se algum objeto relacionado (casamento, fornecedor
+            ObjectNotFoundError: Se algum objeto relacionado (casamento, fornecedor
                 ou contrato pai) não for encontrado para o tenant.
         """
         logger.info(f"Iniciando criação de Contrato para company_id={company.id}")
@@ -359,7 +358,7 @@ class ContractService:
         Raises:
             BusinessRuleViolation: Se houver tentativa de auto-vínculo,
                 casamentos divergentes ou vinculação cíclica.
-            Http404: Se o contrato pai não for encontrado para o tenant.
+            ObjectNotFoundError: Se o contrato pai não for encontrado para o tenant.
         """
         parent: Contract | None = None
         if isinstance(parent_input, Contract):
@@ -420,7 +419,7 @@ class ContractService:
 
         Raises:
             BusinessRuleViolation: Se a validação dos dados falhar.
-            Http404: Se o contrato ou relacionados não forem encontrados
+            ObjectNotFoundError: Se o contrato ou relacionados não forem encontrados
                 para o tenant.
         """
         validate_tenant_ownership(
@@ -503,7 +502,7 @@ class ContractService:
 
         Raises:
             DomainIntegrityError: Se houverem aditivos vinculados.
-            Http404: Se o contrato não pertencer ao tenant.
+            ObjectNotFoundError: Se o contrato não pertencer ao tenant.
         """
         validate_tenant_ownership(
             company,
@@ -553,7 +552,7 @@ class ContractService:
 
         Raises:
             BusinessRuleViolation: Se a transição for inválida.
-            Http404: Se o contrato não pertencer ao tenant.
+            ObjectNotFoundError: Se o contrato não pertencer ao tenant.
         """
         logger.info(
             f"Transição de status do Contrato uuid={instance.uuid}: "
@@ -594,7 +593,7 @@ class ContractService:
             A instância atualizada de Contract.
 
         Raises:
-            Http404: Se o contrato não for encontrado para o tenant.
+            ObjectNotFoundError: Se o contrato não for encontrado para o tenant.
         """
         logger.info(
             f"Associando chave de arquivo {pdf_file_key} ao contrato uuid={uuid}"
@@ -618,7 +617,7 @@ class ContractService:
             uuid: Identificador único (UUID ou string) do contrato.
 
         Raises:
-            Http404: Se o contrato não for encontrado para o tenant.
+            ObjectNotFoundError: Se o contrato não for encontrado para o tenant.
         """
         logger.info(f"Removendo arquivo do contrato uuid={uuid}")
         contract = ContractService.get(company, uuid)
@@ -650,7 +649,7 @@ class ContractService:
         Raises:
             BusinessRuleViolation: Se a configuração do storage
                 estiver incompleta no servidor.
-            Http404: Se o casamento não for encontrado para o tenant.
+            ObjectNotFoundError: Se o casamento não for encontrado para o tenant.
         """
         import uuid
 

--- a/backend/apps/logistics/services/contract_service.py
+++ b/backend/apps/logistics/services/contract_service.py
@@ -53,19 +53,40 @@ class ContractService:
     """
     Camada de serviço para gestão de contratos.
     Foco: Orquestração, Multitenancy Segura e Auditoria.
-    Validações de integridade do dado (ex: datas inválidas) ficam delegadas ao Model.
+    Validações de integridade do dado ficam delegadas ao Model.
     """
 
+    # Injeção de dependência para desacoplar a infraestrutura de Storage (R2/S3).
+    # Permite que testes unitários injetem mocks para evitar chamadas de rede e
+    # dependências de configurações reais de ambiente.
     _storage_service: StorageService | None = None
 
     @classmethod
     def get_storage_client(cls) -> StorageService:
+        """
+        Retorna o cliente de storage ativo.
+
+        Se nenhuma dependência foi injetada anteriormente, inicializa a
+        implementação padrão obtida a partir do app core.
+
+        Returns:
+            A instância ativa de StorageService.
+        """
         if cls._storage_service is None:
             cls._storage_service = get_storage_service()
         return cls._storage_service
 
     @classmethod
     def set_storage_service(cls, storage_service: StorageService) -> None:
+        """
+        Injeta uma instância de StorageService.
+
+        Utilizado para fins de testes ou substituição de infraestrutura
+        em runtime.
+
+        Args:
+            storage_service: Instância customizada ou mock de StorageService.
+        """
         cls._storage_service = storage_service
 
     @staticmethod
@@ -76,6 +97,23 @@ class ContractService:
         supplier_id: UUID | str | None = None,
         parent_id: UUID | str | None = None,
     ) -> QuerySet[Contract]:
+        """
+        Lista os contratos pertencentes ao tenant com filtros aplicados.
+
+        Aplica otimizações de banco de dados (select_related e subqueries)
+        para evitar queries redundantes ao carregar dados do fornecedor,
+        despesas e contagem de aditivos.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            wedding_id: Identificador do casamento para filtragem.
+            status: Status do contrato (ex: DRAFT, SIGNED).
+            supplier_id: Identificador do fornecedor associado.
+            parent_id: Identificador do contrato pai (aditivo).
+
+        Returns:
+            QuerySet contendo os contratos filtrados e anotados.
+        """
         qs = (
             Contract.objects.for_tenant(company)
             .select_related("supplier", "wedding", "parent")
@@ -97,7 +135,8 @@ class ContractService:
                     ),
                     Value(Decimal("0.00")),
                 ),
-                # Bolt Optimization: Use Subquery for count to avoid join explosion
+                # Otimização: Uso de Subquery para contagem para evitar a
+                # explosão de JOINs.
                 addendums_count=Coalesce(
                     Subquery(
                         Contract.objects.filter(parent=OuterRef("pk"))
@@ -121,13 +160,29 @@ class ContractService:
 
     @staticmethod
     def get(company: Company, uuid: UUID | str) -> Contract:
-        """Busca um contrato com annotations detalhadas."""
+        """
+        Busca um contrato específico pertencente ao tenant.
+
+        Garante a separação multitenant e anota contagem de aditivos
+        e despesa vinculada para evitar queries N+1.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            uuid: Identificador único (UUID ou string) do contrato.
+
+        Returns:
+            A instância do Contract correspondente.
+
+        Raises:
+            ObjectNotFoundError: Se o contrato não for encontrado.
+        """
         try:
             return (
                 Contract.objects.for_tenant(company)
                 .select_related("supplier", "wedding", "parent")
                 .annotate(
-                    # Bolt Optimization: Use Subquery for count to avoid join explosion
+                    # Otimização: Uso de Subquery para contagem para evitar a
+                    # explosão de JOINs.
                     addendums_count=Coalesce(
                         Subquery(
                             Contract.objects.filter(parent=OuterRef("pk"))
@@ -151,6 +206,23 @@ class ContractService:
     @staticmethod
     @transaction.atomic
     def create(company: Company, payload: ContractIn) -> Contract:
+        """
+        Cria um contrato básico no banco de dados.
+
+        Resolve as chaves estrangeiras de casamento, fornecedor e
+        contrato pai correspondentes ao tenant informado.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            payload: Objeto de entrada contendo os dados do contrato.
+
+        Returns:
+            A instância criada do Contract.
+
+        Raises:
+            Http404: Se algum objeto relacionado (casamento, fornecedor
+                ou contrato pai) não for encontrado para o tenant.
+        """
         logger.info(f"Iniciando criação de Contrato para company_id={company.id}")
 
         data = payload.model_dump(exclude_unset=True)
@@ -221,11 +293,20 @@ class ContractService:
     ) -> Contract:
         """
         Orquestra a criação completa de um contrato.
-        Cria o contrato base, associa opcionalmente a chave do arquivo PDF/imagem
-        do R2/S3,
-        cria os itens logísticos associados e inicializa o fluxo de despesa
-        financeira correspondente.
-        Em caso de falha em qualquer etapa, garante o rollback no banco.
+
+        Cria o contrato básico, anexa o PDF/imagem e, opcionalmente,
+        cria itens logísticos e a despesa correspondente. Se qualquer
+        etapa falhar, o rollback é efetuado.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            contract_data: Dados básicos do contrato.
+            items_data: Lista opcional de itens a serem criados.
+            expense_data: Dados opcionais da despesa para parcelamento.
+            pdf_file_key: Chave do arquivo PDF/imagem salvo no storage.
+
+        Returns:
+            A instância do Contract criada e totalmente populada.
         """
         logger.info(
             f"Iniciando criação completa de Contrato para company_id={company.id}"
@@ -254,8 +335,8 @@ class ContractService:
                 company=company,
                 payload=expense_data.model_copy(update={"contract": contract.uuid}),
             )
-            # Bolt Optimization: Manually populate the reverse O2O cache and expense_id
-            # to ensure immediate serialization in resolvers remains query-free.
+            # Otimização: Popula manualmente o cache reverso OneToOne e o expense_id
+            # para garantir que a serialização nos resolvers seja livre de queries.
             contract.expense = expense
             contract.expense_id = expense.uuid  # type: ignore[attr-defined]
 
@@ -266,6 +347,20 @@ class ContractService:
     def _resolve_parent(
         company: Company, instance: Contract, parent_input: Any
     ) -> None:
+        """
+        Resolve o contrato pai e valida regras de hierarquia de contratos.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            instance: O contrato em edição que receberá o pai.
+            parent_input: Instância, UUID, string do contrato pai,
+                ou string vazia para remover vínculo.
+
+        Raises:
+            BusinessRuleViolation: Se houver tentativa de auto-vínculo,
+                casamentos divergentes ou vinculação cíclica.
+            Http404: Se o contrato pai não for encontrado para o tenant.
+        """
         parent: Contract | None = None
         if isinstance(parent_input, Contract):
             parent = parent_input
@@ -309,6 +404,25 @@ class ContractService:
     def update(
         company: Company, instance: Contract, payload: ContractPatchIn
     ) -> Contract:
+        """
+        Atualiza dados de um contrato do tenant.
+
+        Garante a validação de acesso ao tenant, além de resolver as
+        referências de fornecedor, contrato pai e status.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            instance: A instância do Contract a ser atualizada.
+            payload: Dados de alteração parcial para atualização.
+
+        Returns:
+            A instância de Contract atualizada.
+
+        Raises:
+            BusinessRuleViolation: Se a validação dos dados falhar.
+            Http404: Se o contrato ou relacionados não forem encontrados
+                para o tenant.
+        """
         validate_tenant_ownership(
             company,
             instance,
@@ -360,6 +474,15 @@ class ContractService:
 
     @staticmethod
     def _apply_fields(instance: Contract, data: dict[str, Any]) -> None:
+        """
+        Aplica campos simples de dicionário na instância do contrato.
+
+        Ignora o campo de arquivo caso seja explicitamente None.
+
+        Args:
+            instance: A instância de Contract que receberá as alterações.
+            data: Dicionário mapeando os campos do model a valores.
+        """
         for field, value in data.items():
             if field == "pdf_file" and value is None:
                 continue
@@ -368,6 +491,20 @@ class ContractService:
     @staticmethod
     @transaction.atomic
     def delete(company: Company, instance: Contract) -> None:
+        """
+        Remove um contrato e suas dependências físicas.
+
+        Desvincula os itens logísticos órfãos e remove o arquivo físico.
+        Valida a propriedade do tenant antes de excluir.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            instance: A instância do Contract a ser removida.
+
+        Raises:
+            DomainIntegrityError: Se houverem aditivos vinculados.
+            Http404: Se o contrato não pertencer ao tenant.
+        """
         validate_tenant_ownership(
             company,
             instance,
@@ -403,6 +540,21 @@ class ContractService:
     def transition_status(
         company: Company, instance: Contract, new_status: str
     ) -> Contract:
+        """
+        Executa a transição de status do contrato.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            instance: A instância do Contract a ter o status alterado.
+            new_status: O novo status desejado para o contrato.
+
+        Returns:
+            A instância atualizada de Contract.
+
+        Raises:
+            BusinessRuleViolation: Se a transição for inválida.
+            Http404: Se o contrato não pertencer ao tenant.
+        """
         logger.info(
             f"Transição de status do Contrato uuid={instance.uuid}: "
             f"{instance.status} -> {new_status}"
@@ -431,7 +583,18 @@ class ContractService:
     @transaction.atomic
     def upload_file(company: Company, uuid: UUID | str, pdf_file_key: str) -> Contract:
         """
-        Associa a chave do arquivo (pdf_file_key) carregado no R2/S3 ao contrato.
+        Associa uma chave de arquivo já carregada no storage ao contrato.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            uuid: Identificador único (UUID ou string) do contrato.
+            pdf_file_key: A chave do objeto de arquivo salva no storage.
+
+        Returns:
+            A instância atualizada de Contract.
+
+        Raises:
+            Http404: Se o contrato não for encontrado para o tenant.
         """
         logger.info(
             f"Associando chave de arquivo {pdf_file_key} ao contrato uuid={uuid}"
@@ -446,7 +609,16 @@ class ContractService:
     @transaction.atomic
     def delete_file(company: Company, uuid: UUID | str) -> None:
         """
-        Remove o arquivo vinculado ao contrato.
+        Remove a associação de arquivo físico do contrato.
+
+        Deleta o arquivo físico do storage caso exista.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            uuid: Identificador único (UUID ou string) do contrato.
+
+        Raises:
+            Http404: Se o contrato não for encontrado para o tenant.
         """
         logger.info(f"Removendo arquivo do contrato uuid={uuid}")
         contract = ContractService.get(company, uuid)
@@ -464,7 +636,21 @@ class ContractService:
         storage_service: StorageService | None = None,
     ) -> dict[str, Any]:
         """
-        Gera presigned URL para upload de contrato no R2/S3.
+        Gera presigned URL para upload direto de contrato no R2/S3.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            filename: Nome do arquivo original a ser carregado.
+            wedding_id: Identificador único do casamento associado.
+            storage_service: Serviço de storage opcional para injeção.
+
+        Returns:
+            Dicionário contendo a 'upload_url' e a 'object_key'.
+
+        Raises:
+            BusinessRuleViolation: Se a configuração do storage
+                estiver incompleta no servidor.
+            Http404: Se o casamento não for encontrado para o tenant.
         """
         import uuid
 

--- a/backend/apps/logistics/services/item_service.py
+++ b/backend/apps/logistics/services/item_service.py
@@ -83,7 +83,7 @@ class ItemService:
             O objeto Item correspondente.
 
         Raises:
-            Http404: Se o item não for encontrado ou não pertencer
+            ObjectNotFoundError: Se o item não for encontrado ou não pertencer
                 ao tenant.
         """
         return get_object_or_404_for_tenant(
@@ -111,7 +111,7 @@ class ItemService:
             A instância resolvida do casamento, ou None se não fornecido.
 
         Raises:
-            Http404: Se o casamento não for encontrado para o tenant.
+            ObjectNotFoundError: Se o casamento não for encontrado para o tenant.
         """
         if not wedding_input:
             return None
@@ -148,7 +148,7 @@ class ItemService:
             A instância resolvida do contrato, ou None se não fornecido.
 
         Raises:
-            Http404: Se o contrato não for encontrado para o tenant.
+            ObjectNotFoundError: Se o contrato não for encontrado para o tenant.
         """
         if not contract_input:
             return None
@@ -245,7 +245,7 @@ class ItemService:
         Raises:
             DomainIntegrityError: Se o novo contrato informado não pertencer
                 ao casamento do item.
-            Http404: Se o item não pertencer ao tenant.
+            ObjectNotFoundError: Se o item não pertencer ao tenant.
         """
         validate_tenant_ownership(
             company,
@@ -290,7 +290,7 @@ class ItemService:
             instance: A instância do Item a ser removida.
 
         Raises:
-            Http404: Se o item não pertencer ao tenant.
+            ObjectNotFoundError: Se o item não pertencer ao tenant.
         """
         validate_tenant_ownership(
             company,
@@ -327,7 +327,7 @@ class ItemService:
         Raises:
             BusinessRuleViolation: Se a transição de status for inválida
                 segundo as regras de validação do modelo.
-            Http404: Se o item não pertencer ao tenant.
+            ObjectNotFoundError: Se o item não pertencer ao tenant.
         """
         validate_tenant_ownership(
             company,

--- a/backend/apps/logistics/services/item_service.py
+++ b/backend/apps/logistics/services/item_service.py
@@ -39,6 +39,22 @@ class ItemService:
         search: str | None = None,
         contract_id: UUID | str | None = None,
     ) -> QuerySet[Item]:
+        """
+        Lista os itens de logística pertencentes ao tenant.
+
+        Permite filtrar os itens por casamento, status de aquisição, termo
+        de busca no nome do item ou contrato associado.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            wedding_id: Identificador único (UUID ou string) do casamento.
+            status: Status de aquisição do item para filtragem.
+            search: Termo de busca para busca parcial no nome do item.
+            contract_id: Identificador único (UUID ou string) do contrato.
+
+        Returns:
+            QuerySet contendo os itens que atendem aos filtros aplicados.
+        """
         qs = Item.objects.for_tenant(company).select_related(
             "wedding", "contract", "contract__supplier"
         )
@@ -54,6 +70,22 @@ class ItemService:
 
     @staticmethod
     def get(company: Company, uuid: UUID | str) -> Item:
+        """
+        Recupera um item de logística específico pelo UUID.
+
+        Realiza a busca garantindo o isolamento multitenant.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            uuid: Identificador único (UUID ou string) do item.
+
+        Returns:
+            O objeto Item correspondente.
+
+        Raises:
+            Http404: Se o item não for encontrado ou não pertencer
+                ao tenant.
+        """
         return get_object_or_404_for_tenant(
             Item,
             company,
@@ -67,7 +99,19 @@ class ItemService:
         company: Company, wedding_input: UUID | str | Wedding | None
     ) -> Wedding | None:
         """
-        Resolve um casamento (instância, UUID ou string) garantindo multi-tenancy.
+        Resolve um casamento garantindo o isolamento multitenant.
+
+        Aceita uma instância de Wedding, UUID ou string identificadora.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            wedding_input: Instância, UUID ou string do casamento.
+
+        Returns:
+            A instância resolvida do casamento, ou None se não fornecido.
+
+        Raises:
+            Http404: Se o casamento não for encontrado para o tenant.
         """
         if not wedding_input:
             return None
@@ -92,7 +136,19 @@ class ItemService:
         company: Company, contract_input: UUID | str | Contract | None
     ) -> Contract | None:
         """
-        Resolve um contrato (instância, UUID ou string) garantindo multi-tenancy.
+        Resolve um contrato garantindo o isolamento multitenant.
+
+        Aceita uma instância de Contract, UUID ou string identificadora.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            contract_input: Instância, UUID ou string do contrato.
+
+        Returns:
+            A instância resolvida do contrato, ou None se não fornecido.
+
+        Raises:
+            Http404: Se o contrato não for encontrado para o tenant.
         """
         if not contract_input:
             return None
@@ -110,6 +166,26 @@ class ItemService:
     @staticmethod
     @transaction.atomic
     def create(company: Company, payload: ItemIn) -> Item:
+        """
+        Cria um novo item de logística associado ao tenant.
+
+        Garante que o item esteja vinculado a um casamento válido e,
+        se houver contrato associado, valida a correspondência do
+        casamento com o do contrato.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            payload: Dados de entrada para criação do item.
+
+        Returns:
+            A instância do Item criada e salva no banco.
+
+        Raises:
+            DomainIntegrityError: Se o casamento do item não coincidir
+                com o casamento do contrato informado.
+            BusinessRuleViolation: Se nem o casamento nem o contrato
+                forem informados.
+        """
         logger.info(f"Iniciando criação de Item para company_id={company.id}")
 
         data = payload.model_dump(exclude_unset=True)
@@ -152,6 +228,25 @@ class ItemService:
     @staticmethod
     @transaction.atomic
     def update(company: Company, instance: Item, payload: ItemPatchIn) -> Item:
+        """
+        Atualiza os dados de um item de logística existente.
+
+        Valida a propriedade do tenant antes da alteração e garante
+        que o contrato informado pertença ao mesmo casamento do item.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            instance: A instância atual do Item a ser atualizada.
+            payload: Dados parciais para atualização do item.
+
+        Returns:
+            A instância atualizada do Item.
+
+        Raises:
+            DomainIntegrityError: Se o novo contrato informado não pertencer
+                ao casamento do item.
+            Http404: Se o item não pertencer ao tenant.
+        """
         validate_tenant_ownership(
             company,
             instance,
@@ -185,6 +280,18 @@ class ItemService:
     @staticmethod
     @transaction.atomic
     def delete(company: Company, instance: Item) -> None:
+        """
+        Remove um item de logística do banco de dados.
+
+        Verifica a propriedade do tenant antes de efetuar a exclusão.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            instance: A instância do Item a ser removida.
+
+        Raises:
+            Http404: Se o item não pertencer ao tenant.
+        """
         validate_tenant_ownership(
             company,
             instance,
@@ -204,6 +311,24 @@ class ItemService:
     @staticmethod
     @transaction.atomic
     def transition_status(company: Company, instance: Item, new_status: str) -> Item:
+        """
+        Realiza a transição do status de aquisição de um item.
+
+        Valida as regras de transição e a propriedade do tenant.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            instance: A instância do Item a ter o status alterado.
+            new_status: O novo status desejado para o item.
+
+        Returns:
+            A instância do Item com o status atualizado.
+
+        Raises:
+            BusinessRuleViolation: Se a transição de status for inválida
+                segundo as regras de validação do modelo.
+            Http404: Se o item não pertencer ao tenant.
+        """
         validate_tenant_ownership(
             company,
             instance,

--- a/backend/apps/logistics/services/supplier_service.py
+++ b/backend/apps/logistics/services/supplier_service.py
@@ -69,7 +69,8 @@ class SupplierService:
             A instância do Supplier correspondente.
 
         Raises:
-            Http404: Se o fornecedor não for encontrado ou acesso for negado.
+            ObjectNotFoundError: Se o fornecedor não for encontrado ou acesso
+                for negado.
         """
         return get_object_or_404_for_tenant(
             Supplier,
@@ -125,7 +126,7 @@ class SupplierService:
             A instância atualizada do Supplier.
 
         Raises:
-            Http404: Se o fornecedor não pertencer ao tenant.
+            ObjectNotFoundError: Se o fornecedor não pertencer ao tenant.
         """
         validate_tenant_ownership(
             company,
@@ -160,7 +161,7 @@ class SupplierService:
             instance: A instância do Supplier a ser removida.
 
         Raises:
-            Http404: Se o fornecedor não pertencer ao tenant.
+            ObjectNotFoundError: Se o fornecedor não pertencer ao tenant.
         """
         validate_tenant_ownership(
             company,

--- a/backend/apps/logistics/services/supplier_service.py
+++ b/backend/apps/logistics/services/supplier_service.py
@@ -28,6 +28,20 @@ class SupplierService:
         search: str = "",
         is_active: bool | None = None,
     ) -> QuerySet[Supplier]:
+        """
+        Lista os fornecedores associados ao tenant.
+
+        Permite filtrar os fornecedores por termo de busca geral (nome,
+        e-mail, telefone ou CNPJ) e status ativo/inativo.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            search: Termo para busca parcial nos campos do fornecedor.
+            is_active: Filtro opcional pelo status ativo/inativo.
+
+        Returns:
+            QuerySet contendo os fornecedores correspondentes.
+        """
         qs = Supplier.objects.for_tenant(company)
         if search:
             qs = qs.filter(
@@ -42,6 +56,21 @@ class SupplierService:
 
     @staticmethod
     def get(company: Company, uuid: UUID | str) -> Supplier:
+        """
+        Recupera um fornecedor específico pelo UUID.
+
+        Garante o isolamento por tenant na busca.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            uuid: Identificador único (UUID ou string) do fornecedor.
+
+        Returns:
+            A instância do Supplier correspondente.
+
+        Raises:
+            Http404: Se o fornecedor não for encontrado ou acesso for negado.
+        """
         return get_object_or_404_for_tenant(
             Supplier,
             company,
@@ -53,6 +82,18 @@ class SupplierService:
     @staticmethod
     @transaction.atomic
     def create(company: Company, payload: SupplierIn) -> Supplier:
+        """
+        Cria um novo fornecedor para o tenant.
+
+        Aplica as validações do modelo ao salvar.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            payload: Dados de entrada para criação do fornecedor.
+
+        Returns:
+            A instância do Supplier criada e salva.
+        """
         logger.info(f"Iniciando criação de Fornecedor para company_id={company.id}")
 
         data = payload.model_dump(exclude_unset=True)
@@ -70,6 +111,22 @@ class SupplierService:
     def update(
         company: Company, instance: Supplier, payload: SupplierPatchIn
     ) -> Supplier:
+        """
+        Atualiza os dados de um fornecedor existente.
+
+        Valida a propriedade do tenant antes de aplicar e salvar as alterações.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            instance: A instância do Supplier a ser atualizada.
+            payload: Dados parciais para atualização do fornecedor.
+
+        Returns:
+            A instância atualizada do Supplier.
+
+        Raises:
+            Http404: Se o fornecedor não pertencer ao tenant.
+        """
         validate_tenant_ownership(
             company,
             instance,
@@ -93,6 +150,18 @@ class SupplierService:
     @staticmethod
     @transaction.atomic
     def delete(company: Company, instance: Supplier) -> None:
+        """
+        Remove um fornecedor do banco de dados.
+
+        Valida a propriedade do tenant antes da exclusão.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            instance: A instância do Supplier a ser removida.
+
+        Raises:
+            Http404: Se o fornecedor não pertencer ao tenant.
+        """
         validate_tenant_ownership(
             company,
             instance,

--- a/backend/apps/scheduler/services/events.py
+++ b/backend/apps/scheduler/services/events.py
@@ -27,6 +27,17 @@ class EventService:
 
     @staticmethod
     def list(company: Company, wedding_id: UUID | str | None = None) -> QuerySet[Event]:
+        """
+        Lista todos os eventos vinculados ao tenant (Company).
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            wedding_id: UUID ou string identificadora do casamento
+                (opcional, para filtragem).
+
+        Returns:
+            QuerySet contendo os eventos filtrados da empresa.
+        """
         qs = Event.objects.for_tenant(company).select_related("wedding")
         if wedding_id:
             qs = qs.filter(wedding__uuid=wedding_id)
@@ -34,6 +45,20 @@ class EventService:
 
     @staticmethod
     def get(company: Company, uuid: UUID | str) -> Event:
+        """
+        Recupera um evento específico pelo seu UUID, garantindo o tenant.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            uuid: O identificador único do evento.
+
+        Returns:
+            A instância do Event localizado.
+
+        Raises:
+            ObjectNotFoundError: Se o evento não for encontrado ou pertencer
+                a outro tenant.
+        """
         return get_object_or_404_for_tenant(
             Event,
             company,
@@ -50,6 +75,24 @@ class EventService:
         *,
         _caller_internal: bool = False,
     ) -> Event:
+        """
+        Cria um novo evento para o tenant especificado.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            payload: Dados de entrada para criação do evento (EventIn ou dict).
+            _caller_internal: Flag interna indicando se a chamada foi originada
+                por outro serviço do sistema (permite bypass de regras de negócio).
+
+        Returns:
+            O evento criado e salvo no banco de dados.
+
+        Raises:
+            BusinessRuleViolation: Se for tentada a criação manual de um evento
+                de pagamento (_caller_internal=False).
+            ObjectNotFoundError: Se o casamento associado não for encontrado ou
+                pertencer a outro tenant.
+        """
         logger.info(f"Iniciando criação de Evento para company_id={company.id}")
 
         if isinstance(payload, dict):
@@ -96,6 +139,22 @@ class EventService:
     @staticmethod
     @transaction.atomic
     def update(company: Company, instance: Event, payload: EventPatchIn) -> Event:
+        """
+        Atualiza as informações de um evento existente.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            instance: A instância do evento a ser atualizada.
+            payload: Dados com as alterações a serem aplicadas.
+
+        Returns:
+            A instância do evento atualizada.
+
+        Raises:
+            ObjectNotFoundError: Se o evento pertencer a outro tenant.
+            BusinessRuleViolation: Se o evento for de pagamento ou se for
+                tentada a alteração do tipo para pagamento.
+        """
         validate_tenant_ownership(
             company,
             instance,
@@ -141,6 +200,17 @@ class EventService:
     @staticmethod
     @transaction.atomic
     def delete(company: Company, instance: Event) -> None:
+        """
+        Exclui um evento existente.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            instance: A instância do evento a ser excluída.
+
+        Raises:
+            ObjectNotFoundError: Se o evento pertencer a outro tenant.
+            BusinessRuleViolation: Se o evento for do tipo pagamento.
+        """
         validate_tenant_ownership(
             company,
             instance,

--- a/backend/apps/scheduler/services/tasks.py
+++ b/backend/apps/scheduler/services/tasks.py
@@ -23,6 +23,17 @@ class TaskService:
 
     @staticmethod
     def list(company: Company, wedding_id: UUID | str | None = None) -> QuerySet[Task]:
+        """
+        Lista todas as tarefas vinculadas ao tenant (Company).
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            wedding_id: UUID ou string identificadora do casamento
+                (opcional, para filtragem).
+
+        Returns:
+            QuerySet contendo as tarefas filtradas da empresa.
+        """
         qs = Task.objects.for_tenant(company).select_related("wedding")
         if wedding_id:
             qs = qs.filter(wedding__uuid=wedding_id)
@@ -30,6 +41,20 @@ class TaskService:
 
     @staticmethod
     def get(company: Company, uuid: UUID | str) -> Task:
+        """
+        Recupera uma tarefa específica pelo seu UUID, garantindo o tenant.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            uuid: O identificador único da tarefa.
+
+        Returns:
+            A instância da Task localizada.
+
+        Raises:
+            ObjectNotFoundError: Se a tarefa não for encontrada ou pertencer
+                a outro tenant.
+        """
         return get_object_or_404_for_tenant(
             Task,
             company,
@@ -41,6 +66,20 @@ class TaskService:
     @staticmethod
     @transaction.atomic
     def create(company: Company, payload: TaskIn) -> Task:
+        """
+        Cria uma nova tarefa para o tenant especificado.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            payload: Dados de entrada para criação da tarefa.
+
+        Returns:
+            A tarefa criada e salva no banco de dados.
+
+        Raises:
+            ObjectNotFoundError: Se o casamento associado não for encontrado ou
+                pertencer a outro tenant.
+        """
         logger.info(f"Iniciando criação de Tarefa para company_id={company.id}")
 
         data = payload.model_dump(exclude_unset=True)
@@ -69,6 +108,20 @@ class TaskService:
     @staticmethod
     @transaction.atomic
     def update(company: Company, instance: Task, payload: TaskPatchIn) -> Task:
+        """
+        Atualiza as informações de uma tarefa existente.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            instance: A instância da tarefa a ser atualizada.
+            payload: Dados com as alterações a serem aplicadas.
+
+        Returns:
+            A instância da tarefa atualizada.
+
+        Raises:
+            ObjectNotFoundError: Se a tarefa pertencer a outro tenant.
+        """
         validate_tenant_ownership(
             company,
             instance,
@@ -92,6 +145,16 @@ class TaskService:
     @staticmethod
     @transaction.atomic
     def delete(company: Company, instance: Task) -> None:
+        """
+        Exclui uma tarefa existente.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            instance: A instância da tarefa a ser excluída.
+
+        Raises:
+            ObjectNotFoundError: Se a tarefa pertencer a outro tenant.
+        """
         validate_tenant_ownership(
             company,
             instance,
@@ -105,5 +168,5 @@ class TaskService:
 
         instance.delete()
         logger.warning(
-            f"Tarefa uuid={instance.uuid} DESTRUÍDA por company_id={company.id}"
+            f"Tarefa uuid={instance.uuid} DESTRUÍDO por company_id={company.id}"
         )

--- a/backend/apps/scheduler/services/templates.py
+++ b/backend/apps/scheduler/services/templates.py
@@ -166,12 +166,17 @@ TEMPLATE_CHOICES: list[str] = list(TEMPLATES.keys())
 
 def get_template_events(template_name: str) -> list[dict[str, Any]]:
     """
-    Retorna a lista de eventos do template solicitado.
+    Retorna a lista de eventos pré-definidos do template solicitado.
 
-    Cada evento contém: title, event_type, offset_days.
+    Args:
+        template_name: O nome identificador do template de cronograma.
+
+    Returns:
+        Lista contendo dicionários representativos dos eventos do template,
+        com as chaves `title`, `event_type` e `offset_days`.
 
     Raises:
-        BusinessRuleViolation: Se o template não existir.
+        BusinessRuleViolation: Se o template solicitado não for encontrado.
     """
     template = TEMPLATES.get(template_name)
     if template is None:

--- a/backend/apps/tenants/services/tenant_service.py
+++ b/backend/apps/tenants/services/tenant_service.py
@@ -11,19 +11,32 @@ logger = logging.getLogger(__name__)
 
 
 class TenantService:
-    """Serviço responsável pela gestão de tenants (Workspaces/Empresas)."""
+    """
+    Serviço responsável pela gestão de tenants (Workspaces/Empresas).
+
+    Centraliza a lógica de criação de workspaces e a inicialização de
+    tenants para isolamento de dados no sistema.
+    """
 
     @staticmethod
     @transaction.atomic
     def create_company(display_name: str, company_name: str = "") -> Company:
         """
         Cria uma Company com base no nome do usuário ou email.
-        Se company_name for fornecido, usa-o diretamente como nome da empresa.
-        Retorna a instância da empresa salva.
+
+        Gera um slug único e curto para evitar colisões e cria o tenant no
+        banco de dados em uma transação atômica.
+
+        Args:
+            display_name: Nome de exibição do usuário proprietário.
+            company_name: Nome opcional da empresa a ser criada.
+
+        Returns:
+            A instância de Company criada e persistida.
         """
         name = company_name.strip() if company_name else f"Workspace de {display_name}"
 
-        # Geramos um slug único e curto para evitar colisões
+        # Gera um slug único concatenando um uuid curto para evitar colisões.
         base_slug = slugify(display_name)[:40]
         unique_slug = f"{base_slug}-{str(uuid_lib.uuid4())[:8]}"
 
@@ -34,7 +47,16 @@ class TenantService:
     @staticmethod
     @transaction.atomic
     def get_or_create_admin_workspace() -> Company:
-        """Garante a existência do workspace administrativo para superusuários."""
+        """
+        Gera ou recupera o workspace de administração padrão do sistema.
+
+        Utilizado para associar superusuários a um tenant administrativo do
+        sistema, prevenindo erros de validação de tenant em ferramentas de
+        gerenciamento global.
+
+        Returns:
+            A instância de Company representativa do workspace administrativo.
+        """
         company, created = Company.objects.get_or_create(
             slug="admin-workspace", defaults={"name": "Workspace Administrativo"}
         )

--- a/backend/apps/users/services/registration_service.py
+++ b/backend/apps/users/services/registration_service.py
@@ -14,7 +14,9 @@ logger = logging.getLogger(__name__)
 class RegistrationService:
     """
     Serviço de orquestração para registro de novos usuários e empresas.
-    Assegura que a criação do par Usuário-Empresa seja atômica.
+
+    Assegura que o fluxo de cadastro e a criação do par Usuário-Empresa
+    sejam executados de forma atômica no banco de dados.
     """
 
     @staticmethod
@@ -27,30 +29,43 @@ class RegistrationService:
         company_name: str = "",
     ) -> User:
         """
-        Realiza o onboarding completo de um novo profissional (Owner).
-        1. Valida se o e-mail já existe.
-        2. Cria a Empresa (Workspace) pragmático.
-        3. Cria o Usuário vinculado a essa empresa.
+        Realiza o onboarding completo de um novo proprietário (Owner).
+
+        Cria a conta do usuário e a empresa correspondente em uma transação
+        atômica, realizando validações de senha e de unicidade do e-mail.
+
+        Args:
+            email: E-mail do novo usuário. Deve ser único.
+            password: Senha em formato texto puro a ser validada e criptografada.
+            first_name: Primeiro nome do usuário.
+            last_name: Sobrenome do usuário.
+            company_name: Nome opcional da empresa a ser criada.
+
+        Returns:
+            Instância do usuário (User) recém-criado e associado à empresa.
+
+        Raises:
+            ValidationError: Se a senha não atender aos requisitos de segurança.
+            DomainIntegrityError: Se o e-mail já estiver cadastrado no sistema.
         """
         logger.info(f"Iniciando registro de novo proprietário: {email}")
 
-        # 1. Validação de Senha (Segurança)
-        # O User.objects.create_user já chama validate_password?
-        # Não por padrão no Django, e queremos falhar cedo.
+        # Validação de senha preventiva antes de persistir dados no banco.
         validate_password(password)
 
-        # 2. Validação Preventiva de E-mail
+        # Evita prosseguir com a criação da empresa se o e-mail já existir.
         if User.objects.filter(email=email).exists():
             raise DomainIntegrityError(
                 detail="Este e-mail já está cadastrado em outra conta.",
                 code="email_already_exists",
             )
 
-        # 2. Criação da Empresa
+        # Cria a empresa associada ao novo usuário.
         display_name = f"{first_name} {last_name}".strip() or email
         company = TenantService.create_company(display_name, company_name=company_name)
 
-        # 3. Criação do Usuário com captura de erro de integridade (Race conditions)
+        # Cria o usuário. Captura erro de concorrência se o e-mail for registrado
+        # concorrentemente.
         try:
             user = User.objects.create_user(
                 email=email,

--- a/backend/apps/users/services/token_service.py
+++ b/backend/apps/users/services/token_service.py
@@ -19,18 +19,26 @@ logger = logging.getLogger(__name__)
 class TokenService:
     """
     Serviço de orquestração para autenticação e geração de tokens JWT.
+
     Centraliza a lógica de validação de credenciais, criação de tokens
-    e montagem da resposta.
+    e montagem da resposta com dados do usuário autenticado.
     """
 
     @staticmethod
     def obtain(email: str, password: str) -> TokenOut:
         """
-        Autentica o usuário por email/senha e retorna tokens JWT.
+        Autentica o usuário por e-mail e senha, gerando os tokens JWT correspondentes.
+
+        Args:
+            email: O endereço de e-mail do usuário para autenticação.
+            password: A senha em texto puro fornecida pelo usuário.
+
+        Returns:
+            TokenOut contendo o token de acesso (access), o token de atualização
+            (refresh) e os dados básicos do usuário autenticado.
 
         Raises:
-            HttpError (401): Se as credenciais forem inválidas ou a conta
-                estiver desativada.
+            HttpError: Caso as credenciais sejam inválidas ou a conta esteja inativa.
         """
         logger.info(f"Tentativa de obtenção de token para email={email}")
 
@@ -58,14 +66,21 @@ class TokenService:
     @staticmethod
     def refresh(refresh_token: str) -> TokenRefreshOutputSchema:
         """
-        Gera um novo par de tokens a partir de um refresh token válido.
+        Gera um novo par de tokens a partir de um token de atualização (refresh token).
 
-        Se ROTATE_REFRESH_TOKENS estiver ativo (padrão), o refresh token
-        anterior é invalidado (blacklist) e um novo refresh é emitido.
+        Se a rotação de tokens estiver ativa (padrão do ninja_jwt), o token antigo
+        será invalidado e adicionado à blacklist, emitindo-se um novo refresh.
+
+        Args:
+            refresh_token: O refresh token atual recebido na requisição.
+
+        Returns:
+            TokenRefreshOutputSchema contendo o novo token de acesso e,
+            opcionalmente, o novo refresh token.
 
         Raises:
-            HttpError (401): Se o refresh token for inválido ou estiver
-                na blacklist.
+            HttpError: Se o refresh token for inválido, estiver expirado ou
+                constar na blacklist.
         """
         token_fp = hashlib.sha256(refresh_token.encode()).hexdigest()[:12]
         logger.info(f"Tentativa de refresh de token (fp={token_fp})")
@@ -77,14 +92,21 @@ class TokenService:
     @staticmethod
     def verify(token: str) -> VerifyTokenOut:
         """
-        Verifica se um token JWT é válido e não expirou.
+        Verifica a integridade e a validade temporal de um token JWT.
+
+        Args:
+            token: O token JWT (geralmente o access token) a ser validado.
+
+        Returns:
+            VerifyTokenOut indicando sucesso caso o token seja válido.
 
         Raises:
-            HttpError (401): Se o token for inválido ou expirado.
+            HttpError: Se o token for inválido, estiver corrompido ou expirado.
         """
         token_fp = hashlib.sha256(token.encode()).hexdigest()[:12]
         logger.info(f"Tentativa de verificação de token (fp={token_fp})")
         schema = TokenVerifyInputSchema(token=token)
-        schema.to_response_schema()  # levanta HttpError(401) se inválido
+        # O método levanta HttpError(401) caso o token seja inválido.
+        schema.to_response_schema()
         logger.info(f"Token verificado com sucesso (fp={token_fp})")
         return VerifyTokenOut()

--- a/backend/apps/weddings/services/dashboard_service.py
+++ b/backend/apps/weddings/services/dashboard_service.py
@@ -22,8 +22,34 @@ logger = logging.getLogger(__name__)
 
 
 class DashboardService:
+    """
+    Serviço para consolidação de dados e métricas do painel do usuário (Dashboard).
+
+    Agrupa dados financeiros, tarefas pendentes, contratos e casamentos
+    críticos em um único ponto de consulta para exibição no frontend.
+    """
+
     @staticmethod
     def get_summary(company: Company) -> dict[str, Any]:
+        """
+        Gera um resumo consolidado de indicadores importantes para a empresa.
+
+        Busca estatísticas financeiras gerais (parcelas a vencer e atrasadas),
+        quantidade de tarefas urgentes, contratos pendentes e uma listagem
+        de casamentos críticos ocorrendo nos próximos 90 dias com pendências.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+
+        Returns:
+            Dicionário contendo as chaves:
+                - pending_installments_7d (str): Valor pendente em 7 dias.
+                - urgent_tasks_count (int): Tarefas urgentes acumuladas.
+                - overdue_installments_amount (str): Valor total em atraso.
+                - overdue_installments_count (int): Quantidade de parcelas em atraso.
+                - pending_contracts_count (int): Quantidade de contratos pendentes.
+                - critical_weddings (list[dict]): Lista dos top 5 casamentos críticos.
+        """
         logger.info(f"Computando resumo do dashboard para company_id={company.id}")
         today = date.today()
 
@@ -136,6 +162,23 @@ class DashboardService:
 
     @staticmethod
     def get_wedding_overview(company: Company, wedding_uuid: UUID) -> dict[str, Any]:
+        """
+        Computa uma visão geral detalhada de um casamento específico.
+
+        Reúne métricas de cronômetro, uso do orçamento, progresso de tarefas,
+        assinatura de contratos, parcelas financeiras a vencer, tarefas
+        urgentes e resumo por categorias de despesa.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            wedding_uuid: O identificador único (UUID) do casamento.
+
+        Returns:
+            Dicionário com os indicadores detalhados do casamento solicitado.
+
+        Raises:
+            HttpError: Se o casamento correspondente ao UUID não for encontrado.
+        """
         wedding = WeddingService.get(company, wedding_uuid)
         logger.info(
             f"Computando visão geral do casamento uuid={wedding_uuid} "

--- a/backend/apps/weddings/services/summaries/contract.py
+++ b/backend/apps/weddings/services/summaries/contract.py
@@ -4,9 +4,23 @@ from apps.weddings.models import Wedding
 
 
 class ContractSummaryService:
+    """
+    Camada de serviço para consolidação de resumos e estatísticas de contratos.
+    Agrega informações sobre o status de assinatura de contratos vinculados
+    a casamentos específicos ou de maneira global por tenant.
+    """
+
     @staticmethod
     def pending_contracts_count(*, company: Company) -> int:
-        """Return the number of contracts in DRAFT or PENDING status for the company."""
+        """
+        Retorna a quantidade de contratos em rascunho ou pendentes do tenant.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+
+        Returns:
+            Quantidade total de contratos nos status DRAFT ou PENDING.
+        """
         return (
             Contract.objects.for_tenant(company)
             .filter(
@@ -22,7 +36,18 @@ class ContractSummaryService:
     def wedding_contract_stats(
         *, company: Company, wedding: Wedding
     ) -> tuple[int, int]:
-        """Return (signed, total non-canceled) contract counts for a wedding."""
+        """
+        Retorna as estatísticas de contratos assinados e totais de um casamento.
+
+        Considera apenas contratos que não foram cancelados no cômputo total.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            wedding: Instância do casamento a ser consultado.
+
+        Returns:
+            Uma tupla contendo (contratos_assinados, total_contratos_ativos).
+        """
         contracts = Contract.objects.for_tenant(company).filter(wedding=wedding)
         total = contracts.exclude(status=Contract.StatusChoices.CANCELED).count()
         signed = contracts.filter(status=Contract.StatusChoices.SIGNED).count()

--- a/backend/apps/weddings/services/summaries/financial.py
+++ b/backend/apps/weddings/services/summaries/financial.py
@@ -14,11 +14,26 @@ logger = logging.getLogger(__name__)
 
 
 class FinancialSummaryService:
+    """
+    Camada de serviço para consolidação de resumos e relatórios financeiros.
+    Agrega informações sobre parcelas pendentes, vencidas, uso de orçamento
+    e distribuição de gastos por categorias de orçamento do tenant.
+    """
+
     @staticmethod
     def pending_installments_7d(
         *, company: Company, today: date | None = None
     ) -> Decimal:
-        """Return total amount of pending installments due within the next 7 days."""
+        """
+        Retorna o valor total de parcelas pendentes que vencem nos próximos 7 dias.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            today: Data de referência (caso não informada, usa a data atual).
+
+        Returns:
+            Valor decimal total acumulado das parcelas que vencem em 7 dias.
+        """
         today = today or date.today()
         seven_days = today + timedelta(days=7)
         total = (
@@ -36,7 +51,19 @@ class FinancialSummaryService:
     def overdue_installments(
         *, company: Company, today: date | None = None
     ) -> tuple[Decimal, int]:
-        """Return total amount and count of overdue installments."""
+        """
+        Retorna o valor total acumulado e a quantidade de parcelas atrasadas.
+
+        Considera parcelas com status explícito de atraso (OVERDUE) ou
+        pendentes com vencimento anterior à data de referência.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            today: Data de referência (caso não informada, usa a data atual).
+
+        Returns:
+            Uma tupla contendo (valor_total_atrasado, quantidade_de_parcelas).
+        """
         today = today or date.today()
         qs = Installment.objects.for_tenant(company).filter(
             Q(status=Installment.StatusChoices.OVERDUE)
@@ -47,7 +74,18 @@ class FinancialSummaryService:
 
     @staticmethod
     def budget_percentage_used(*, company: Company, wedding: Wedding) -> float:
-        """Return the percentage of total estimated budget spent, capped at 100%."""
+        """
+        Calcula o percentual do orçamento estimado consumido até o momento.
+
+        O percentual retornado é limitado ao teto máximo de 100%.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            wedding: Instância do casamento associado.
+
+        Returns:
+            Percentual utilizado (float) arredondado para uma casa decimal.
+        """
         try:
             budget = Budget.objects.for_tenant(company).get(wedding=wedding)
             total_spent = budget.total_overall_spent
@@ -63,7 +101,21 @@ class FinancialSummaryService:
     def upcoming_installments(
         *, company: Company, wedding: Wedding, today: date | None = None
     ) -> list[dict[str, Any]]:
-        """Return up to 5 upcoming unpaid installments within 30 days for a wedding."""
+        """
+        Retorna até 5 parcelas a vencer nos próximos 30 dias de um casamento.
+
+        Também inclui parcelas que já estejam vencidas (status OVERDUE).
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            wedding: Instância do casamento associado.
+            today: Data de referência (caso não informada, usa a data atual).
+
+        Returns:
+            Lista de dicionários contendo os dados das parcelas ordenadas por
+            data de vencimento. Cada dicionário possui chaves: `uuid`,
+            `installment_number`, `amount`, `due_date` e `status`.
+        """
         today = today or date.today()
         thirty_days = today + timedelta(days=30)
         installments = (
@@ -91,7 +143,17 @@ class FinancialSummaryService:
     def categories_summary(
         *, company: Company, wedding: Wedding
     ) -> list[dict[str, Any]]:
-        """Return a summary of budget categories with allocated and spent."""
+        """
+        Gera um resumo de categorias de orçamento com alocação e gastos.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            wedding: Instância do casamento associado.
+
+        Returns:
+            Lista de dicionários contendo o nome da categoria, valor alocado,
+            valor gasto e a respectiva porcentagem consumida.
+        """
         categories = (
             BudgetCategory.objects.for_tenant(company)
             .filter(wedding=wedding)

--- a/backend/apps/weddings/services/summaries/task.py
+++ b/backend/apps/weddings/services/summaries/task.py
@@ -13,9 +13,24 @@ logger = logging.getLogger(__name__)
 
 
 class TaskSummaryService:
+    """
+    Camada de serviço para consolidação de resumos e estatísticas de tarefas.
+    Agrega informações sobre tarefas atrasadas, totais por casamento
+    e listagens de pendências urgentes do tenant.
+    """
+
     @staticmethod
     def urgent_tasks_count(*, company: Company, today: date | None = None) -> int:
-        """Return the number of uncompleted tasks past due for the company."""
+        """
+        Retorna a quantidade de tarefas não concluídas e atrasadas do tenant.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            today: Data de referência (caso não informada, usa a data atual).
+
+        Returns:
+            Quantidade total de tarefas atrasadas.
+        """
         today = today or date.today()
         return (
             Task.objects.for_tenant(company)
@@ -25,7 +40,16 @@ class TaskSummaryService:
 
     @staticmethod
     def wedding_task_stats(*, company: Company, wedding: Wedding) -> tuple[int, int]:
-        """Return (completed, total) task counts for a wedding."""
+        """
+        Retorna as estatísticas de tarefas concluídas e totais de um casamento.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            wedding: Instância do casamento a ser consultado.
+
+        Returns:
+            Uma tupla contendo (tarefas_concluidas, total_tarefas).
+        """
         tasks = Task.objects.for_tenant(company).filter(wedding=wedding)
         total = tasks.count()
         completed = tasks.filter(is_completed=True).count()
@@ -35,7 +59,22 @@ class TaskSummaryService:
     def urgent_tasks(
         *, company: Company, wedding: Wedding, today: date | None = None, limit: int = 3
     ) -> list[dict[str, Any]]:
-        """Return up to `limit` urgent tasks for a wedding, ordered by due date."""
+        """
+        Retorna as tarefas urgentes (atrasadas ou sem prazo) de um casamento.
+
+        Ordena as tarefas de forma ascendente pela data de vencimento, com
+        valores nulos ao final.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            wedding: Instância do casamento a ser consultado.
+            today: Data de referência (caso não informada, usa a data atual).
+            limit: Limite máximo de tarefas a serem retornadas (padrão: 3).
+
+        Returns:
+            Lista contendo até `limit` dicionários com as chaves `uuid`, `title`
+            e `due_date`.
+        """
         today = today or date.today()
         urgent = (
             Task.objects.for_tenant(company)

--- a/backend/apps/weddings/services/wedding_service.py
+++ b/backend/apps/weddings/services/wedding_service.py
@@ -37,8 +37,24 @@ class WeddingService:
 
     @staticmethod
     def list(company: Company, search: str = "", status: str = "") -> QuerySet[Wedding]:
-        """Lista casamentos com suporte a filtro por texto e status, incluindo anotações
-        de orçamento total, parcelas atrasadas e tarefas incompletas via Subquery."""
+        """
+        Lista os casamentos associados à empresa com filtros e anotações.
+
+        Permite busca textual por nomes dos noivos/local e filtragem por status.
+        Anota de forma otimizada o orçamento estimado total, contagem de parcelas
+        em atraso e de tarefas incompletas usando Subqueries.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            search: Termo de busca para filtrar por noivos ou local.
+            status: Filtro por status do casamento (ex: IN_PROGRESS).
+
+        Returns:
+            QuerySet contendo os casamentos correspondentes e anotados.
+
+        Raises:
+            BusinessRuleViolation: Se o status de filtro fornecido for inválido.
+        """
         qs = Wedding.objects.for_tenant(company).select_related("company")
         if search:
             qs = qs.filter(
@@ -57,9 +73,9 @@ class WeddingService:
         from apps.finances.models import Installment
         from apps.scheduler.models import Task
 
-        # Bolt Optimization: Use Subqueries for counts instead of Count(distinct=True)
-        # to avoid the "Cartesian Product" join explosion when multiple related sets
-        # are counted on the same query.
+        # Otimização: Uso de Subqueries para contagem ao invés de Count(distinct=True)
+        # para evitar a explosão do produto cartesiano (JOIN explosion) quando
+        # múltiplos conjuntos relacionados são contados na mesma query.
         qs = qs.annotate(
             total_budget=Subquery(
                 Budget.objects.filter(
@@ -98,14 +114,16 @@ class WeddingService:
 
     @staticmethod
     def count_by_month(company: Company, year: int) -> Sequence[dict]:
-        """Agrupa casamentos por mês no ano informado, retornando contagens.
+        """
+        Agrupa e conta os casamentos por mês para um determinado ano.
 
         Args:
-            company: Tenant para isolamento multitenancy.
-            year: Ano para filtrar os casamentos.
+            company: O tenant atual para isolamento de dados.
+            year: O ano correspondente para filtragem dos casamentos.
 
         Returns:
-            Lista de dicts com {"month": int, "count": int} ordenada por mês.
+            Sequência de dicionários com chaves 'month' e 'count',
+            ordenada cronologicamente pelo mês.
         """
         qs = (
             Wedding.objects.for_tenant(company)
@@ -118,6 +136,19 @@ class WeddingService:
 
     @staticmethod
     def get(company: Company, uuid: UUID | str) -> Wedding:
+        """
+        Recupera um casamento pelo UUID validando o tenant.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            uuid: O UUID ou representação em string do casamento.
+
+        Returns:
+            A instância do casamento solicitada.
+
+        Raises:
+            HttpError: Se o casamento não pertencer à empresa ou não existir.
+        """
         return get_object_or_404_for_tenant(
             Wedding,
             company,
@@ -129,6 +160,23 @@ class WeddingService:
     @staticmethod
     @transaction.atomic
     def create(company: Company, payload: WeddingIn) -> Wedding:
+        """
+        Cria um novo casamento e opcionalmente aplica um template de cronograma.
+
+        Realiza a persistência do casamento após validar os dados de entrada
+        com o método full_clean(). Se especificado no payload, agenda
+        automaticamente os eventos de template configurados.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            payload: Dados de entrada para criação do casamento.
+
+        Returns:
+            A instância de Wedding criada e salva no banco de dados.
+
+        Raises:
+            BusinessRuleViolation: Se houver erro de validação nos dados fornecidos.
+        """
         logger.info(f"Criando casamento para company_id={company.id}")
 
         data = payload.model_dump(exclude_unset=True)
@@ -165,6 +213,24 @@ class WeddingService:
     @staticmethod
     @transaction.atomic
     def update(company: Company, instance: Wedding, payload: WeddingPatchIn) -> Wedding:
+        """
+        Atualiza dados de um casamento existente com base no payload fornecido.
+
+        Garante isolamento de tenant antes de atualizar e executa validações
+        com full_clean() antes de persistir as modificações.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            instance: Instância atual de Wedding a ser atualizada.
+            payload: Campos modificados a serem aplicados no casamento.
+
+        Returns:
+            A instância do casamento atualizada e salva.
+
+        Raises:
+            BusinessRuleViolation: Se a atualização violar regras de negócio ou de
+                validação do modelo.
+        """
         validate_tenant_ownership(
             company,
             instance,
@@ -203,7 +269,18 @@ class WeddingService:
     @transaction.atomic
     def delete(company: Company, instance: Wedding) -> None:
         """
-        Deleta um casamento.
+        Deleta um casamento existente validando a propriedade de tenant.
+
+        Previne a deleção caso existam contratos ou despesas protegidos
+        por chaves estrangeiras vinculadas.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            instance: Instância de Wedding a ser deletada.
+
+        Raises:
+            DomainIntegrityError: Se houver violação de integridade ou se
+                o casamento possuir relacionamentos protegidos.
         """
         validate_tenant_ownership(
             company,
@@ -240,10 +317,15 @@ def _apply_template_events(
     company: Company, wedding: Wedding, template_name: str
 ) -> None:
     """
-    Aplica um template de cronograma ao casamento, criando eventos
-    com base no offset em dias antes da data do casamento.
+    Aplica um template de cronograma criando eventos para o casamento.
 
-    Importação lazy do EventService para evitar circular imports.
+    Calcula a data de início de cada evento usando a quantidade de dias
+    especificada como offset relativo à data do casamento.
+
+    Args:
+        company: O tenant atual para isolamento de dados.
+        wedding: O casamento a receber os eventos do template.
+        template_name: O identificador/nome do template a ser aplicado.
     """
     from django.utils import timezone
 

--- a/docs/ADR/021-padrao-comentarios-docstrings.md
+++ b/docs/ADR/021-padrao-comentarios-docstrings.md
@@ -19,7 +19,7 @@ Isso trazia dois problemas:
 
 ## Decisão
 
-1. Adotar formalmente o guia [COMMENTING_STANDARDS.md](file:///home/rafael/.gemini/antigravity/worktrees/wedding_management/review-service-documentation-comments/docs/COMMENTING_STANDARDS.md) como a especificação única de escrita de documentação do Wedding Management System.
+1. Adotar formalmente o guia [COMMENTING_STANDARDS.md](../COMMENTING_STANDARDS.md) como a especificação única de escrita de documentação do Wedding Management System.
 2. Adotar **Google Style** (em PT-BR) para docstrings de métodos de negócio (Services) e descrição curta para endpoints (API/Django Ninja).
 3. Banir do código de produção qualquer menção a nomes de ferramentas de geração de código.
 

--- a/docs/ADR/021-padrao-comentarios-docstrings.md
+++ b/docs/ADR/021-padrao-comentarios-docstrings.md
@@ -1,0 +1,33 @@
+# ADR-021: Padrão de Comentários e Docstrings
+
+**Status:** Aceito
+**Data:** Julho 2026
+**Decisor:** Rafael
+**Contexto:** Padronização da documentação no código e remoção de referências a ferramentas específicas.
+
+---
+
+## Contexto e Problema
+
+O código-fonte possuía comentários dispersos com diferentes idiomas e estilos de documentação. Adicionalmente, havia comentários com referências explícitas a assistentes de codificação de IA (como "Bolt Optimization" e "Copilot Review Fix").
+
+Isso trazia dois problemas:
+1. **Poluição visual e acoplamento:** Referências a ferramentas externas poluem o histórico e a leitura do código de produção.
+2. **Falta de consistência:** Métodos complexos sem parâmetros explicados aumentavam a carga cognitiva de onboarding.
+
+---
+
+## Decisão
+
+1. Adotar formalmente o guia [COMMENTING_STANDARDS.md](file:///home/rafael/.gemini/antigravity/worktrees/wedding_management/review-service-documentation-comments/docs/COMMENTING_STANDARDS.md) como a especificação única de escrita de documentação do Wedding Management System.
+2. Adotar **Google Style** (em PT-BR) para docstrings de métodos de negócio (Services) e descrição curta para endpoints (API/Django Ninja).
+3. Banir do código de produção qualquer menção a nomes de ferramentas de geração de código.
+
+---
+
+## Consequências
+
+* **Positivas:**
+  * Facilidade de onboarding e manutenção de longo prazo.
+  * API Docs (Swagger) mais rica, pois o Django Ninja extrai automaticamente as docstrings dos endpoints para o OpenAPI.
+  * Código limpo e independente de ferramentas ou ambientes.

--- a/docs/COMMENTING_STANDARDS.md
+++ b/docs/COMMENTING_STANDARDS.md
@@ -1,0 +1,111 @@
+# Padrões de Comentários e Docstrings
+
+Este documento define os padrões oficiais de comentários e documentação de código (*docstrings*) para a base de código do **Wedding Management System**.
+
+O objetivo é garantir legibilidade de longo prazo, facilitar o onboarding de novos desenvolvedores e evitar poluição ou referências desnecessárias a ferramentas externas.
+
+---
+
+## 1. Idioma Padrão
+
+* **Explicações de Lógica e Negócio:** Devem ser escritas em **Português (PT-BR)**, alinhadas com as definições de regras de negócio do produto.
+* **Termos Técnicos e de Bibliotecas:** Mantêm-se no idioma original em **Inglês** (ex: *QuerySet*, *OneToOne*, *middleware*, *fallback*, *payload*).
+
+---
+
+## 2. Docstrings de Classe e Método
+
+### Docstrings de Classe
+Devem descrever de forma concisa a responsabilidade do módulo ou classe no domínio do sistema, mencionando regras de negócio ou ADRs relevantes.
+
+```python
+class SupplierService:
+    """
+    Camada de serviço para gestão de fornecedores.
+    Centraliza a lógica de catálogo transversal à Company (RF09).
+    """
+```
+
+### Docstrings de Método (Google Style)
+Para métodos públicos ou com regras de negócio complexas, use o formato **Google Style**. Ele deve incluir seções explícitas de `Args`, `Returns` e `Raises` (se aplicável).
+
+```python
+def auto_generate_installments(
+    company: Company,
+    expense: Expense,
+    num_installments: int,
+    first_due_date: date,
+) -> list[Installment]:
+    """
+    Gera automaticamente as parcelas de uma despesa com ajuste na última
+    parcela (Tolerância Zero).
+
+    Args:
+        company: O tenant atual para isolamento de dados.
+        expense: A despesa pai que receberá o parcelamento.
+        num_installments: Número total de parcelas (> 0).
+        first_due_date: Data de vencimento da primeira parcela.
+
+    Returns:
+        Lista com as instâncias de parcelas geradas e salvas no banco.
+
+    Raises:
+        BusinessRuleViolation: Se a despesa já possuir parcelas ou valor inválido.
+    """
+```
+
+---
+
+## 3. Comentários Inline (Código)
+
+* **Foco no "Porquê" (*Why*), não no "O quê" (*What*):**
+  Evite descrever o que uma linha de código autoexplicativa faz. Use comentários para documentar decisões de design, restrições de banco de dados, contornos de bugs (*workarounds*) ou otimizações.
+* **Marcação de Sequência:**
+  Em fluxos lineares complexos (como transações atômicas com múltiplas etapas), use comentários numerados para guiar o leitor.
+
+```python
+# ⚠️ BOM:
+# O Django não valida a senha por padrão no create_user, executamos a validação preventivamente.
+validate_password(password)
+
+# ❌ RUIM (Redundante):
+# Salva o usuário no banco de dados
+user.save()
+```
+
+---
+
+## 4. Restrições e Proibições
+
+### Sem Referências a Ferramentas Externas ou IAs
+É terminantemente **proibido** incluir referências a assistentes de codificação, ferramentas de geração ou termos de ambientes de terceiros nos comentários de produção.
+* **Exemplos proibidos:** `# Bolt Optimization`, `# jules fix`, `# Copilot Review Fix`, `# gerado por IA`.
+* **Substitutos adequados:** `# Otimização de performance: ...`, `# Correção de segurança: ...`, `# Ajuste preventivo: ...`.
+
+### Sem Metadados Temporários
+Evite incluir números de Pull Requests, nomes de branches ou nomes de desenvolvedores nos comentários. Esse histórico pertence ao Git.
+
+---
+
+## 5. Documentando Padrões de Arquitetura Implícitos
+
+Quando uma classe utilizar padrões estruturais menos comuns (como Injeção de Dependência manual para desacoplar infraestrutura de storage em testes), documente claramente a finalidade do atributo e seus métodos acessores.
+
+```python
+# Injeção de dependência para desacoplar a infraestrutura de Storage.
+# Permite que testes unitários injetem mocks para evitar chamadas reais à rede.
+_storage_service: StorageService | None = None
+```
+
+---
+
+## 6. Padrões por Camada da Aplicação
+
+Cada camada arquitetural do Django Ninja possui necessidades diferentes de documentação:
+
+| Camada | Padrão de Documentação Recomendado | Finalidade Principal |
+| :--- | :--- | :--- |
+| **API / Views (`api.py`)** | Docstring descritiva simples (1 a 2 linhas). Sem necessidade de `Args:` ou `Returns:`. | Alimentar automaticamente a descrição da rota na documentação gerada pelo Swagger / OpenAPI do Django Ninja. |
+| **Services (`services/`)** | Docstrings completas em estilo **Google Style** (`Args`, `Returns`, `Raises`). | Documentar a orquestração de lógica de negócios, tipos internos e fluxo de exceções. |
+| **Models (`models.py`)** | Docstring de classe simples focada no papel da entidade. Docstrings Google Style apenas para métodos de *Manager* / *QuerySet*. | Explicar o papel do modelo no domínio de negócio e relações. |
+| **Schemas (`schemas.py`)** | Sem docstrings nas classes. Apenas comentários inline quando houver resolvedores ou validadores (`@model_validator`) complexos. | Manter a camada de transporte de dados limpa (os tipos Pydantic já são autoexplicativos). |


### PR DESCRIPTION
## Descrição das Alterações

Este Pull Request implementa a padronização completa de comentários e docstrings em todos os serviços do backend do **Wedding Management System**, seguindo o guia oficial de padrões estabelecido e a nova ADR-021.

### Alterações Principais:
1. **Padrão de Comentários (docs/COMMENTING_STANDARDS.md):** Criado o guia contendo o uso de Português (PT-BR) para explicações de lógica de negócios, adoção do padrão Google Style para docstrings, e níveis de detalhamento recomendados por camada (API, Services, Models e Schemas).
2. **Registro de Decisão Arquitetural (docs/ADR/021-padrao-comentarios-docstrings.md):** Criada a ADR-021 formalizando a decisão de banir comentários acoplados a ferramentas específicas (como "Bolt Optimization", "Copilot Review Fix" ou "jules fix").
3. **Limpeza e Refatoração:** 
   - Removidos e traduzidos todos os comentários contendo menções a "Bolt", "Jules" ou "Copilot" nos arquivos schemas.py, contract_service.py, wedding_service.py e installment_service.py.
   - Adicionada documentação detalhada sobre a injeção de dependência estática do _storage_service no ContractService para isolamento de testes unitários.
4. **Padronização em Larga Escala:** Aplicado o formato Google Style (PT-BR) nas docstrings de classe e métodos públicos de todos os 19 arquivos de serviço do backend (incluindo apps finances, logistics, users, tenants, scheduler e weddings).
5. **Configuração de Agente:** Atualizados o arquivo AGENTS.md e a skill customizada de backend para garantir conformidade em futuras manutenções.

### Verificação:
- **Lint:** Ruff (ruff check) passou com sucesso (todos os limites de E501 de 88 caracteres foram respeitados).
- **Tipagem:** Mypy passou com sucesso.
- **Testes:** pytest executou os 707 testes unitários e todos foram aprovados sem regressões.