### PR TITLE
refactor(core): add tenant resource resolver

### DIFF
--- a/backend/apps/core/shortcuts.py
+++ b/backend/apps/core/shortcuts.py
@@ -5,10 +5,27 @@ from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import models
 
 from apps.core.exceptions import ObjectNotFoundError
+from apps.core.tenant import validate_tenant_ownership
 
 
 if TYPE_CHECKING:
     from apps.tenants.models import Company
+
+
+def _get_not_found_detail(model_cls: type[models.Model], detail: str | None) -> str:
+    if detail:
+        return detail
+
+    model_name = getattr(model_cls._meta, "verbose_name", "Recurso")
+
+    name_str = str(model_name).lower()
+    suffix = (
+        "encontrada"
+        if name_str.endswith("a") or name_str.endswith("ão")
+        else "encontrado"
+    )
+
+    return f"{model_name} não {suffix} ou acesso negado."
 
 
 def get_object_or_404_for_tenant[ModelT: models.Model](
@@ -46,17 +63,80 @@ def get_object_or_404_for_tenant[ModelT: models.Model](
 
         return cast(ModelT, queryset.get(uuid=uuid))
     except (ObjectDoesNotExist, ValueError, ValidationError) as e:
-        model_name = getattr(model_cls._meta, "verbose_name", "Recurso")
+        raise ObjectNotFoundError(
+            detail=_get_not_found_detail(model_cls, detail),
+            code=code,
+        ) from e
 
-        # Ajuste de concordância gramatical básica
-        # Se termina em 'a' ou 'ão' (como em Categoria ou Organização),
-        # usamos 'encontrada'. É uma heurística simples.
-        name_str = str(model_name).lower()
-        suffix = (
-            "encontrada"
-            if name_str.endswith("a") or name_str.endswith("ão")
-            else "encontrado"
+
+def resolve_tenant_resource[ModelT: models.Model](
+    model_cls: type[ModelT],
+    company: "Company",
+    resource_input: ModelT | UUID | str,
+    *,
+    lookup_field: str = "uuid",
+    select_related: list[str] | None = None,
+    prefetch_related: list[str] | None = None,
+    detail: str | None = None,
+    code: str = "not_found_or_denied",
+) -> ModelT:
+    """
+    Resolve uma instância ou identificador garantindo isolamento por tenant.
+
+    Args:
+        model_cls: Classe esperada do modelo Django.
+        company: Tenant atual usado para validação e busca.
+        resource_input: Instância pré-carregada, UUID ou string identificadora.
+        lookup_field: Campo usado na busca quando o input é identificador.
+        select_related: Relações FK para otimização da busca.
+        prefetch_related: Relações reversas ou M2M para otimização da busca.
+        detail: Mensagem de erro customizada.
+        code: Código de erro customizado.
+
+    Returns:
+        A instância resolvida e pertencente ao tenant atual.
+
+    Raises:
+        ObjectNotFoundError: Se o recurso não existir, pertencer a outro tenant
+            ou o tipo recebido não puder ser resolvido com segurança.
+    """
+    if isinstance(resource_input, model_cls):
+        validate_tenant_ownership(
+            company,
+            resource_input,
+            detail=_get_not_found_detail(model_cls, detail),
+            code=code,
+        )
+        return resource_input
+
+    if not isinstance(resource_input, UUID | str):
+        raise ObjectNotFoundError(
+            detail=_get_not_found_detail(model_cls, detail),
+            code=code,
         )
 
-        error_detail = detail or f"{model_name} não {suffix} ou acesso negado."
-        raise ObjectNotFoundError(detail=error_detail, code=code) from e
+    if lookup_field == "uuid":
+        return get_object_or_404_for_tenant(
+            model_cls,
+            company,
+            resource_input,
+            select_related=select_related,
+            prefetch_related=prefetch_related,
+            detail=detail,
+            code=code,
+        )
+
+    try:
+        queryset = model_cls.objects.for_tenant(company)  # type: ignore[attr-defined]
+
+        if select_related:
+            queryset = queryset.select_related(*select_related)
+        if prefetch_related:
+            queryset = queryset.prefetch_related(*prefetch_related)
+
+        return cast(ModelT, queryset.get(**{lookup_field: resource_input}))
+    except (ObjectDoesNotExist, ValueError, ValidationError, TypeError) as e:
+        raise ObjectNotFoundError(
+            detail=_get_not_found_detail(model_cls, detail),
+            code=code,
+        ) from e

--- a/backend/apps/core/shortcuts.py
+++ b/backend/apps/core/shortcuts.py
@@ -9,6 +9,8 @@ from apps.core.tenant import validate_tenant_ownership
 
 
 if TYPE_CHECKING:
+    from django.db.models import QuerySet
+
     from apps.tenants.models import Company
 
 
@@ -26,6 +28,23 @@ def _get_not_found_detail(model_cls: type[models.Model], detail: str | None) -> 
     )
 
     return f"{model_name} não {suffix} ou acesso negado."
+
+
+def _build_tenant_queryset[ModelT: models.Model](
+    model_cls: type[ModelT],
+    company: "Company",
+    *,
+    select_related: list[str] | None = None,
+    prefetch_related: list[str] | None = None,
+) -> "QuerySet[ModelT]":
+    queryset = model_cls.objects.for_tenant(company)  # type: ignore[attr-defined]
+
+    if select_related:
+        queryset = queryset.select_related(*select_related)
+    if prefetch_related:
+        queryset = queryset.prefetch_related(*prefetch_related)
+
+    return cast("QuerySet[ModelT]", queryset)
 
 
 def get_object_or_404_for_tenant[ModelT: models.Model](
@@ -52,16 +71,14 @@ def get_object_or_404_for_tenant[ModelT: models.Model](
         code: Código de erro customizado.
     """
     try:
-        # Assumimos que o model_cls tem o TenantManager (objects)
-        # que implementa o método for_tenant.
-        queryset = model_cls.objects.for_tenant(company)  # type: ignore[attr-defined]
+        queryset = _build_tenant_queryset(
+            model_cls,
+            company,
+            select_related=select_related,
+            prefetch_related=prefetch_related,
+        )
 
-        if select_related:
-            queryset = queryset.select_related(*select_related)
-        if prefetch_related:
-            queryset = queryset.prefetch_related(*prefetch_related)
-
-        return cast(ModelT, queryset.get(uuid=uuid))
+        return queryset.get(uuid=uuid)
     except (ObjectDoesNotExist, ValueError, ValidationError) as e:
         raise ObjectNotFoundError(
             detail=_get_not_found_detail(model_cls, detail),
@@ -127,15 +144,15 @@ def resolve_tenant_resource[ModelT: models.Model](
         )
 
     try:
-        queryset = model_cls.objects.for_tenant(company)  # type: ignore[attr-defined]
+        queryset = _build_tenant_queryset(
+            model_cls,
+            company,
+            select_related=select_related,
+            prefetch_related=prefetch_related,
+        )
 
-        if select_related:
-            queryset = queryset.select_related(*select_related)
-        if prefetch_related:
-            queryset = queryset.prefetch_related(*prefetch_related)
-
-        return cast(ModelT, queryset.get(**{lookup_field: resource_input}))
-    except (ObjectDoesNotExist, ValueError, ValidationError, TypeError) as e:
+        return queryset.get(**{lookup_field: resource_input})
+    except (ObjectDoesNotExist, ValueError, ValidationError) as e:
         raise ObjectNotFoundError(
             detail=_get_not_found_detail(model_cls, detail),
             code=code,

--- a/backend/apps/core/tests/test_shortcuts.py
+++ b/backend/apps/core/tests/test_shortcuts.py
@@ -1,4 +1,4 @@
-from typing import Any, cast, no_type_check
+from typing import Any, cast
 from uuid import uuid4
 
 import pytest
@@ -169,20 +169,18 @@ class TestShortcuts:
 
 @pytest.mark.django_db
 class TestValidateTenantOwnership:
-    @no_type_check
     def test_validate_tenant_ownership_returns_instance_for_same_tenant(self) -> None:
-        company = CompanyFactory()
-        wedding = WeddingFactory(company=company)
+        company = _company()
+        wedding = _wedding(company=company)
 
         result = validate_tenant_ownership(company, wedding)
 
         assert result is wedding
 
-    @no_type_check
     def test_validate_tenant_ownership_raises_not_found_for_other_tenant(self) -> None:
-        company = CompanyFactory()
-        other_company = CompanyFactory()
-        wedding = WeddingFactory(company=other_company)
+        company = _company()
+        other_company = _company()
+        wedding = _wedding(company=other_company)
 
         with pytest.raises(ObjectNotFoundError) as exc_info:
             validate_tenant_ownership(

--- a/backend/apps/core/tests/test_shortcuts.py
+++ b/backend/apps/core/tests/test_shortcuts.py
@@ -1,4 +1,4 @@
-from typing import no_type_check
+from typing import Any, cast, no_type_check
 from uuid import uuid4
 
 import pytest
@@ -6,24 +6,33 @@ import pytest
 from apps.core.exceptions import ObjectNotFoundError
 from apps.core.shortcuts import get_object_or_404_for_tenant, resolve_tenant_resource
 from apps.core.tenant import validate_tenant_ownership
+from apps.tenants.models import Company
 from apps.tenants.tests.factories import CompanyFactory
 from apps.weddings.models import Wedding
 from apps.weddings.tests.factories import WeddingFactory
 
 
+def _company() -> Company:
+    return cast(Company, CompanyFactory())
+
+
+def _wedding(**kwargs: Any) -> Wedding:
+    return cast(Wedding, WeddingFactory(**kwargs))
+
+
 @pytest.mark.django_db
 class TestShortcuts:
-    def test_get_object_success(self):
-        company = CompanyFactory()
-        wedding = WeddingFactory(company=company)
+    def test_get_object_success(self) -> None:
+        company = _company()
+        wedding = _wedding(company=company)
 
         result = get_object_or_404_for_tenant(Wedding, company, wedding.uuid)
         assert result == wedding
 
-    def test_get_object_wrong_tenant(self):
-        company_a = CompanyFactory()
-        company_b = CompanyFactory()
-        wedding_a = WeddingFactory(company=company_a)
+    def test_get_object_wrong_tenant(self) -> None:
+        company_a = _company()
+        company_b = _company()
+        wedding_a = _wedding(company=company_a)
 
         with pytest.raises(ObjectNotFoundError) as exc_info:
             get_object_or_404_for_tenant(Wedding, company_b, wedding_a.uuid)
@@ -31,55 +40,58 @@ class TestShortcuts:
         assert "não encontrado" in str(exc_info.value).lower()
         assert exc_info.value.code == "not_found_or_denied"
 
-    def test_get_object_not_exists(self):
-        company = CompanyFactory()
+    def test_get_object_not_exists(self) -> None:
+        company = _company()
 
         with pytest.raises(ObjectNotFoundError):
             get_object_or_404_for_tenant(Wedding, company, uuid4())
 
-    def test_get_object_invalid_uuid(self):
-        company = CompanyFactory()
+    def test_get_object_invalid_uuid(self) -> None:
+        company = _company()
 
         with pytest.raises(ObjectNotFoundError):
             get_object_or_404_for_tenant(Wedding, company, "invalid-uuid")
 
-    def test_get_object_select_related(self):
-        company = CompanyFactory()
-        wedding = WeddingFactory(company=company)
+    def test_get_object_select_related(self) -> None:
+        company = _company()
+        wedding = _wedding(company=company)
 
         result = get_object_or_404_for_tenant(
             Wedding, company, wedding.uuid, select_related=["company"]
         )
         assert result == wedding
+        assert "company" in result._state.fields_cache
 
-    def test_resolve_tenant_resource_with_uuid_success(self):
-        company = CompanyFactory()
-        wedding = WeddingFactory(company=company)
+    def test_resolve_tenant_resource_with_uuid_success(self) -> None:
+        company = _company()
+        wedding = _wedding(company=company)
 
         result = resolve_tenant_resource(Wedding, company, wedding.uuid)
 
         assert result == wedding
 
-    def test_resolve_tenant_resource_with_string_success(self):
-        company = CompanyFactory()
-        wedding = WeddingFactory(company=company)
+    def test_resolve_tenant_resource_with_string_success(self) -> None:
+        company = _company()
+        wedding = _wedding(company=company)
 
         result = resolve_tenant_resource(Wedding, company, str(wedding.uuid))
 
         assert result == wedding
 
-    def test_resolve_tenant_resource_with_valid_instance_success(self):
-        company = CompanyFactory()
-        wedding = WeddingFactory(company=company)
+    def test_resolve_tenant_resource_with_valid_instance_success(self) -> None:
+        company = _company()
+        wedding = _wedding(company=company)
 
         result = resolve_tenant_resource(Wedding, company, wedding)
 
         assert result == wedding
 
-    def test_resolve_tenant_resource_with_cross_tenant_instance_raises_error(self):
-        company_a = CompanyFactory()
-        company_b = CompanyFactory()
-        wedding = WeddingFactory(company=company_a)
+    def test_resolve_tenant_resource_with_cross_tenant_instance_raises_error(
+        self,
+    ) -> None:
+        company_a = _company()
+        company_b = _company()
+        wedding = _wedding(company=company_a)
 
         with pytest.raises(ObjectNotFoundError) as exc_info:
             resolve_tenant_resource(
@@ -93,14 +105,15 @@ class TestShortcuts:
         assert exc_info.value.detail == "Casamento não encontrado ou acesso negado."
         assert exc_info.value.code == "wedding_not_found_or_denied"
 
-    def test_resolve_tenant_resource_with_invalid_type_raises_error(self):
-        company = CompanyFactory()
+    def test_resolve_tenant_resource_with_invalid_type_raises_error(self) -> None:
+        company = _company()
+        invalid_resource: Any = object()
 
         with pytest.raises(ObjectNotFoundError) as exc_info:
             resolve_tenant_resource(
                 Wedding,
                 company,
-                object(),
+                invalid_resource,
                 detail="Casamento inválido ou acesso negado.",
                 code="wedding_not_found_or_denied",
             )
@@ -108,9 +121,9 @@ class TestShortcuts:
         assert exc_info.value.detail == "Casamento inválido ou acesso negado."
         assert exc_info.value.code == "wedding_not_found_or_denied"
 
-    def test_resolve_tenant_resource_with_select_related_success(self):
-        company = CompanyFactory()
-        wedding = WeddingFactory(company=company)
+    def test_resolve_tenant_resource_with_select_related_success(self) -> None:
+        company = _company()
+        wedding = _wedding(company=company)
 
         result = resolve_tenant_resource(
             Wedding,
@@ -120,6 +133,38 @@ class TestShortcuts:
         )
 
         assert result == wedding
+        assert "company" in result._state.fields_cache
+
+    def test_resolve_tenant_resource_with_custom_lookup_field_success(self) -> None:
+        company = _company()
+        wedding = _wedding(company=company, groom_name="Rafael")
+
+        result = resolve_tenant_resource(
+            Wedding,
+            company,
+            "Rafael",
+            lookup_field="groom_name",
+            select_related=["company"],
+        )
+
+        assert result == wedding
+        assert "company" in result._state.fields_cache
+
+    def test_resolve_tenant_resource_with_custom_lookup_field_not_found(self) -> None:
+        company = _company()
+
+        with pytest.raises(ObjectNotFoundError) as exc_info:
+            resolve_tenant_resource(
+                Wedding,
+                company,
+                "Nome inexistente",
+                lookup_field="groom_name",
+                detail="Casamento não encontrado ou acesso negado.",
+                code="wedding_not_found_or_denied",
+            )
+
+        assert exc_info.value.detail == "Casamento não encontrado ou acesso negado."
+        assert exc_info.value.code == "wedding_not_found_or_denied"
 
 
 @pytest.mark.django_db

--- a/backend/apps/core/tests/test_shortcuts.py
+++ b/backend/apps/core/tests/test_shortcuts.py
@@ -3,36 +3,25 @@ from uuid import uuid4
 import pytest
 
 from apps.core.exceptions import ObjectNotFoundError
-from apps.core.shortcuts import get_object_or_404_for_tenant
-from apps.tenants.models import Company
+from apps.core.shortcuts import get_object_or_404_for_tenant, resolve_tenant_resource
+from apps.tenants.tests.factories import CompanyFactory
 from apps.weddings.models import Wedding
+from apps.weddings.tests.factories import WeddingFactory
 
 
 @pytest.mark.django_db
 class TestShortcuts:
     def test_get_object_success(self):
-        company = Company.objects.create(name="Test Company", slug="test-company")
-        wedding = Wedding.objects.create(
-            company=company,
-            groom_name="Groom",
-            bride_name="Bride",
-            date="2026-12-31",
-            location="Test Location",
-        )
+        company = CompanyFactory()
+        wedding = WeddingFactory(company=company)
 
         result = get_object_or_404_for_tenant(Wedding, company, wedding.uuid)
         assert result == wedding
 
     def test_get_object_wrong_tenant(self):
-        company_a = Company.objects.create(name="Company A", slug="company-a")
-        company_b = Company.objects.create(name="Company B", slug="company-b")
-        wedding_a = Wedding.objects.create(
-            company=company_a,
-            groom_name="Groom A",
-            bride_name="Bride A",
-            date="2026-12-31",
-            location="Test Location A",
-        )
+        company_a = CompanyFactory()
+        company_b = CompanyFactory()
+        wedding_a = WeddingFactory(company=company_a)
 
         with pytest.raises(ObjectNotFoundError) as exc_info:
             get_object_or_404_for_tenant(Wedding, company_b, wedding_a.uuid)
@@ -41,29 +30,92 @@ class TestShortcuts:
         assert exc_info.value.code == "not_found_or_denied"
 
     def test_get_object_not_exists(self):
-        company = Company.objects.create(name="Test Company", slug="test-company")
+        company = CompanyFactory()
 
         with pytest.raises(ObjectNotFoundError):
             get_object_or_404_for_tenant(Wedding, company, uuid4())
 
     def test_get_object_invalid_uuid(self):
-        company = Company.objects.create(name="Test Company", slug="test-company")
+        company = CompanyFactory()
 
         with pytest.raises(ObjectNotFoundError):
             get_object_or_404_for_tenant(Wedding, company, "invalid-uuid")
 
     def test_get_object_select_related(self):
-        company = Company.objects.create(name="Test Company", slug="test-company")
-        wedding = Wedding.objects.create(
-            company=company,
-            groom_name="Groom",
-            bride_name="Bride",
-            date="2026-12-31",
-            location="Test Location",
-        )
+        company = CompanyFactory()
+        wedding = WeddingFactory(company=company)
 
         # Apenas para verificar se não explode e chama o método
         result = get_object_or_404_for_tenant(
             Wedding, company, wedding.uuid, select_related=["company"]
         )
+        assert result == wedding
+
+    def test_resolve_tenant_resource_with_uuid_success(self):
+        company = CompanyFactory()
+        wedding = WeddingFactory(company=company)
+
+        result = resolve_tenant_resource(Wedding, company, wedding.uuid)
+
+        assert result == wedding
+
+    def test_resolve_tenant_resource_with_string_success(self):
+        company = CompanyFactory()
+        wedding = WeddingFactory(company=company)
+
+        result = resolve_tenant_resource(Wedding, company, str(wedding.uuid))
+
+        assert result == wedding
+
+    def test_resolve_tenant_resource_with_valid_instance_success(self):
+        company = CompanyFactory()
+        wedding = WeddingFactory(company=company)
+
+        result = resolve_tenant_resource(Wedding, company, wedding)
+
+        assert result == wedding
+
+    def test_resolve_tenant_resource_with_cross_tenant_instance_raises_error(self):
+        company_a = CompanyFactory()
+        company_b = CompanyFactory()
+        wedding = WeddingFactory(company=company_a)
+
+        with pytest.raises(ObjectNotFoundError) as exc_info:
+            resolve_tenant_resource(
+                Wedding,
+                company_b,
+                wedding,
+                detail="Casamento não encontrado ou acesso negado.",
+                code="wedding_not_found_or_denied",
+            )
+
+        assert exc_info.value.detail == "Casamento não encontrado ou acesso negado."
+        assert exc_info.value.code == "wedding_not_found_or_denied"
+
+    def test_resolve_tenant_resource_with_invalid_type_raises_error(self):
+        company = CompanyFactory()
+
+        with pytest.raises(ObjectNotFoundError) as exc_info:
+            resolve_tenant_resource(
+                Wedding,
+                company,
+                object(),
+                detail="Casamento inválido ou acesso negado.",
+                code="wedding_not_found_or_denied",
+            )
+
+        assert exc_info.value.detail == "Casamento inválido ou acesso negado."
+        assert exc_info.value.code == "wedding_not_found_or_denied"
+
+    def test_resolve_tenant_resource_with_select_related_success(self):
+        company = CompanyFactory()
+        wedding = WeddingFactory(company=company)
+
+        result = resolve_tenant_resource(
+            Wedding,
+            company,
+            wedding.uuid,
+            select_related=["company"],
+        )
+
         assert result == wedding

--- a/backend/apps/finances/services/budget_category_service.py
+++ b/backend/apps/finances/services/budget_category_service.py
@@ -10,7 +10,7 @@ from apps.core.exceptions import (
     BusinessRuleViolation,
     DomainIntegrityError,
 )
-from apps.core.shortcuts import get_object_or_404_for_tenant
+from apps.core.shortcuts import resolve_tenant_resource
 from apps.core.tenant import validate_tenant_ownership
 from apps.finances.managers import BudgetCategoryQuerySet
 from apps.finances.models import Budget, BudgetCategory
@@ -141,16 +141,13 @@ class BudgetCategoryService:
 
         budget_input = data.pop("budget", None)
 
-        if isinstance(budget_input, Budget):
-            budget = budget_input
-        else:
-            budget = get_object_or_404_for_tenant(
-                Budget,
-                company,
-                budget_input,
-                detail="Orçamento mestre não encontrado ou acesso negado.",
-                code="budget_not_found_or_denied",
-            )
+        budget = resolve_tenant_resource(
+            Budget,
+            company,
+            budget_input,
+            detail="Orçamento mestre não encontrado ou acesso negado.",
+            code="budget_not_found_or_denied",
+        )
 
         # TRAVA DE SEGURANÇA (TOCTOU): lock no budget antes de ler soma das categorias
         budget = (

--- a/backend/apps/finances/services/budget_service.py
+++ b/backend/apps/finances/services/budget_service.py
@@ -7,7 +7,7 @@ from django.db import IntegrityError, transaction
 from django.db.models import ProtectedError, QuerySet
 
 from apps.core.exceptions import DomainIntegrityError
-from apps.core.shortcuts import get_object_or_404_for_tenant
+from apps.core.shortcuts import get_object_or_404_for_tenant, resolve_tenant_resource
 from apps.core.tenant import validate_tenant_ownership
 from apps.finances.managers import BudgetQuerySet
 from apps.finances.models import Budget
@@ -96,15 +96,12 @@ class BudgetService:
 
         wedding_input = data.pop("wedding", None)
 
-        if isinstance(wedding_input, Wedding):
-            wedding = wedding_input
-        else:
-            wedding = get_object_or_404_for_tenant(
-                Wedding,
-                company,
-                wedding_input,
-                code="wedding_not_found_or_denied",
-            )
+        wedding = resolve_tenant_resource(
+            Wedding,
+            company,
+            wedding_input,
+            code="wedding_not_found_or_denied",
+        )
 
         # 2. Instanciação em Memória
         budget = Budget(company=company, wedding=wedding, **data)

--- a/backend/apps/finances/services/expense_service.py
+++ b/backend/apps/finances/services/expense_service.py
@@ -12,7 +12,7 @@ from apps.core.exceptions import (
     BusinessRuleViolation,
     ObjectNotFoundError,
 )
-from apps.core.shortcuts import get_object_or_404_for_tenant
+from apps.core.shortcuts import get_object_or_404_for_tenant, resolve_tenant_resource
 from apps.core.tenant import validate_tenant_ownership
 from apps.finances.managers import ExpenseQuerySet
 from apps.finances.models import BudgetCategory, Expense
@@ -143,31 +143,25 @@ class ExpenseService:
 
         category_input = data.pop("category", None)
 
-        if isinstance(category_input, BudgetCategory):
-            category = category_input
-        else:
-            category = get_object_or_404_for_tenant(
-                BudgetCategory,
-                company,
-                category_input,
-                detail="Categoria de orçamento não encontrada ou acesso negado.",
-                code="budget_category_not_found_or_denied",
-            )
+        category = resolve_tenant_resource(
+            BudgetCategory,
+            company,
+            category_input,
+            detail="Categoria de orçamento não encontrada ou acesso negado.",
+            code="budget_category_not_found_or_denied",
+        )
 
         # 2. Resolução de Contrato (Opcional)
         contract = None
         contract_input = data.pop("contract", None)
 
         if contract_input:
-            if isinstance(contract_input, Contract):
-                contract = contract_input
-            else:
-                contract = get_object_or_404_for_tenant(
-                    Contract,
-                    company,
-                    contract_input,
-                    code="contract_not_found_or_denied",
-                )
+            contract = resolve_tenant_resource(
+                Contract,
+                company,
+                contract_input,
+                code="contract_not_found_or_denied",
+            )
 
         num_installments = data.pop("num_installments", None)
         if num_installments is None:
@@ -266,16 +260,13 @@ class ExpenseService:
             ObjectNotFoundError: Se o contrato especificado não for encontrado.
         """
         if contract_input:
-            if isinstance(contract_input, Contract):
-                instance.contract = contract_input
-            else:
-                instance.contract = get_object_or_404_for_tenant(
-                    Contract,
-                    company,
-                    contract_input,
-                    code="contract_not_found_or_denied",
-                    detail="Contrato inválido ou acesso negado.",
-                )
+            instance.contract = resolve_tenant_resource(
+                Contract,
+                company,
+                contract_input,
+                code="contract_not_found_or_denied",
+                detail="Contrato inválido ou acesso negado.",
+            )
         else:
             instance.contract = None
 

--- a/backend/apps/finances/services/installment_service.py
+++ b/backend/apps/finances/services/installment_service.py
@@ -11,9 +11,8 @@ from django.db.models import QuerySet
 from apps.core.exceptions import (
     BusinessRuleViolation,
     DomainIntegrityError,
-    ObjectNotFoundError,
 )
-from apps.core.shortcuts import get_object_or_404_for_tenant
+from apps.core.shortcuts import get_object_or_404_for_tenant, resolve_tenant_resource
 from apps.core.tenant import validate_tenant_ownership
 from apps.finances.models import Expense, Installment
 from apps.finances.schemas import InstallmentAdjustIn, InstallmentIn, InstallmentPatchIn
@@ -252,19 +251,13 @@ class InstallmentService:
         data = payload.model_dump(exclude_unset=True)
 
         expense_input = data.pop("expense", None)
-        if isinstance(expense_input, Expense):
-            expense = expense_input
-        else:
-            try:
-                expense = Expense.objects.for_tenant(company).get(uuid=expense_input)
-            except Expense.DoesNotExist as e:
-                logger.warning(
-                    f"Tentativa de uso de despesa inválida/negada: {expense_input}"
-                )
-                raise ObjectNotFoundError(
-                    detail="Despesa não encontrada ou acesso negado.",
-                    code="expense_not_found_or_denied",
-                ) from e
+        expense = resolve_tenant_resource(
+            Expense,
+            company,
+            expense_input,
+            detail="Despesa não encontrada ou acesso negado.",
+            code="expense_not_found_or_denied",
+        )
 
         # 2. Injeção de Contexto e Instanciação
         installment = Installment(

--- a/backend/apps/logistics/services/contract_service.py
+++ b/backend/apps/logistics/services/contract_service.py
@@ -29,7 +29,7 @@ from apps.core.services.storage_service import (
     StorageService,
     get_storage_service,
 )
-from apps.core.shortcuts import get_object_or_404_for_tenant
+from apps.core.shortcuts import get_object_or_404_for_tenant, resolve_tenant_resource
 from apps.core.tenant import validate_tenant_ownership
 from apps.finances.models import Expense, Installment
 from apps.finances.schemas import ExpenseIn
@@ -230,32 +230,24 @@ class ContractService:
         supplier_input = data.pop("supplier", None)
         pdf_file_key = data.pop("pdf_file_key", None)
 
-        # Resolução do Casamento
-        if isinstance(wedding_input, Wedding):
-            wedding = wedding_input
-        else:
-            wedding = get_object_or_404_for_tenant(
-                Wedding,
-                company,
-                wedding_input,
-                code="wedding_not_found_or_denied",
-            )
+        wedding = resolve_tenant_resource(
+            Wedding,
+            company,
+            wedding_input,
+            code="wedding_not_found_or_denied",
+        )
 
-        # Resolução do Fornecedor
-        if isinstance(supplier_input, Supplier):
-            supplier = supplier_input
-        else:
-            supplier = get_object_or_404_for_tenant(
-                Supplier,
-                company,
-                supplier_input,
-                code="supplier_not_found_or_denied",
-            )
+        supplier = resolve_tenant_resource(
+            Supplier,
+            company,
+            supplier_input,
+            code="supplier_not_found_or_denied",
+        )
 
         parent_input = data.pop("parent", None)
         parent = None
         if parent_input:
-            parent = get_object_or_404_for_tenant(
+            parent = resolve_tenant_resource(
                 Contract,
                 company,
                 parent_input,
@@ -361,19 +353,17 @@ class ContractService:
             ObjectNotFoundError: Se o contrato pai não for encontrado para o tenant.
         """
         parent: Contract | None = None
-        if isinstance(parent_input, Contract):
-            parent = parent_input
-        elif parent_input == "":
+        if parent_input == "":
             instance.parent = None
             return
-        else:
-            parent = get_object_or_404_for_tenant(
-                Contract,
-                company,
-                parent_input,
-                detail="Contrato pai inválido ou acesso negado.",
-                code="parent_contract_not_found_or_denied",
-            )
+
+        parent = resolve_tenant_resource(
+            Contract,
+            company,
+            parent_input,
+            detail="Contrato pai inválido ou acesso negado.",
+            code="parent_contract_not_found_or_denied",
+        )
 
         if parent is not None:
             if parent.pk == instance.pk:
@@ -439,16 +429,13 @@ class ContractService:
 
         supplier_input = data.pop("supplier", None)
         if supplier_input:
-            if isinstance(supplier_input, Supplier):
-                instance.supplier = supplier_input
-            else:
-                instance.supplier = get_object_or_404_for_tenant(
-                    Supplier,
-                    company,
-                    supplier_input,
-                    detail="Fornecedor inválido ou acesso negado.",
-                    code="supplier_not_found_or_denied",
-                )
+            instance.supplier = resolve_tenant_resource(
+                Supplier,
+                company,
+                supplier_input,
+                detail="Fornecedor inválido ou acesso negado.",
+                code="supplier_not_found_or_denied",
+            )
 
         parent_input = data.pop("parent", None)
         if parent_input is not None:

--- a/backend/apps/logistics/services/item_service.py
+++ b/backend/apps/logistics/services/item_service.py
@@ -12,7 +12,7 @@ from apps.core.exceptions import (
     BusinessRuleViolation,
     DomainIntegrityError,
 )
-from apps.core.shortcuts import get_object_or_404_for_tenant
+from apps.core.shortcuts import get_object_or_404_for_tenant, resolve_tenant_resource
 from apps.core.tenant import validate_tenant_ownership
 from apps.logistics.models import Contract, Item
 from apps.logistics.schemas import ItemIn, ItemPatchIn
@@ -120,16 +120,12 @@ class ItemService:
 
         Wedding = apps.get_model("weddings", "Wedding")
 
-        if isinstance(wedding_input, Wedding):
-            return wedding_input
-        if isinstance(wedding_input, UUID | str):
-            return get_object_or_404_for_tenant(
-                Wedding,
-                company,
-                wedding_input,
-                code="wedding_not_found_or_denied",
-            )
-        return None
+        return resolve_tenant_resource(
+            Wedding,
+            company,
+            wedding_input,
+            code="wedding_not_found_or_denied",
+        )
 
     @staticmethod
     def _resolve_contract(
@@ -153,10 +149,7 @@ class ItemService:
         if not contract_input:
             return None
 
-        if isinstance(contract_input, Contract):
-            return contract_input
-
-        return get_object_or_404_for_tenant(
+        return resolve_tenant_resource(
             Contract,
             company,
             contract_input,

--- a/backend/apps/scheduler/services/events.py
+++ b/backend/apps/scheduler/services/events.py
@@ -8,7 +8,7 @@ from django.db.models import QuerySet
 from apps.core.exceptions import (
     BusinessRuleViolation,
 )
-from apps.core.shortcuts import get_object_or_404_for_tenant
+from apps.core.shortcuts import get_object_or_404_for_tenant, resolve_tenant_resource
 from apps.core.tenant import validate_tenant_ownership
 from apps.scheduler.models import Event
 from apps.scheduler.schemas import EventIn, EventPatchIn
@@ -116,16 +116,13 @@ class EventService:
                 code="payment_event_readonly",
             )
 
-        if isinstance(wedding_input, Wedding):
-            wedding = wedding_input
-        else:
-            wedding = get_object_or_404_for_tenant(
-                Wedding,
-                company,
-                wedding_input,
-                code="wedding_not_found_or_denied",
-                detail="Acesso negado ao casamento.",
-            )
+        wedding = resolve_tenant_resource(
+            Wedding,
+            company,
+            wedding_input,
+            code="wedding_not_found_or_denied",
+            detail="Acesso negado ao casamento.",
+        )
 
         event = Event(company=company, wedding=wedding, **data)
         event.save()

--- a/backend/apps/scheduler/services/tasks.py
+++ b/backend/apps/scheduler/services/tasks.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from django.db import transaction
 from django.db.models import QuerySet
 
-from apps.core.shortcuts import get_object_or_404_for_tenant
+from apps.core.shortcuts import get_object_or_404_for_tenant, resolve_tenant_resource
 from apps.core.tenant import validate_tenant_ownership
 from apps.scheduler.models import Task
 from apps.scheduler.schemas import TaskIn, TaskPatchIn
@@ -85,16 +85,13 @@ class TaskService:
         data = payload.model_dump(exclude_unset=True)
         wedding_input = data.pop("wedding", None)
 
-        if isinstance(wedding_input, Wedding):
-            wedding = wedding_input
-        else:
-            wedding = get_object_or_404_for_tenant(
-                Wedding,
-                company,
-                wedding_input,
-                code="wedding_not_found_or_denied",
-                detail="Acesso negado ao casamento.",
-            )
+        wedding = resolve_tenant_resource(
+            Wedding,
+            company,
+            wedding_input,
+            code="wedding_not_found_or_denied",
+            detail="Acesso negado ao casamento.",
+        )
 
         task = Task(company=company, wedding=wedding, **data)
         task.save()


### PR DESCRIPTION
## Summary
- add resolve_tenant_resource to centralize tenant-aware resolution for model instances and UUID/string inputs
- migrate finances, logistics, and scheduler services away from repeated instance-vs-lookup branches
- expand shortcut tests for UUID, string, valid instance, cross-tenant instance, invalid type, and select_related cases

## Validation
- uv run pytest apps/core/tests/test_shortcuts.py apps/finances/tests apps/logistics/tests apps/scheduler/tests
- uv run ruff check .
- uv run mypy .

Closes #283

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a shared tenant-aware resolver that can take either an existing record or a tenant-scoped identifier, with optional related-data loading.
- **Bug Fixes**
  - Standardized “not found or access denied” Portuguese messaging and consistent `detail`/`code` behavior across budget, expense, contract, item, event, task, and installment flows.
- **Refactor**
  - Unified resource resolution and authorization logic across multiple services for consistent outcomes.
- **Tests**
  - Expanded resolver and authorization coverage, including custom lookup fields and assertions for related-data caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->