### PR TITLE
fix(backend): harden tenant domain boundaries

### DIFF
--- a/backend/apps/core/tenant.py
+++ b/backend/apps/core/tenant.py
@@ -1,30 +1,39 @@
 from typing import TYPE_CHECKING
 
+from django.db import models
+
 from apps.core.exceptions import ObjectNotFoundError
 
 
 if TYPE_CHECKING:
-    from django.db.models import Model
-
     from apps.tenants.models import Company
 
 
-def validate_tenant_ownership(
+def validate_tenant_ownership[ModelT: models.Model](
     company: "Company",
-    instance: "Model",
+    instance: ModelT,
     *,
     detail: str = "Recurso não encontrado ou acesso negado.",
     code: str = "not_found_or_denied",
-) -> None:
-    """
-    Verifica se a instância pertence ao tenant informado.
+) -> ModelT:
+    """Verifica se uma instância pré-carregada pertence ao tenant informado.
 
-    Usada em métodos que recebem uma instância pré-carregada (update, delete, etc.)
-    para garantir que o tenant que fez a requisição é o dono do recurso.
-    Deve ser chamada antes de qualquer operação sobre a instância.
+    Serviços que recebem instâncias diretamente precisam validar o tenant antes
+    de ler ou alterar o recurso, preservando a semântica de 404 para não revelar
+    a existência de dados de outra empresa.
 
-    Levanta ObjectNotFoundError (404) em vez de PermissionError (403) para não
-    revelar a existência de recursos de outros tenants (segurança multi-tenant).
+    Args:
+        company: Empresa do usuário autenticado.
+        instance: Modelo tenant-owned já carregado pelo chamador.
+        detail: Mensagem segura retornada quando o tenant não confere.
+        code: Código de erro seguro retornado quando o tenant não confere.
+
+    Returns:
+        A própria instância validada, permitindo uso em expressões.
+
+    Raises:
+        ObjectNotFoundError: Se a instância pertencer a outro tenant.
     """
-    if instance.company_id != company.id:  # type: ignore[attr-defined]
+    if getattr(instance, "company_id", None) != company.id:
         raise ObjectNotFoundError(detail=detail, code=code)
+    return instance

--- a/backend/apps/core/tests/test_shortcuts.py
+++ b/backend/apps/core/tests/test_shortcuts.py
@@ -1,3 +1,4 @@
+from typing import no_type_check
 from uuid import uuid4
 
 import pytest
@@ -55,15 +56,17 @@ class TestShortcuts:
 
 @pytest.mark.django_db
 class TestValidateTenantOwnership:
-    def test_validate_tenant_ownership_returns_instance_for_same_tenant(self):
+    @no_type_check
+    def test_validate_tenant_ownership_returns_instance_for_same_tenant(self) -> None:
         company = CompanyFactory()
         wedding = WeddingFactory(company=company)
 
         result = validate_tenant_ownership(company, wedding)
 
-        assert result == wedding
+        assert result is wedding
 
-    def test_validate_tenant_ownership_raises_not_found_for_other_tenant(self):
+    @no_type_check
+    def test_validate_tenant_ownership_raises_not_found_for_other_tenant(self) -> None:
         company = CompanyFactory()
         other_company = CompanyFactory()
         wedding = WeddingFactory(company=other_company)

--- a/backend/apps/core/tests/test_shortcuts.py
+++ b/backend/apps/core/tests/test_shortcuts.py
@@ -4,35 +4,25 @@ import pytest
 
 from apps.core.exceptions import ObjectNotFoundError
 from apps.core.shortcuts import get_object_or_404_for_tenant
-from apps.tenants.models import Company
+from apps.core.tenant import validate_tenant_ownership
+from apps.core.tests.factories import WeddingFactory
+from apps.tenants.tests.factories import CompanyFactory
 from apps.weddings.models import Wedding
 
 
 @pytest.mark.django_db
 class TestShortcuts:
     def test_get_object_success(self):
-        company = Company.objects.create(name="Test Company", slug="test-company")
-        wedding = Wedding.objects.create(
-            company=company,
-            groom_name="Groom",
-            bride_name="Bride",
-            date="2026-12-31",
-            location="Test Location",
-        )
+        company = CompanyFactory()
+        wedding = WeddingFactory(company=company)
 
         result = get_object_or_404_for_tenant(Wedding, company, wedding.uuid)
         assert result == wedding
 
     def test_get_object_wrong_tenant(self):
-        company_a = Company.objects.create(name="Company A", slug="company-a")
-        company_b = Company.objects.create(name="Company B", slug="company-b")
-        wedding_a = Wedding.objects.create(
-            company=company_a,
-            groom_name="Groom A",
-            bride_name="Bride A",
-            date="2026-12-31",
-            location="Test Location A",
-        )
+        company_a = CompanyFactory()
+        company_b = CompanyFactory()
+        wedding_a = WeddingFactory(company=company_a)
 
         with pytest.raises(ObjectNotFoundError) as exc_info:
             get_object_or_404_for_tenant(Wedding, company_b, wedding_a.uuid)
@@ -41,29 +31,50 @@ class TestShortcuts:
         assert exc_info.value.code == "not_found_or_denied"
 
     def test_get_object_not_exists(self):
-        company = Company.objects.create(name="Test Company", slug="test-company")
+        company = CompanyFactory()
 
         with pytest.raises(ObjectNotFoundError):
             get_object_or_404_for_tenant(Wedding, company, uuid4())
 
     def test_get_object_invalid_uuid(self):
-        company = Company.objects.create(name="Test Company", slug="test-company")
+        company = CompanyFactory()
 
         with pytest.raises(ObjectNotFoundError):
             get_object_or_404_for_tenant(Wedding, company, "invalid-uuid")
 
     def test_get_object_select_related(self):
-        company = Company.objects.create(name="Test Company", slug="test-company")
-        wedding = Wedding.objects.create(
-            company=company,
-            groom_name="Groom",
-            bride_name="Bride",
-            date="2026-12-31",
-            location="Test Location",
-        )
+        company = CompanyFactory()
+        wedding = WeddingFactory(company=company)
 
         # Apenas para verificar se não explode e chama o método
         result = get_object_or_404_for_tenant(
             Wedding, company, wedding.uuid, select_related=["company"]
         )
         assert result == wedding
+
+
+@pytest.mark.django_db
+class TestValidateTenantOwnership:
+    def test_validate_tenant_ownership_returns_instance_for_same_tenant(self):
+        company = CompanyFactory()
+        wedding = WeddingFactory(company=company)
+
+        result = validate_tenant_ownership(company, wedding)
+
+        assert result == wedding
+
+    def test_validate_tenant_ownership_raises_not_found_for_other_tenant(self):
+        company = CompanyFactory()
+        other_company = CompanyFactory()
+        wedding = WeddingFactory(company=other_company)
+
+        with pytest.raises(ObjectNotFoundError) as exc_info:
+            validate_tenant_ownership(
+                company,
+                wedding,
+                detail="Casamento não encontrado ou acesso negado.",
+                code="wedding_not_found_or_denied",
+            )
+
+        assert exc_info.value.detail == "Casamento não encontrado ou acesso negado."
+        assert exc_info.value.code == "wedding_not_found_or_denied"

--- a/backend/apps/finances/services/budget_category_service.py
+++ b/backend/apps/finances/services/budget_category_service.py
@@ -142,7 +142,12 @@ class BudgetCategoryService:
         budget_input = data.pop("budget", None)
 
         if isinstance(budget_input, Budget):
-            budget = budget_input
+            budget = validate_tenant_ownership(
+                company,
+                budget_input,
+                detail="Orçamento mestre não encontrado ou acesso negado.",
+                code="budget_not_found_or_denied",
+            )
         else:
             budget = get_object_or_404_for_tenant(
                 Budget,

--- a/backend/apps/finances/services/budget_service.py
+++ b/backend/apps/finances/services/budget_service.py
@@ -97,7 +97,12 @@ class BudgetService:
         wedding_input = data.pop("wedding", None)
 
         if isinstance(wedding_input, Wedding):
-            wedding = wedding_input
+            wedding = validate_tenant_ownership(
+                company,
+                wedding_input,
+                detail="Casamento não encontrado ou acesso negado.",
+                code="wedding_not_found_or_denied",
+            )
         else:
             wedding = get_object_or_404_for_tenant(
                 Wedding,

--- a/backend/apps/finances/services/expense_service.py
+++ b/backend/apps/finances/services/expense_service.py
@@ -26,34 +26,34 @@ from apps.tenants.models import Company
 logger = logging.getLogger(__name__)
 
 
-def _validate_contract_wedding(
-    category: BudgetCategory, contract: Contract | None
-) -> None:
-    """Valida a fronteira cross-wedding entre categoria e contrato.
-
-    Args:
-        category: Categoria financeira que define o casamento da despesa.
-        contract: Contrato logístico opcional vinculado à despesa.
-
-    Raises:
-        DomainIntegrityError: Se o contrato pertencer a outro casamento.
-    """
-    if contract and contract.wedding_id != category.wedding_id:
-        raise DomainIntegrityError(
-            detail=(
-                "O contrato vinculado deve pertencer ao mesmo casamento da "
-                "categoria de orçamento."
-            ),
-            code="expense_contract_wedding_mismatch",
-        )
-
-
 class ExpenseService:
     """Camada de serviço para orquestração de Despesas.
 
     Garante que gastos reais respeitem o contexto do casamento, os contratos
     e assegura a rastreabilidade estrita da operação.
     """
+
+    @staticmethod
+    def _validate_contract_wedding(
+        category: BudgetCategory, contract: Contract | None
+    ) -> None:
+        """Valida a fronteira cross-wedding entre categoria e contrato.
+
+        Args:
+            category: Categoria financeira que define o casamento da despesa.
+            contract: Contrato logístico opcional vinculado à despesa.
+
+        Raises:
+            DomainIntegrityError: Se o contrato pertencer a outro casamento.
+        """
+        if contract and contract.wedding_id != category.wedding_id:
+            raise DomainIntegrityError(
+                detail=(
+                    "O contrato vinculado deve pertencer ao mesmo casamento da "
+                    "categoria de orçamento."
+                ),
+                code="expense_contract_wedding_mismatch",
+            )
 
     @staticmethod
     def list(
@@ -204,7 +204,7 @@ class ExpenseService:
                     code="contract_not_found_or_denied",
                 )
 
-        _validate_contract_wedding(category, contract)
+        ExpenseService._validate_contract_wedding(category, contract)
 
         num_installments = data.pop("num_installments", None)
         if num_installments is None:
@@ -302,29 +302,27 @@ class ExpenseService:
         Raises:
             ObjectNotFoundError: Se o contrato especificado não for encontrado.
         """
+        resolved_contract = None
         if contract_input:
             if isinstance(contract_input, Contract):
-                instance.contract = contract_input
-                validate_tenant_ownership(
+                resolved_contract = validate_tenant_ownership(
                     company,
-                    instance.contract,
+                    contract_input,
                     detail="Contrato inválido ou acesso negado.",
                     code="contract_not_found_or_denied",
                 )
             else:
-                instance.contract = get_object_or_404_for_tenant(
+                resolved_contract = get_object_or_404_for_tenant(
                     Contract,
                     company,
                     contract_input,
                     code="contract_not_found_or_denied",
                     detail="Contrato inválido ou acesso negado.",
                 )
-        else:
-            instance.contract = None
 
         if (
-            instance.contract is not None
-            and instance.contract.wedding_id != instance.wedding_id
+            resolved_contract is not None
+            and resolved_contract.wedding_id != instance.wedding_id
         ):
             raise DomainIntegrityError(
                 detail=(
@@ -332,6 +330,8 @@ class ExpenseService:
                 ),
                 code="expense_contract_wedding_mismatch",
             )
+
+        instance.contract = resolved_contract
 
     @staticmethod
     @transaction.atomic

--- a/backend/apps/finances/services/expense_service.py
+++ b/backend/apps/finances/services/expense_service.py
@@ -10,6 +10,7 @@ from django.db.models import QuerySet
 
 from apps.core.exceptions import (
     BusinessRuleViolation,
+    DomainIntegrityError,
     ObjectNotFoundError,
 )
 from apps.core.shortcuts import get_object_or_404_for_tenant
@@ -23,6 +24,28 @@ from apps.tenants.models import Company
 
 
 logger = logging.getLogger(__name__)
+
+
+def _validate_contract_wedding(
+    category: BudgetCategory, contract: Contract | None
+) -> None:
+    """Valida a fronteira cross-wedding entre categoria e contrato.
+
+    Args:
+        category: Categoria financeira que define o casamento da despesa.
+        contract: Contrato logístico opcional vinculado à despesa.
+
+    Raises:
+        DomainIntegrityError: Se o contrato pertencer a outro casamento.
+    """
+    if contract and contract.wedding_id != category.wedding_id:
+        raise DomainIntegrityError(
+            detail=(
+                "O contrato vinculado deve pertencer ao mesmo casamento da "
+                "categoria de orçamento."
+            ),
+            code="expense_contract_wedding_mismatch",
+        )
 
 
 class ExpenseService:
@@ -145,6 +168,12 @@ class ExpenseService:
 
         if isinstance(category_input, BudgetCategory):
             category = category_input
+            validate_tenant_ownership(
+                company,
+                category,
+                detail="Categoria de orçamento não encontrada ou acesso negado.",
+                code="budget_category_not_found_or_denied",
+            )
         else:
             category = get_object_or_404_for_tenant(
                 BudgetCategory,
@@ -161,6 +190,12 @@ class ExpenseService:
         if contract_input:
             if isinstance(contract_input, Contract):
                 contract = contract_input
+                validate_tenant_ownership(
+                    company,
+                    contract,
+                    detail="Contrato inválido ou acesso negado.",
+                    code="contract_not_found_or_denied",
+                )
             else:
                 contract = get_object_or_404_for_tenant(
                     Contract,
@@ -168,6 +203,8 @@ class ExpenseService:
                     contract_input,
                     code="contract_not_found_or_denied",
                 )
+
+        _validate_contract_wedding(category, contract)
 
         num_installments = data.pop("num_installments", None)
         if num_installments is None:
@@ -268,6 +305,12 @@ class ExpenseService:
         if contract_input:
             if isinstance(contract_input, Contract):
                 instance.contract = contract_input
+                validate_tenant_ownership(
+                    company,
+                    instance.contract,
+                    detail="Contrato inválido ou acesso negado.",
+                    code="contract_not_found_or_denied",
+                )
             else:
                 instance.contract = get_object_or_404_for_tenant(
                     Contract,
@@ -278,6 +321,17 @@ class ExpenseService:
                 )
         else:
             instance.contract = None
+
+        if (
+            instance.contract is not None
+            and instance.contract.wedding_id != instance.wedding_id
+        ):
+            raise DomainIntegrityError(
+                detail=(
+                    "O contrato vinculado deve pertencer ao mesmo casamento da despesa."
+                ),
+                code="expense_contract_wedding_mismatch",
+            )
 
     @staticmethod
     @transaction.atomic

--- a/backend/apps/finances/services/installment_service.py
+++ b/backend/apps/finances/services/installment_service.py
@@ -254,6 +254,12 @@ class InstallmentService:
         expense_input = data.pop("expense", None)
         if isinstance(expense_input, Expense):
             expense = expense_input
+            validate_tenant_ownership(
+                company,
+                expense,
+                detail="Despesa não encontrada ou acesso negado.",
+                code="expense_not_found_or_denied",
+            )
         else:
             try:
                 expense = Expense.objects.for_tenant(company).get(uuid=expense_input)
@@ -329,6 +335,23 @@ class InstallmentService:
         )
 
         data = payload.model_dump(exclude_unset=True)
+        protected_fields = {"amount", "due_date", "installment_number"}
+        changed_protected_fields = {
+            field
+            for field in protected_fields & data.keys()
+            if data[field] != getattr(instance, field)
+        }
+        if (
+            instance.status == Installment.StatusChoices.PAID
+            and changed_protected_fields
+        ):
+            raise BusinessRuleViolation(
+                detail=(
+                    "Parcelas pagas não podem ter valor, vencimento ou número "
+                    "alterados. Faça a reversão antes de ajustar."
+                ),
+                code="paid_installment_immutable",
+            )
 
         for field, value in data.items():
             setattr(instance, field, value)

--- a/backend/apps/finances/tests/budgets/test_services.py
+++ b/backend/apps/finances/tests/budgets/test_services.py
@@ -84,6 +84,22 @@ class TestBudgetServiceCritical:
         # Verificar que NÃO foi criado budget para wedding_a (user_b não tem acesso)
         assert Budget.objects.filter(wedding=wedding_a).count() == 0
 
+    def test_create_budget_rejects_wedding_instance_from_other_tenant(self):
+        """Instância de Wedding pré-carregada também passa por validação tenant."""
+        user_a = UserFactory()
+        user_b = UserFactory()
+        wedding_b = WeddingFactory(user_context=user_b)
+        payload = BudgetIn.model_construct(
+            wedding=wedding_b,
+            total_estimated=Decimal("1000.00"),
+            notes="",
+        )
+
+        with pytest.raises(ObjectNotFoundError) as exc_info:
+            BudgetService.create(user_a.company, payload)
+
+        assert exc_info.value.code == "wedding_not_found_or_denied"
+
     def test_get_or_create_for_wedding_with_nonexistent_wedding(self, user):
         """
         Teste CRÍTICO: UUID de wedding não existente.

--- a/backend/apps/finances/tests/budgets/test_services.py
+++ b/backend/apps/finances/tests/budgets/test_services.py
@@ -9,6 +9,7 @@ Estes testes cobrem as áreas de maior risco identificadas na análise:
 """
 
 from decimal import Decimal
+from typing import no_type_check
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -84,7 +85,8 @@ class TestBudgetServiceCritical:
         # Verificar que NÃO foi criado budget para wedding_a (user_b não tem acesso)
         assert Budget.objects.filter(wedding=wedding_a).count() == 0
 
-    def test_create_budget_rejects_wedding_instance_from_other_tenant(self):
+    @no_type_check
+    def test_create_budget_rejects_wedding_instance_from_other_tenant(self) -> None:
         """Instância de Wedding pré-carregada também passa por validação tenant."""
         user_a = UserFactory()
         user_b = UserFactory()

--- a/backend/apps/finances/tests/categories/test_services.py
+++ b/backend/apps/finances/tests/categories/test_services.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from typing import no_type_check
 from uuid import uuid4
 
 import pytest
@@ -91,7 +92,8 @@ class TestBudgetCategoryServiceCreate:
 
         assert "budget_not_found_or_denied" in str(exc_info.value.code)
 
-    def test_create_category_rejects_budget_instance_from_other_tenant(self):
+    @no_type_check
+    def test_create_category_rejects_budget_instance_from_other_tenant(self) -> None:
         """Instância de Budget pré-carregada também passa por validação tenant."""
         user_a = UserFactory()
         user_b = UserFactory()

--- a/backend/apps/finances/tests/categories/test_services.py
+++ b/backend/apps/finances/tests/categories/test_services.py
@@ -91,6 +91,23 @@ class TestBudgetCategoryServiceCreate:
 
         assert "budget_not_found_or_denied" in str(exc_info.value.code)
 
+    def test_create_category_rejects_budget_instance_from_other_tenant(self):
+        """Instância de Budget pré-carregada também passa por validação tenant."""
+        user_a = UserFactory()
+        user_b = UserFactory()
+        _, budget_b = _setup_budget(user_b)
+        payload = BudgetCategoryIn.model_construct(
+            budget=budget_b,
+            name="Invasão por instância",
+            description="",
+            allocated_budget=Decimal("1000.00"),
+        )
+
+        with pytest.raises(ObjectNotFoundError) as exc_info:
+            BudgetCategoryService.create(user_a.company, payload)
+
+        assert exc_info.value.code == "budget_not_found_or_denied"
+
     def test_create_category_exceeds_budget_cap_raises_error(self, user):
         """
         TOCTOU: criar categoria que ultrapassa o teto do orçamento

--- a/backend/apps/finances/tests/expenses/test_services.py
+++ b/backend/apps/finances/tests/expenses/test_services.py
@@ -4,7 +4,11 @@ from uuid import uuid4
 
 import pytest
 
-from apps.core.exceptions import BusinessRuleViolation, ObjectNotFoundError
+from apps.core.exceptions import (
+    BusinessRuleViolation,
+    DomainIntegrityError,
+    ObjectNotFoundError,
+)
 from apps.finances.models import Expense, Installment
 from apps.finances.schemas import ExpenseIn, ExpensePatchIn
 from apps.finances.services.expense_service import ExpenseService
@@ -166,6 +170,32 @@ class TestExpenseServiceCreate:
             ExpenseService.create(user.company, ExpenseIn(**data))
 
         assert exc_info.value.code == "br_f02_violation"
+
+    def test_create_expense_contract_from_other_wedding_raises_error(self, user):
+        """BR-L02: contrato e categoria devem pertencer ao mesmo casamento."""
+        from apps.logistics.tests.factories import ContractFactory, SupplierFactory
+
+        category = _setup_category(user)
+        other_category = _setup_category(user)
+        supplier = SupplierFactory(company=user.company)
+        contract = ContractFactory(
+            wedding=other_category.wedding,
+            supplier=supplier,
+            total_amount=Decimal("5000.00"),
+        )
+
+        data = {
+            "category": category.uuid,
+            "contract": contract.uuid,
+            "name": "Despesa cross-wedding",
+            "estimated_amount": Decimal("5000.00"),
+            "actual_amount": Decimal("5000.00"),
+        }
+
+        with pytest.raises(DomainIntegrityError) as exc_info:
+            ExpenseService.create(user.company, ExpenseIn(**data))
+
+        assert exc_info.value.code == "expense_contract_wedding_mismatch"
 
     def test_create_expense_triggers_tolerance_zero(self, user):
         """BR-F01: expense com actual_amount > 0 deve gerar parcelas que somam
@@ -341,6 +371,39 @@ class TestExpenseServiceUpdate:
                 ExpensePatchIn(actual_amount=Decimal("1000.00")),
             )
         assert exc.value.code == "amount_change_blocked_by_paid"
+
+    def test_update_expense_contract_from_other_wedding_raises_error(self, user):
+        """BR-L02: despesa não pode ser religada a contrato de outro casamento."""
+        from apps.logistics.tests.factories import ContractFactory, SupplierFactory
+
+        category = _setup_category(user)
+        other_category = _setup_category(user)
+        supplier = SupplierFactory(company=user.company)
+        contract = ContractFactory(
+            wedding=other_category.wedding,
+            supplier=supplier,
+            total_amount=Decimal("500.00"),
+        )
+        expense = ExpenseFactory(
+            wedding=category.wedding,
+            category=category,
+            contract=None,
+            actual_amount=Decimal("500.00"),
+        )
+        InstallmentFactory(
+            expense=expense,
+            installment_number=1,
+            amount=Decimal("500.00"),
+        )
+
+        with pytest.raises(DomainIntegrityError) as exc_info:
+            ExpenseService.update(
+                user.company,
+                expense,
+                ExpensePatchIn(contract=contract.uuid),
+            )
+
+        assert exc_info.value.code == "expense_contract_wedding_mismatch"
 
 
 @pytest.mark.django_db

--- a/backend/apps/finances/tests/expenses/test_services.py
+++ b/backend/apps/finances/tests/expenses/test_services.py
@@ -1,5 +1,6 @@
 from datetime import date
 from decimal import Decimal
+from typing import no_type_check
 from uuid import uuid4
 
 import pytest
@@ -171,7 +172,10 @@ class TestExpenseServiceCreate:
 
         assert exc_info.value.code == "br_f02_violation"
 
-    def test_create_expense_contract_from_other_wedding_raises_error(self, user):
+    @no_type_check
+    def test_create_expense_contract_from_other_wedding_raises_error(
+        self, user
+    ) -> None:
         """BR-L02: contrato e categoria devem pertencer ao mesmo casamento."""
         from apps.logistics.tests.factories import ContractFactory, SupplierFactory
 
@@ -196,6 +200,35 @@ class TestExpenseServiceCreate:
             ExpenseService.create(user.company, ExpenseIn(**data))
 
         assert exc_info.value.code == "expense_contract_wedding_mismatch"
+
+    @no_type_check
+    def test_create_expense_rejects_contract_instance_from_other_tenant(
+        self,
+    ) -> None:
+        """Contrato pré-carregado de outro tenant deve ser rejeitado."""
+        from apps.logistics.tests.factories import ContractFactory, SupplierFactory
+
+        user_a = UserFactory()
+        user_b = UserFactory()
+        category_a = _setup_category(user_a)
+        wedding_b = WeddingFactory(user_context=user_b)
+        supplier_b = SupplierFactory(company=user_b.company)
+        contract_b = ContractFactory(wedding=wedding_b, supplier=supplier_b)
+        payload = ExpenseIn.model_construct(
+            category=category_a,
+            contract=contract_b,
+            name="Despesa cross-tenant",
+            description="",
+            estimated_amount=contract_b.total_amount,
+            actual_amount=contract_b.total_amount,
+            num_installments=1,
+            first_due_date=date.today(),
+        )
+
+        with pytest.raises(ObjectNotFoundError) as exc_info:
+            ExpenseService.create(user_a.company, payload)
+
+        assert exc_info.value.code == "contract_not_found_or_denied"
 
     def test_create_expense_triggers_tolerance_zero(self, user):
         """BR-F01: expense com actual_amount > 0 deve gerar parcelas que somam
@@ -372,7 +405,10 @@ class TestExpenseServiceUpdate:
             )
         assert exc.value.code == "amount_change_blocked_by_paid"
 
-    def test_update_expense_contract_from_other_wedding_raises_error(self, user):
+    @no_type_check
+    def test_update_expense_contract_from_other_wedding_raises_error(
+        self, user
+    ) -> None:
         """BR-L02: despesa não pode ser religada a contrato de outro casamento."""
         from apps.logistics.tests.factories import ContractFactory, SupplierFactory
 
@@ -404,6 +440,37 @@ class TestExpenseServiceUpdate:
             )
 
         assert exc_info.value.code == "expense_contract_wedding_mismatch"
+
+    @no_type_check
+    def test_update_expense_rejects_contract_instance_without_mutating(
+        self, user
+    ) -> None:
+        """Falha de tenant não deve trocar o contrato em memória."""
+        from apps.logistics.tests.factories import ContractFactory, SupplierFactory
+
+        category = _setup_category(user)
+        supplier = SupplierFactory(company=user.company)
+        current_contract = ContractFactory(wedding=category.wedding, supplier=supplier)
+        expense = ExpenseFactory(
+            wedding=category.wedding,
+            category=category,
+            contract=current_contract,
+            actual_amount=current_contract.total_amount,
+        )
+        other_user = UserFactory()
+        other_wedding = WeddingFactory(user_context=other_user)
+        other_supplier = SupplierFactory(company=other_user.company)
+        other_contract = ContractFactory(
+            wedding=other_wedding,
+            supplier=other_supplier,
+        )
+        payload = ExpensePatchIn.model_construct(contract=other_contract)
+
+        with pytest.raises(ObjectNotFoundError) as exc_info:
+            ExpenseService.update(user.company, expense, payload)
+
+        assert exc_info.value.code == "contract_not_found_or_denied"
+        assert expense.contract is current_contract
 
 
 @pytest.mark.django_db

--- a/backend/apps/finances/tests/installments/test_services.py
+++ b/backend/apps/finances/tests/installments/test_services.py
@@ -1,5 +1,6 @@
 from datetime import date, timedelta
 from decimal import Decimal
+from typing import no_type_check
 from uuid import uuid4
 
 import pytest
@@ -319,7 +320,10 @@ class TestInstallmentServiceUpdate:
             ("installment_number", 2),
         ],
     )
-    def test_update_paid_installment_protected_fields_blocked(self, user, field, value):
+    @no_type_check
+    def test_update_paid_installment_protected_fields_blocked(
+        self, user, field, value
+    ) -> None:
         """BR-F06: parcela paga não permite alterar valor, vencimento ou número."""
         expense = _setup_expense(user, actual_amount=Decimal("500.00"))
         installment = InstallmentFactory(
@@ -339,7 +343,8 @@ class TestInstallmentServiceUpdate:
 
         assert exc_info.value.code == "paid_installment_immutable"
 
-    def test_update_paid_installment_notes_allowed(self, user):
+    @no_type_check
+    def test_update_paid_installment_notes_allowed(self, user) -> None:
         """BR-F06 protege campos contábeis, mas permite anotação operacional."""
         expense = _setup_expense(user, actual_amount=Decimal("500.00"))
         installment = InstallmentFactory(

--- a/backend/apps/finances/tests/installments/test_services.py
+++ b/backend/apps/finances/tests/installments/test_services.py
@@ -311,6 +311,53 @@ class TestInstallmentServiceUpdate:
         )
         assert updated.due_date == new_due_date
 
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            ("amount", Decimal("400.00")),
+            ("due_date", date.today() + timedelta(days=90)),
+            ("installment_number", 2),
+        ],
+    )
+    def test_update_paid_installment_protected_fields_blocked(self, user, field, value):
+        """BR-F06: parcela paga não permite alterar valor, vencimento ou número."""
+        expense = _setup_expense(user, actual_amount=Decimal("500.00"))
+        installment = InstallmentFactory(
+            expense=expense,
+            installment_number=1,
+            amount=Decimal("500.00"),
+            status=Installment.StatusChoices.PAID,
+            paid_date=date.today(),
+        )
+
+        with pytest.raises(BusinessRuleViolation) as exc_info:
+            InstallmentService.update(
+                user.company,
+                installment,
+                InstallmentPatchIn(**{field: value}),
+            )
+
+        assert exc_info.value.code == "paid_installment_immutable"
+
+    def test_update_paid_installment_notes_allowed(self, user):
+        """BR-F06 protege campos contábeis, mas permite anotação operacional."""
+        expense = _setup_expense(user, actual_amount=Decimal("500.00"))
+        installment = InstallmentFactory(
+            expense=expense,
+            installment_number=1,
+            amount=Decimal("500.00"),
+            status=Installment.StatusChoices.PAID,
+            paid_date=date.today(),
+        )
+
+        updated = InstallmentService.update(
+            user.company,
+            installment,
+            InstallmentPatchIn(notes="Comprovante conferido."),
+        )
+
+        assert updated.notes == "Comprovante conferido."
+
     def test_update_installment_cross_tenant(self, user):
         """Parcela de outro tenant não pode ser atualizada."""
         other_user = UserFactory()

--- a/backend/apps/finances/tests/test_performance.py
+++ b/backend/apps/finances/tests/test_performance.py
@@ -14,7 +14,7 @@ from apps.finances.tests.factories import (
     ExpenseFactory,
     InstallmentFactory,
 )
-from apps.tenants.models import Company
+from apps.tenants.tests.factories import CompanyFactory
 from apps.weddings.tests.factories import WeddingFactory
 
 
@@ -23,7 +23,7 @@ def test_benchmark_n_plus_one_resolved():
     print("\n--- ⚡ Iniciando Benchmark de Performance (Verificação de Correção) ---")
 
     # 1. Setup Data
-    company = Company.objects.create(name="Benchmarking Co", slug="benchmarking-co")
+    company = CompanyFactory(name="Benchmarking Co")
     wedding = WeddingFactory(company=company)
     budget = BudgetFactory(wedding=wedding, company=company)
 

--- a/backend/apps/logistics/api/contracts.py
+++ b/backend/apps/logistics/api/contracts.py
@@ -1,13 +1,9 @@
-import json
-from typing import Any
-
 from django.db.models import QuerySet
 from ninja.pagination import paginate
 from ninja_extra import Router
 from pydantic import UUID4
 
 from apps.core.constants import MUTATION_ERROR_RESPONSES, READ_ERROR_RESPONSES
-from apps.finances.schemas import ExpenseIn
 from apps.logistics.models.contract import Contract
 from apps.logistics.schemas import (
     ContractFullCreateIn,
@@ -18,7 +14,6 @@ from apps.logistics.schemas import (
     ContractUploadIn,
     ContractUploadUrlIn,
     ContractUploadUrlOut,
-    ItemIn,
 )
 from apps.logistics.services.contract_service import ContractService
 from apps.users.auth import require_user
@@ -113,41 +108,9 @@ def create_contract_full(
     Cria contrato com arquivo, itens e despesa em uma única transação atômica.
     """
     user = require_user(request.user)
-
-    contract_in = ContractIn(
-        wedding=payload.wedding,
-        supplier=payload.supplier,
-        name=payload.name,
-        total_amount=payload.total_amount,
-        status=payload.status,
-        description=payload.description,
-        parent=payload.parent,
-    )
-
-    items_list: list[ItemIn] = []
-    raw_items: list[dict[str, Any]] = json.loads(payload.items_data or "[]")
-    for item_dict in raw_items:
-        item_dict["wedding"] = payload.wedding
-        items_list.append(ItemIn(**item_dict))
-
-    expense_in: ExpenseIn | None = None
-    if payload.create_expense:
-        expense_in = ExpenseIn(
-            category=payload.expense_category,  # type: ignore[arg-type]
-            name=payload.name,
-            description=payload.description,
-            estimated_amount=payload.total_amount,
-            actual_amount=payload.total_amount,
-            num_installments=payload.expense_num_installments,
-            first_due_date=payload.expense_first_due_date,
-        )
-
-    contract = ContractService.create_full(
+    contract = ContractService.create_full_from_payload(
         company=user.company,
-        contract_data=contract_in,
-        items_data=items_list or None,
-        expense_data=expense_in,
-        pdf_file_key=payload.pdf_file_key,
+        payload=payload,
     )
     return 201, contract
 

--- a/backend/apps/logistics/schemas.py
+++ b/backend/apps/logistics/schemas.py
@@ -2,14 +2,18 @@ import datetime
 import json
 from datetime import date
 from decimal import Decimal
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
+from django.core.exceptions import ObjectDoesNotExist
 from ninja import Field, Schema
 from pydantic import UUID4, field_validator, model_validator
 
 
 if TYPE_CHECKING:
     from apps.logistics.models.contract import Contract
+
+
+_MISSING = object()
 
 
 # ==============================================================================
@@ -144,18 +148,16 @@ class ContractOut(Schema):
 
     @staticmethod
     def resolve_expense_uuid(obj: "Contract") -> UUID4 | None:
-        # Otimização de performance: Evita a avaliação eager de getattr e queries
-        # reversas OneToOne.
-        if hasattr(obj, "expense_id"):
-            return obj.expense_id
+        expense_id = getattr(obj, "expense_id", _MISSING)
+        if expense_id is not _MISSING:
+            return cast("UUID4 | None", expense_id)
 
-        # Check __dict__ to avoid query if not loaded
-        if "expense" in obj.__dict__:
-            return obj.expense.uuid if obj.expense else None
-
-        # Fallback to real query if data is missing (ensures correctness)
-        # Note: getattr(obj, 'expense', None) is safe as long as it's not a default arg
-        expense = getattr(obj, "expense", None)
+        expense = obj._state.fields_cache.get("expense")
+        if expense is None:
+            try:
+                expense = obj.expense
+            except ObjectDoesNotExist:
+                return None
         return expense.uuid if expense else None
 
     @staticmethod
@@ -182,16 +184,17 @@ class ContractOut(Schema):
 
     @staticmethod
     def resolve_has_linked_expense(obj: "Contract") -> bool:
-        # Otimização de performance: Evita a query reversa OneToOne.
-        if hasattr(obj, "expense_id"):
-            return bool(obj.expense_id)
+        expense_id = getattr(obj, "expense_id", _MISSING)
+        if expense_id is not _MISSING:
+            return bool(expense_id)
 
-        # Fallback using __dict__ cache
-        if "expense" in obj.__dict__:
+        if obj._state.fields_cache.get("expense") is not None:
+            return True
+
+        try:
             return obj.expense is not None
-
-        # Fallback to real query if data is missing (ensures correctness)
-        return hasattr(obj, "expense") and obj.expense is not None
+        except ObjectDoesNotExist:
+            return False
 
     @staticmethod
     def resolve_progress_percent(obj: "Contract") -> int:

--- a/backend/apps/logistics/schemas.py
+++ b/backend/apps/logistics/schemas.py
@@ -152,8 +152,10 @@ class ContractOut(Schema):
         if expense_id is not _MISSING:
             return cast("UUID4 | None", expense_id)
 
-        expense = obj._state.fields_cache.get("expense")
-        if expense is None:
+        cached_expense = obj._state.fields_cache.get("expense", _MISSING)
+        if cached_expense is not _MISSING:
+            expense = cached_expense
+        else:
             try:
                 expense = obj.expense
             except ObjectDoesNotExist:
@@ -188,8 +190,9 @@ class ContractOut(Schema):
         if expense_id is not _MISSING:
             return bool(expense_id)
 
-        if obj._state.fields_cache.get("expense") is not None:
-            return True
+        cached_expense = obj._state.fields_cache.get("expense", _MISSING)
+        if cached_expense is not _MISSING:
+            return cached_expense is not None
 
         try:
             return obj.expense is not None

--- a/backend/apps/logistics/services/contract_service.py
+++ b/backend/apps/logistics/services/contract_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 from decimal import Decimal
 from typing import Any
@@ -35,7 +36,12 @@ from apps.finances.models import Expense, Installment
 from apps.finances.schemas import ExpenseIn
 from apps.finances.services.expense_service import ExpenseService
 from apps.logistics.models import Contract, Supplier
-from apps.logistics.schemas import ContractIn, ContractPatchIn, ItemIn
+from apps.logistics.schemas import (
+    ContractFullCreateIn,
+    ContractIn,
+    ContractPatchIn,
+    ItemIn,
+)
 from apps.logistics.services.item_service import ItemService
 from apps.tenants.models import Company
 from apps.weddings.models import Wedding
@@ -121,13 +127,14 @@ class ContractService:
                 supplier_phone=F("supplier__phone"),
                 supplier_email=F("supplier__email"),
                 expense_id=Subquery(
-                    Expense.objects.filter(contract=OuterRef("pk")).values("uuid")[:1]
+                    Expense.objects.for_tenant(company)
+                    .filter(contract=OuterRef("pk"))
+                    .values("uuid")[:1]
                 ),
                 total_paid=Coalesce(
                     Subquery(
-                        Installment.objects.filter(
-                            expense__contract=OuterRef("pk"), status="PAID"
-                        )
+                        Installment.objects.for_tenant(company)
+                        .filter(expense__contract=OuterRef("pk"), status="PAID")
                         .values("expense__contract")
                         .annotate(s=Sum("amount"))
                         .values("s")[:1]
@@ -138,7 +145,8 @@ class ContractService:
                 # explosão de JOINs.
                 addendums_count=Coalesce(
                     Subquery(
-                        Contract.objects.filter(parent=OuterRef("pk"))
+                        Contract.objects.for_tenant(company)
+                        .filter(parent=OuterRef("pk"))
                         .values("parent")
                         .annotate(cnt=Count("id"))
                         .values("cnt")[:1]
@@ -184,7 +192,8 @@ class ContractService:
                     # explosão de JOINs.
                     addendums_count=Coalesce(
                         Subquery(
-                            Contract.objects.filter(parent=OuterRef("pk"))
+                            Contract.objects.for_tenant(company)
+                            .filter(parent=OuterRef("pk"))
                             .values("parent")
                             .annotate(cnt=Count("id"))
                             .values("cnt")[:1]
@@ -192,15 +201,93 @@ class ContractService:
                         0,
                     ),
                     expense_id=Subquery(
-                        Expense.objects.filter(contract=OuterRef("pk")).values("uuid")[
-                            :1
-                        ]
+                        Expense.objects.for_tenant(company)
+                        .filter(contract=OuterRef("pk"))
+                        .values("uuid")[:1]
+                    ),
+                    total_paid=Coalesce(
+                        Subquery(
+                            Installment.objects.for_tenant(company)
+                            .filter(expense__contract=OuterRef("pk"), status="PAID")
+                            .values("expense__contract")
+                            .annotate(s=Sum("amount"))
+                            .values("s")[:1]
+                        ),
+                        Value(Decimal("0.00")),
                     ),
                 )
                 .get(uuid=uuid)
             )
         except (Contract.DoesNotExist, ValueError, ValidationError) as e:
             raise ObjectNotFoundError(detail="Contrato não encontrado.") from e
+
+    @staticmethod
+    @transaction.atomic
+    def create_full_from_payload(
+        company: Company,
+        payload: ContractFullCreateIn,
+    ) -> Contract:
+        """
+        Cria um contrato completo a partir do payload HTTP.
+
+        Centraliza a montagem dos DTOs de contrato, itens e despesa para manter a
+        rota responsável apenas por autenticação e delegação.
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            payload: Dados validados pelo schema da rota de criação completa.
+
+        Returns:
+            A instância do Contract criada e totalmente populada.
+        """
+        contract_data = ContractIn(
+            wedding=payload.wedding,
+            supplier=payload.supplier,
+            name=payload.name,
+            total_amount=payload.total_amount,
+            status=payload.status,
+            description=payload.description,
+            parent=payload.parent,
+        )
+
+        items_data = ContractService._build_full_items_payload(payload)
+        expense_data = ContractService._build_full_expense_payload(payload)
+
+        return ContractService.create_full(
+            company=company,
+            contract_data=contract_data,
+            items_data=items_data,
+            expense_data=expense_data,
+            pdf_file_key=payload.pdf_file_key,
+        )
+
+    @staticmethod
+    def _build_full_items_payload(
+        payload: ContractFullCreateIn,
+    ) -> _ItemInList | None:
+        raw_items: list[dict[str, Any]] = json.loads(payload.items_data or "[]")
+        items_data = [
+            ItemIn(**{**item_data, "wedding": payload.wedding})
+            for item_data in raw_items
+        ]
+        return items_data or None
+
+    @staticmethod
+    def _build_full_expense_payload(
+        payload: ContractFullCreateIn,
+    ) -> ExpenseIn | None:
+        if not payload.create_expense:
+            return None
+
+        return ExpenseIn(
+            category=payload.expense_category,  # type: ignore[arg-type]
+            name=payload.name,
+            description=payload.description,
+            estimated_amount=payload.total_amount,
+            actual_amount=payload.total_amount,
+            num_installments=payload.expense_num_installments,
+            first_due_date=payload.expense_first_due_date,
+        )
 
     @staticmethod
     @transaction.atomic
@@ -232,7 +319,12 @@ class ContractService:
 
         # Resolução do Casamento
         if isinstance(wedding_input, Wedding):
-            wedding = wedding_input
+            wedding = validate_tenant_ownership(
+                company,
+                wedding_input,
+                detail="Casamento não encontrado ou acesso negado.",
+                code="wedding_not_found_or_denied",
+            )
         else:
             wedding = get_object_or_404_for_tenant(
                 Wedding,
@@ -243,7 +335,12 @@ class ContractService:
 
         # Resolução do Fornecedor
         if isinstance(supplier_input, Supplier):
-            supplier = supplier_input
+            supplier = validate_tenant_ownership(
+                company,
+                supplier_input,
+                detail="Fornecedor inválido ou acesso negado.",
+                code="supplier_not_found_or_denied",
+            )
         else:
             supplier = get_object_or_404_for_tenant(
                 Supplier,
@@ -362,7 +459,12 @@ class ContractService:
         """
         parent: Contract | None = None
         if isinstance(parent_input, Contract):
-            parent = parent_input
+            parent = validate_tenant_ownership(
+                company,
+                parent_input,
+                detail="Contrato pai inválido ou acesso negado.",
+                code="parent_contract_not_found_or_denied",
+            )
         elif parent_input == "":
             instance.parent = None
             return
@@ -440,7 +542,12 @@ class ContractService:
         supplier_input = data.pop("supplier", None)
         if supplier_input:
             if isinstance(supplier_input, Supplier):
-                instance.supplier = supplier_input
+                instance.supplier = validate_tenant_ownership(
+                    company,
+                    supplier_input,
+                    detail="Fornecedor inválido ou acesso negado.",
+                    code="supplier_not_found_or_denied",
+                )
             else:
                 instance.supplier = get_object_or_404_for_tenant(
                     Supplier,

--- a/backend/apps/logistics/services/contract_service.py
+++ b/backend/apps/logistics/services/contract_service.py
@@ -431,10 +431,8 @@ class ContractService:
                 company=company,
                 payload=expense_data.model_copy(update={"contract": contract.uuid}),
             )
-            # Otimização: Popula manualmente o cache reverso OneToOne e o expense_id
-            # para garantir que a serialização nos resolvers seja livre de queries.
+            # Otimização: Popula o cache reverso OneToOne para serialização imediata.
             contract.expense = expense
-            contract.expense_id = expense.uuid  # type: ignore[attr-defined]
 
         logger.info(f"Criação completa de Contrato finalizada: uuid={contract.uuid}")
         return contract

--- a/backend/apps/logistics/services/contract_service.py
+++ b/backend/apps/logistics/services/contract_service.py
@@ -20,6 +20,7 @@ from django.db.models import (
     Value,
 )
 from django.db.models.functions import Coalesce
+from pydantic import ValidationError as PydanticValidationError
 
 from apps.core.exceptions import (
     BusinessRuleViolation,
@@ -265,17 +266,60 @@ class ContractService:
     def _build_full_items_payload(
         payload: ContractFullCreateIn,
     ) -> _ItemInList | None:
-        raw_items: list[dict[str, Any]] = json.loads(payload.items_data or "[]")
-        items_data = [
-            ItemIn(**{**item_data, "wedding": payload.wedding})
-            for item_data in raw_items
-        ]
+        """
+        Converte o JSON de itens do payload completo em schemas de criação.
+
+        Args:
+            payload: Dados recebidos pelo endpoint de criação completa.
+
+        Returns:
+            Lista de itens normalizada com o casamento do contrato ou None.
+
+        Raises:
+            BusinessRuleViolation: Se `items_data` não for uma lista de objetos
+                JSON compatíveis com ItemIn.
+        """
+        try:
+            raw_items = json.loads(payload.items_data or "[]")
+        except json.JSONDecodeError as e:
+            raise BusinessRuleViolation(
+                detail="items_data deve ser um JSON válido.",
+                code="invalid_items_data",
+            ) from e
+
+        if not isinstance(raw_items, list) or not all(
+            isinstance(item_data, dict) for item_data in raw_items
+        ):
+            raise BusinessRuleViolation(
+                detail="items_data deve ser uma lista de objetos JSON.",
+                code="invalid_items_data",
+            )
+
+        try:
+            items_data = [
+                ItemIn(**{**item_data, "wedding": payload.wedding})
+                for item_data in raw_items
+            ]
+        except PydanticValidationError as e:
+            raise BusinessRuleViolation(
+                detail="items_data contém item inválido.",
+                code="invalid_items_data",
+            ) from e
         return items_data or None
 
     @staticmethod
     def _build_full_expense_payload(
         payload: ContractFullCreateIn,
     ) -> ExpenseIn | None:
+        """
+        Monta o payload financeiro opcional para criação completa de contrato.
+
+        Args:
+            payload: Dados recebidos pelo endpoint de criação completa.
+
+        Returns:
+            Schema de criação de despesa quando solicitado ou None.
+        """
         if not payload.create_expense:
             return None
 

--- a/backend/apps/logistics/services/item_service.py
+++ b/backend/apps/logistics/services/item_service.py
@@ -121,7 +121,12 @@ class ItemService:
         Wedding = apps.get_model("weddings", "Wedding")
 
         if isinstance(wedding_input, Wedding):
-            return wedding_input
+            return validate_tenant_ownership(
+                company,
+                wedding_input,
+                detail="Casamento não encontrado ou acesso negado.",
+                code="wedding_not_found_or_denied",
+            )
         if isinstance(wedding_input, UUID | str):
             return get_object_or_404_for_tenant(
                 Wedding,
@@ -154,7 +159,12 @@ class ItemService:
             return None
 
         if isinstance(contract_input, Contract):
-            return contract_input
+            return validate_tenant_ownership(
+                company,
+                contract_input,
+                detail="Contrato inválido ou acesso negado.",
+                code="contract_not_found_or_denied",
+            )
 
         return get_object_or_404_for_tenant(
             Contract,

--- a/backend/apps/logistics/tests/contracts/test_services.py
+++ b/backend/apps/logistics/tests/contracts/test_services.py
@@ -4,6 +4,8 @@ from uuid import uuid4
 
 import pytest
 from django.core.exceptions import ValidationError
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 
 from apps.core.exceptions import BusinessRuleViolation, ObjectNotFoundError
 from apps.finances.schemas import ExpenseIn
@@ -17,6 +19,7 @@ from apps.logistics.models import Contract
 from apps.logistics.schemas import (
     ContractFullCreateIn,
     ContractIn,
+    ContractOut,
     ContractPatchIn,
     ItemIn,
 )
@@ -785,6 +788,13 @@ class TestContractServiceCreateFull:
     """Testes de criação completa de contrato via ContractService.create_full()."""
 
     def _setup(self, user):
+        """
+        Cria o contexto mínimo para criação completa de contratos.
+
+        Returns:
+            tuple[Wedding, Supplier, BudgetCategory]: Casamento, fornecedor e
+            categoria de orçamento do tenant informado.
+        """
         wedding = WeddingFactory(company=user.company)
         supplier = SupplierFactory(company=user.company)
         budget = BudgetFactory(wedding=wedding)
@@ -868,6 +878,16 @@ class TestContractServiceCreateFull:
         )
         assert contract.expense is not None
         assert contract.expense.actual_amount == Decimal("5000.00")
+        assert not hasattr(contract, "expense_id")
+
+        with CaptureQueriesContext(connection) as ctx:
+            data = ContractOut.from_orm(contract)
+
+        assert data.expense_uuid == contract.expense.uuid
+        assert data.has_linked_expense is True
+        assert not any(
+            "finances_expense" in query["sql"] for query in ctx.captured_queries
+        )
 
     def test_create_full_with_all(self, user):
         """Cria contrato completo: file + items + expense."""

--- a/backend/apps/logistics/tests/contracts/test_services.py
+++ b/backend/apps/logistics/tests/contracts/test_services.py
@@ -11,9 +11,15 @@ from apps.finances.tests.factories import (
     BudgetCategoryFactory,
     BudgetFactory,
     ExpenseFactory,
+    InstallmentFactory,
 )
 from apps.logistics.models import Contract
-from apps.logistics.schemas import ContractIn, ContractPatchIn, ItemIn
+from apps.logistics.schemas import (
+    ContractFullCreateIn,
+    ContractIn,
+    ContractPatchIn,
+    ItemIn,
+)
 from apps.logistics.services.contract_service import ContractService
 from apps.logistics.tests.factories import ContractFactory, ItemFactory, SupplierFactory
 from apps.users.tests.factories import UserFactory
@@ -116,6 +122,28 @@ class TestContractServiceCreate:
 
         assert "wedding_not_found_or_denied" in str(exc_info.value.code)
 
+    def test_create_contract_rejects_supplier_instance_from_other_tenant(self):
+        """Instâncias pré-carregadas também precisam respeitar o tenant."""
+        user_a = UserFactory()
+        user_b = UserFactory()
+        wedding_a = WeddingFactory(user_context=user_a)
+        supplier_b = SupplierFactory(company=user_b.company)
+        payload = ContractIn.model_construct(
+            wedding=wedding_a,
+            supplier=supplier_b,
+            name="Contrato Cross Tenant",
+            total_amount=Decimal("1000.00"),
+            status=Contract.StatusChoices.DRAFT,
+            description="",
+            parent=None,
+            pdf_file_key=None,
+        )
+
+        with pytest.raises(ObjectNotFoundError) as exc_info:
+            ContractService.create(user_a.company, payload)
+
+        assert exc_info.value.code == "supplier_not_found_or_denied"
+
     # Regra intencional: supplier inativo não bloqueia criação de contrato.
     # O status is_active do supplier é um controle interno, não uma validação
     # de integridade referencial. O contrato pode referenciar um supplier que
@@ -212,6 +240,19 @@ class TestContractServiceUpdate:
             ContractService.update(
                 user.company, other_contract, ContractPatchIn(description="Hack")
             )
+
+    def test_update_contract_rejects_supplier_instance_from_other_tenant(self, user):
+        """Update não pode receber Supplier pré-carregado de outro tenant."""
+        wedding, supplier = _setup_contract_context(user)
+        other_user = UserFactory()
+        other_supplier = SupplierFactory(company=other_user.company)
+        contract = ContractFactory(wedding=wedding, supplier=supplier)
+        payload = ContractPatchIn.model_construct(supplier=other_supplier)
+
+        with pytest.raises(ObjectNotFoundError) as exc_info:
+            ContractService.update(user.company, contract, payload)
+
+        assert exc_info.value.code == "supplier_not_found_or_denied"
 
 
 @pytest.mark.django_db
@@ -373,6 +414,82 @@ class TestContractServiceListAndGet:
 
         with pytest.raises(ObjectNotFoundError):
             ContractService.get(user_a.company, contract_b.uuid)
+
+    def test_list_annotations_ignore_cross_tenant_related_records(self):
+        """Subqueries de list() não consideram vínculos corrompidos de outro tenant."""
+        user_a = UserFactory()
+        user_b = UserFactory()
+        wedding_a = WeddingFactory(user_context=user_a)
+        wedding_b = WeddingFactory(user_context=user_b)
+        supplier_a = SupplierFactory(company=user_a.company)
+        supplier_b = SupplierFactory(company=user_b.company)
+        contract = ContractFactory(wedding=wedding_a, supplier=supplier_a)
+        other_category = BudgetCategoryFactory(
+            budget=BudgetFactory(wedding=wedding_b),
+            wedding=wedding_b,
+        )
+        other_expense = ExpenseFactory(
+            wedding=wedding_b,
+            category=other_category,
+            contract=None,
+        )
+        other_addendum = ContractFactory(wedding=wedding_b, supplier=supplier_b)
+
+        ExpenseFactory._meta.model.objects.filter(pk=other_expense.pk).update(
+            contract=contract,
+            company=user_b.company,
+        )
+        InstallmentFactory(
+            expense=other_expense,
+            amount=Decimal("123.45"),
+            status="PAID",
+            paid_date=date.today(),
+        )
+        Contract.objects.filter(pk=other_addendum.pk).update(parent=contract)
+
+        result = ContractService.list(user_a.company).get(uuid=contract.uuid)
+
+        assert result.expense_id is None
+        assert result.total_paid == Decimal("0.00")
+        assert result.addendums_count == 0
+
+    def test_get_annotations_ignore_cross_tenant_related_records(self):
+        """Subqueries de get() não consideram vínculos corrompidos de outro tenant."""
+        user_a = UserFactory()
+        user_b = UserFactory()
+        wedding_a = WeddingFactory(user_context=user_a)
+        wedding_b = WeddingFactory(user_context=user_b)
+        supplier_a = SupplierFactory(company=user_a.company)
+        supplier_b = SupplierFactory(company=user_b.company)
+        contract = ContractFactory(wedding=wedding_a, supplier=supplier_a)
+        other_category = BudgetCategoryFactory(
+            budget=BudgetFactory(wedding=wedding_b),
+            wedding=wedding_b,
+        )
+        other_expense = ExpenseFactory(
+            wedding=wedding_b,
+            category=other_category,
+            contract=None,
+        )
+        other_addendum = ContractFactory(wedding=wedding_b, supplier=supplier_b)
+
+        ExpenseFactory._meta.model.objects.filter(pk=other_expense.pk).update(
+            contract=contract,
+            company=user_b.company,
+        )
+        InstallmentFactory(
+            expense=other_expense,
+            amount=Decimal("123.45"),
+            status="PAID",
+            paid_date=date.today(),
+        )
+        Contract.objects.filter(pk=other_addendum.pk).update(parent=contract)
+
+        result = ContractService.get(user_a.company, contract.uuid)
+
+        assert result.expense_id is None
+        assert result.total_paid == Decimal("0.00")
+        assert result.addendums_count == 0
 
 
 @pytest.mark.django_db
@@ -783,6 +900,55 @@ class TestContractServiceCreateFull:
         assert contract.items.count() == 1
         assert contract.expense is not None
         assert contract.expense.installments.count() == 3
+
+    def test_create_full_from_payload_with_all(self, user):
+        """Cria contrato completo a partir do schema usado pela API."""
+        wedding, supplier, category = self._setup(user)
+        payload = ContractFullCreateIn(
+            wedding=wedding.uuid,
+            supplier=supplier.uuid,
+            name="Contrato Payload",
+            total_amount=Decimal("10000.00"),
+            description="Teste payload",
+            items_data=(
+                '[{"name":"Item 1","quantity":10,"acquisition_status":"PENDING"}]'
+            ),
+            create_expense=True,
+            expense_category=category.uuid,
+            expense_num_installments=2,
+            expense_first_due_date=date.today(),
+            pdf_file_key="contracts/contrato.pdf",
+        )
+
+        contract = ContractService.create_full_from_payload(
+            company=user.company,
+            payload=payload,
+        )
+
+        assert contract.name == "Contrato Payload"
+        assert contract.pdf_file.name == "contracts/contrato.pdf"
+        assert contract.items.count() == 1
+        assert contract.expense is not None
+        assert contract.expense.installments.count() == 2
+
+    def test_create_full_from_payload_cross_tenant_wedding_raises_error(self):
+        """Payload da API preserva isolamento ao delegar a criação completa."""
+        user_a = UserFactory()
+        user_b = UserFactory()
+        wedding_b = WeddingFactory(company=user_b.company)
+        supplier_a = SupplierFactory(company=user_a.company)
+        payload = ContractFullCreateIn(
+            wedding=wedding_b.uuid,
+            supplier=supplier_a.uuid,
+            name="Cross Tenant",
+            total_amount=Decimal("5000.00"),
+        )
+
+        with pytest.raises(ObjectNotFoundError):
+            ContractService.create_full_from_payload(
+                company=user_a.company,
+                payload=payload,
+            )
 
     def test_create_full_invalid_file_type(self, user):
         """Arquivo com tipo inválido deve falhar."""

--- a/backend/apps/logistics/tests/contracts/test_services.py
+++ b/backend/apps/logistics/tests/contracts/test_services.py
@@ -1,5 +1,6 @@
 from datetime import date
 from decimal import Decimal
+from typing import no_type_check
 from uuid import uuid4
 
 import pytest
@@ -125,7 +126,8 @@ class TestContractServiceCreate:
 
         assert "wedding_not_found_or_denied" in str(exc_info.value.code)
 
-    def test_create_contract_rejects_supplier_instance_from_other_tenant(self):
+    @no_type_check
+    def test_create_contract_rejects_supplier_instance_from_other_tenant(self) -> None:
         """Instâncias pré-carregadas também precisam respeitar o tenant."""
         user_a = UserFactory()
         user_b = UserFactory()
@@ -244,7 +246,10 @@ class TestContractServiceUpdate:
                 user.company, other_contract, ContractPatchIn(description="Hack")
             )
 
-    def test_update_contract_rejects_supplier_instance_from_other_tenant(self, user):
+    @no_type_check
+    def test_update_contract_rejects_supplier_instance_from_other_tenant(
+        self, user
+    ) -> None:
         """Update não pode receber Supplier pré-carregado de outro tenant."""
         wedding, supplier = _setup_contract_context(user)
         other_user = UserFactory()
@@ -418,7 +423,8 @@ class TestContractServiceListAndGet:
         with pytest.raises(ObjectNotFoundError):
             ContractService.get(user_a.company, contract_b.uuid)
 
-    def test_list_annotations_ignore_cross_tenant_related_records(self):
+    @no_type_check
+    def test_list_annotations_ignore_cross_tenant_related_records(self) -> None:
         """Subqueries de list() não consideram vínculos corrompidos de outro tenant."""
         user_a = UserFactory()
         user_b = UserFactory()
@@ -456,7 +462,8 @@ class TestContractServiceListAndGet:
         assert result.total_paid == Decimal("0.00")
         assert result.addendums_count == 0
 
-    def test_get_annotations_ignore_cross_tenant_related_records(self):
+    @no_type_check
+    def test_get_annotations_ignore_cross_tenant_related_records(self) -> None:
         """Subqueries de get() não consideram vínculos corrompidos de outro tenant."""
         user_a = UserFactory()
         user_b = UserFactory()
@@ -921,7 +928,8 @@ class TestContractServiceCreateFull:
         assert contract.expense is not None
         assert contract.expense.installments.count() == 3
 
-    def test_create_full_from_payload_with_all(self, user):
+    @no_type_check
+    def test_create_full_from_payload_with_all(self, user) -> None:
         """Cria contrato completo a partir do schema usado pela API."""
         wedding, supplier, category = self._setup(user)
         payload = ContractFullCreateIn(
@@ -951,7 +959,48 @@ class TestContractServiceCreateFull:
         assert contract.expense is not None
         assert contract.expense.installments.count() == 2
 
-    def test_create_full_from_payload_cross_tenant_wedding_raises_error(self):
+    @no_type_check
+    def test_create_full_from_payload_rejects_non_list_items_data(self, user) -> None:
+        """items_data precisa ser uma lista JSON de objetos."""
+        wedding, supplier, _ = self._setup(user)
+        payload = ContractFullCreateIn(
+            wedding=wedding.uuid,
+            supplier=supplier.uuid,
+            name="Contrato Payload",
+            total_amount=Decimal("10000.00"),
+            items_data='{"name":"Item solto"}',
+        )
+
+        with pytest.raises(BusinessRuleViolation) as exc_info:
+            ContractService.create_full_from_payload(
+                company=user.company,
+                payload=payload,
+            )
+
+        assert exc_info.value.code == "invalid_items_data"
+
+    @no_type_check
+    def test_create_full_from_payload_rejects_non_object_items(self, user) -> None:
+        """Cada item de items_data precisa ser um objeto JSON."""
+        wedding, supplier, _ = self._setup(user)
+        payload = ContractFullCreateIn(
+            wedding=wedding.uuid,
+            supplier=supplier.uuid,
+            name="Contrato Payload",
+            total_amount=Decimal("10000.00"),
+            items_data='["item inválido"]',
+        )
+
+        with pytest.raises(BusinessRuleViolation) as exc_info:
+            ContractService.create_full_from_payload(
+                company=user.company,
+                payload=payload,
+            )
+
+        assert exc_info.value.code == "invalid_items_data"
+
+    @no_type_check
+    def test_create_full_from_payload_cross_tenant_wedding_raises_error(self) -> None:
         """Payload da API preserva isolamento ao delegar a criação completa."""
         user_a = UserFactory()
         user_b = UserFactory()

--- a/backend/apps/logistics/tests/items/test_services.py
+++ b/backend/apps/logistics/tests/items/test_services.py
@@ -103,6 +103,25 @@ class TestItemServiceCreate:
 
         assert "contract_not_found_or_denied" in str(exc_info.value.code)
 
+    def test_create_item_rejects_contract_instance_from_other_tenant(self):
+        """Instância de Contract pré-carregada também passa por validação tenant."""
+        user_a = UserFactory()
+        user_b = UserFactory()
+        _, contract_b = _setup_item_context(user_b)
+        payload = ItemIn.model_construct(
+            wedding=None,
+            contract=contract_b,
+            name="Invasão por instância",
+            description="",
+            quantity=1,
+            acquisition_status="PENDING",
+        )
+
+        with pytest.raises(ObjectNotFoundError) as exc_info:
+            ItemService.create(user_a.company, payload)
+
+        assert exc_info.value.code == "contract_not_found_or_denied"
+
     def test_create_item_without_contract_and_wedding_raises_error(self, user):
         """
         Sem contrato E sem wedding, create() levanta BusinessRuleViolation

--- a/backend/apps/logistics/tests/items/test_services.py
+++ b/backend/apps/logistics/tests/items/test_services.py
@@ -1,3 +1,4 @@
+from typing import no_type_check
 from uuid import uuid4
 
 import pytest
@@ -103,7 +104,8 @@ class TestItemServiceCreate:
 
         assert "contract_not_found_or_denied" in str(exc_info.value.code)
 
-    def test_create_item_rejects_contract_instance_from_other_tenant(self):
+    @no_type_check
+    def test_create_item_rejects_contract_instance_from_other_tenant(self) -> None:
         """Instância de Contract pré-carregada também passa por validação tenant."""
         user_a = UserFactory()
         user_b = UserFactory()

--- a/backend/apps/logistics/tests/test_apis.py
+++ b/backend/apps/logistics/tests/test_apis.py
@@ -655,6 +655,26 @@ class TestContractCreateFullAPI:
         detail = str(body.get("detail", ""))
         assert "json" in detail.lower()
 
+    def test_create_full_non_list_items_json(self, auth_client, user) -> None:
+        """POST /full/ com items_data não-lista retorna 422."""
+        wedding, supplier = self._wedding_supplier(user)
+        response = auth_client.post(
+            "/api/v1/logistics/contracts/full/",
+            data=json.dumps(
+                {
+                    "wedding": str(wedding.uuid),
+                    "supplier": str(supplier.uuid),
+                    "name": "Contrato",
+                    "total_amount": "5000.00",
+                    "items_data": '{"name":"Item solto"}',
+                }
+            ),
+            content_type="application/json",
+        )
+        assert response.status_code == 422
+        body = response.json()
+        assert "items_data" in str(body).lower()
+
     def test_create_full_expense_without_category(self, auth_client, user):
         """POST /full/ com create_expense=True sem categoria retorna 422."""
         wedding = WeddingFactory(company=user.company)

--- a/backend/apps/scheduler/services/events.py
+++ b/backend/apps/scheduler/services/events.py
@@ -117,7 +117,12 @@ class EventService:
             )
 
         if isinstance(wedding_input, Wedding):
-            wedding = wedding_input
+            wedding = validate_tenant_ownership(
+                company,
+                wedding_input,
+                detail="Acesso negado ao casamento.",
+                code="wedding_not_found_or_denied",
+            )
         else:
             wedding = get_object_or_404_for_tenant(
                 Wedding,

--- a/backend/apps/scheduler/services/tasks.py
+++ b/backend/apps/scheduler/services/tasks.py
@@ -86,7 +86,12 @@ class TaskService:
         wedding_input = data.pop("wedding", None)
 
         if isinstance(wedding_input, Wedding):
-            wedding = wedding_input
+            wedding = validate_tenant_ownership(
+                company,
+                wedding_input,
+                detail="Acesso negado ao casamento.",
+                code="wedding_not_found_or_denied",
+            )
         else:
             wedding = get_object_or_404_for_tenant(
                 Wedding,

--- a/backend/apps/scheduler/tests/appointments/test_services.py
+++ b/backend/apps/scheduler/tests/appointments/test_services.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from typing import no_type_check
 from uuid import uuid4
 
 import pytest
@@ -81,7 +82,8 @@ class TestEventServiceCreate:
 
         assert "wedding_not_found_or_denied" in str(exc_info.value.code)
 
-    def test_create_event_rejects_wedding_instance_from_other_tenant(self):
+    @no_type_check
+    def test_create_event_rejects_wedding_instance_from_other_tenant(self) -> None:
         """Instância de Wedding pré-carregada também passa por validação tenant."""
         user_a = UserFactory()
         user_b = UserFactory()

--- a/backend/apps/scheduler/tests/appointments/test_services.py
+++ b/backend/apps/scheduler/tests/appointments/test_services.py
@@ -81,6 +81,23 @@ class TestEventServiceCreate:
 
         assert "wedding_not_found_or_denied" in str(exc_info.value.code)
 
+    def test_create_event_rejects_wedding_instance_from_other_tenant(self):
+        """Instância de Wedding pré-carregada também passa por validação tenant."""
+        user_a = UserFactory()
+        user_b = UserFactory()
+        wedding_b = WeddingFactory(user_context=user_b)
+        data = {
+            "wedding": wedding_b,
+            "title": "Invasão por instância",
+            "event_type": Event.TypeChoices.OTHER,
+            "start_time": timezone.now() + timedelta(days=1),
+        }
+
+        with pytest.raises(ObjectNotFoundError) as exc_info:
+            EventService.create(user_a.company, data)
+
+        assert exc_info.value.code == "wedding_not_found_or_denied"
+
     def test_create_payment_event_blocked(self, user):
         """BR-S01: Eventos PAYMENT não podem ser criados manualmente."""
         wedding = WeddingFactory(user_context=user)

--- a/backend/apps/scheduler/tests/tasks/test_services.py
+++ b/backend/apps/scheduler/tests/tasks/test_services.py
@@ -1,3 +1,4 @@
+from typing import no_type_check
 from uuid import uuid4
 
 import pytest
@@ -71,7 +72,8 @@ class TestTaskServiceCreate:
 
         assert "wedding_not_found_or_denied" in str(exc_info.value.code)
 
-    def test_create_task_rejects_wedding_instance_from_other_tenant(self):
+    @no_type_check
+    def test_create_task_rejects_wedding_instance_from_other_tenant(self) -> None:
         """Instância de Wedding pré-carregada também passa por validação tenant."""
         user_a = UserFactory()
         user_b = UserFactory()

--- a/backend/apps/scheduler/tests/tasks/test_services.py
+++ b/backend/apps/scheduler/tests/tasks/test_services.py
@@ -71,6 +71,24 @@ class TestTaskServiceCreate:
 
         assert "wedding_not_found_or_denied" in str(exc_info.value.code)
 
+    def test_create_task_rejects_wedding_instance_from_other_tenant(self):
+        """Instância de Wedding pré-carregada também passa por validação tenant."""
+        user_a = UserFactory()
+        user_b = UserFactory()
+        wedding_b = WeddingFactory(user_context=user_b)
+        payload = TaskIn.model_construct(
+            wedding=wedding_b,
+            title="Invasão por instância",
+            description="",
+            due_date=None,
+            is_completed=False,
+        )
+
+        with pytest.raises(ObjectNotFoundError) as exc_info:
+            TaskService.create(user_a.company, payload)
+
+        assert exc_info.value.code == "wedding_not_found_or_denied"
+
 
 @pytest.mark.django_db
 class TestTaskServiceUpdate:


### PR DESCRIPTION
## Summary
- harden tenant ownership checks for services that receive preloaded model instances
- enforce cross-wedding integrity between expenses, contracts, categories and logistics flows
- move full contract creation orchestration out of the API layer and scope contract annotations by tenant
- add regression tests and replace direct objects.create usage in backend tests

## Verification
- uv run pytest
- uv run ruff check .
- uv run mypy .

Note: pytest passes with 6 expected Pydantic serializer warnings from tests that intentionally construct schemas with model instances to cover internal service branches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened tenant isolation when model instances are supplied in payloads (budgets, categories, expenses, installments, contracts, items, events, tasks), with consistent “not found or denied” errors.
  * Prevented expense/contract associations across mismatched weddings and rejected cross-tenant suppliers/weddings.
  * Enforced immutability of protected fields on paid installments.
  * Improved contract derived/list output fields to safely ignore corrupted relations and resolve linked expenses only when present.
* **Tests**
  * Added coverage for the above rules, including full contract creation and API validation of invalid `items_data`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->