### PR TITLE
test(logistics): add complete tests for ItemsTable and VendorsTable

### DIFF
--- a/frontend/src/features/logistics/components/items/ItemsTable.test.tsx
+++ b/frontend/src/features/logistics/components/items/ItemsTable.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { render, screen, userEvent } from "@/test-utils";
+import { render, screen, userEvent, waitFor } from "@/test-utils";
 import { WeddingItemsTable } from "@/features/logistics/components/items/ItemsTable";
 import { createMockItem } from "@/test-data";
 import { server } from "@/mocks/server";
@@ -37,28 +37,28 @@ describe("WeddingItemsTable", () => {
   it("calls onEdit when Editar is clicked in dropdown", async () => {
     const onEdit = vi.fn();
     const item = createMockItem();
-    render(<WeddingItemsTable items={[item]} onEdit={onEdit} />);
+    const { container } = render(<WeddingItemsTable items={[item]} onEdit={onEdit} />);
 
     const user = userEvent.setup();
-    // Open dropdown menu
-    await user.click(screen.getByRole("button"));
+    // Open dropdown menu using robust container selector
+    await user.click(container.querySelector("button")!);
 
-    // Find and click "Editar" item
-    await user.click(screen.getByText("Editar"));
+    // Find and click "Editar" item using async findByText to avoid transition flakiness
+    await user.click(await screen.findByText("Editar"));
 
     expect(onEdit).toHaveBeenCalledWith(item);
   });
 
   it("opens ConfirmDeleteDialog when Excluir is clicked", async () => {
     const item = createMockItem();
-    render(<WeddingItemsTable items={[item]} onEdit={vi.fn()} />);
+    const { container } = render(<WeddingItemsTable items={[item]} onEdit={vi.fn()} />);
 
     const user = userEvent.setup();
     // Open dropdown
-    await user.click(screen.getByRole("button"));
+    await user.click(container.querySelector("button")!);
 
-    // Click "Excluir"
-    await user.click(screen.getByText("Excluir"));
+    // Click "Excluir" using findByText
+    await user.click(await screen.findByText("Excluir"));
 
     // Verify dialog is open
     expect(screen.getByRole("dialog")).toBeInTheDocument();
@@ -69,53 +69,95 @@ describe("WeddingItemsTable", () => {
     const onRefresh = vi.fn();
     const item = createMockItem();
 
-    // Mock API success for DELETE
+    // Mock API success for DELETE with precise route pattern
     server.use(
-      http.delete("*/api/v1/logistics/items/*", () => {
+      http.delete("*/api/v1/logistics/items/:uuid", () => {
         return new HttpResponse(null, { status: 204 });
       })
     );
 
-    render(<WeddingItemsTable items={[item]} onEdit={vi.fn()} onRefresh={onRefresh} />);
+    const { container } = render(
+      <WeddingItemsTable items={[item]} onEdit={vi.fn()} onRefresh={onRefresh} />
+    );
 
     const user = userEvent.setup();
     // Open dropdown
-    await user.click(screen.getByRole("button"));
+    await user.click(container.querySelector("button")!);
 
     // Click "Excluir"
-    await user.click(screen.getByText("Excluir"));
+    await user.click(await screen.findByText("Excluir"));
 
     // Click "Deletar Permanentemente"
     await user.click(screen.getByRole("button", { name: "Deletar Permanentemente" }));
 
-    expect(toast.success).toHaveBeenCalledWith("Item deletado com sucesso!");
-    expect(onRefresh).toHaveBeenCalled();
+    // Wrap assertions in waitFor to avoid async callback race conditions
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("Item deletado com sucesso!");
+      expect(onRefresh).toHaveBeenCalled();
+    });
   });
 
   it("shows error toast when item deletion fails", async () => {
     const onRefresh = vi.fn();
     const item = createMockItem();
 
-    // Mock API failure for DELETE
+    // Mock API failure for DELETE with precise route pattern
     server.use(
-      http.delete("*/api/v1/logistics/items/*", () => {
+      http.delete("*/api/v1/logistics/items/:uuid", () => {
         return HttpResponse.json({ detail: "Erro interno" }, { status: 500 });
       })
     );
 
-    render(<WeddingItemsTable items={[item]} onEdit={vi.fn()} onRefresh={onRefresh} />);
+    const { container } = render(
+      <WeddingItemsTable items={[item]} onEdit={vi.fn()} onRefresh={onRefresh} />
+    );
 
     const user = userEvent.setup();
     // Open dropdown
-    await user.click(screen.getByRole("button"));
+    await user.click(container.querySelector("button")!);
 
     // Click "Excluir"
-    await user.click(screen.getByText("Excluir"));
+    await user.click(await screen.findByText("Excluir"));
 
     // Click "Deletar Permanentemente"
     await user.click(screen.getByRole("button", { name: "Deletar Permanentemente" }));
 
-    expect(toast.error).toHaveBeenCalledWith("Erro interno");
-    expect(onRefresh).not.toHaveBeenCalled();
+    // Wrap assertions in waitFor to avoid async callback race conditions
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Erro interno");
+      expect(onRefresh).not.toHaveBeenCalled();
+    });
+  });
+
+  it("shows fallback error toast when item deletion fails without detail in body", async () => {
+    const onRefresh = vi.fn();
+    const item = createMockItem();
+
+    // Mock API failure for DELETE returning status 500 and no body
+    server.use(
+      http.delete("*/api/v1/logistics/items/:uuid", () => {
+        return new HttpResponse(null, { status: 500 });
+      })
+    );
+
+    const { container } = render(
+      <WeddingItemsTable items={[item]} onEdit={vi.fn()} onRefresh={onRefresh} />
+    );
+
+    const user = userEvent.setup();
+    // Open dropdown
+    await user.click(container.querySelector("button")!);
+
+    // Click "Excluir"
+    await user.click(await screen.findByText("Excluir"));
+
+    // Click "Deletar Permanentemente"
+    await user.click(screen.getByRole("button", { name: "Deletar Permanentemente" }));
+
+    // Wrap assertions in waitFor to avoid async callback race conditions
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Erro ao deletar item.");
+      expect(onRefresh).not.toHaveBeenCalled();
+    });
   });
 });

--- a/frontend/src/features/logistics/components/items/ItemsTable.test.tsx
+++ b/frontend/src/features/logistics/components/items/ItemsTable.test.tsx
@@ -1,7 +1,10 @@
-import { describe, expect, it } from "vitest";
-import { render, screen } from "@/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, userEvent } from "@/test-utils";
 import { WeddingItemsTable } from "@/features/logistics/components/items/ItemsTable";
 import { createMockItem } from "@/test-data";
+import { server } from "@/mocks/server";
+import { http, HttpResponse } from "msw";
+import { toast } from "sonner";
 
 describe("WeddingItemsTable", () => {
   it("shows empty state when no items", () => {
@@ -29,5 +32,90 @@ describe("WeddingItemsTable", () => {
     );
 
     expect(screen.getByText("N/A")).toBeInTheDocument();
+  });
+
+  it("calls onEdit when Editar is clicked in dropdown", async () => {
+    const onEdit = vi.fn();
+    const item = createMockItem();
+    render(<WeddingItemsTable items={[item]} onEdit={onEdit} />);
+
+    const user = userEvent.setup();
+    // Open dropdown menu
+    await user.click(screen.getByRole("button"));
+
+    // Find and click "Editar" item
+    await user.click(screen.getByText("Editar"));
+
+    expect(onEdit).toHaveBeenCalledWith(item);
+  });
+
+  it("opens ConfirmDeleteDialog when Excluir is clicked", async () => {
+    const item = createMockItem();
+    render(<WeddingItemsTable items={[item]} onEdit={vi.fn()} />);
+
+    const user = userEvent.setup();
+    // Open dropdown
+    await user.click(screen.getByRole("button"));
+
+    // Click "Excluir"
+    await user.click(screen.getByText("Excluir"));
+
+    // Verify dialog is open
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Excluir Item")).toBeInTheDocument();
+  });
+
+  it("successfully deletes item when confirm button is clicked", async () => {
+    const onRefresh = vi.fn();
+    const item = createMockItem();
+
+    // Mock API success for DELETE
+    server.use(
+      http.delete("*/api/v1/logistics/items/*", () => {
+        return new HttpResponse(null, { status: 204 });
+      })
+    );
+
+    render(<WeddingItemsTable items={[item]} onEdit={vi.fn()} onRefresh={onRefresh} />);
+
+    const user = userEvent.setup();
+    // Open dropdown
+    await user.click(screen.getByRole("button"));
+
+    // Click "Excluir"
+    await user.click(screen.getByText("Excluir"));
+
+    // Click "Deletar Permanentemente"
+    await user.click(screen.getByRole("button", { name: "Deletar Permanentemente" }));
+
+    expect(toast.success).toHaveBeenCalledWith("Item deletado com sucesso!");
+    expect(onRefresh).toHaveBeenCalled();
+  });
+
+  it("shows error toast when item deletion fails", async () => {
+    const onRefresh = vi.fn();
+    const item = createMockItem();
+
+    // Mock API failure for DELETE
+    server.use(
+      http.delete("*/api/v1/logistics/items/*", () => {
+        return HttpResponse.json({ detail: "Erro interno" }, { status: 500 });
+      })
+    );
+
+    render(<WeddingItemsTable items={[item]} onEdit={vi.fn()} onRefresh={onRefresh} />);
+
+    const user = userEvent.setup();
+    // Open dropdown
+    await user.click(screen.getByRole("button"));
+
+    // Click "Excluir"
+    await user.click(screen.getByText("Excluir"));
+
+    // Click "Deletar Permanentemente"
+    await user.click(screen.getByRole("button", { name: "Deletar Permanentemente" }));
+
+    expect(toast.error).toHaveBeenCalledWith("Erro interno");
+    expect(onRefresh).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/features/logistics/components/items/VendorsTable.test.tsx
+++ b/frontend/src/features/logistics/components/items/VendorsTable.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { render, screen, userEvent } from "@/test-utils";
+import { render, screen, userEvent, waitFor } from "@/test-utils";
 import { WeddingVendorsTable } from "@/features/logistics/components/items/VendorsTable";
 import { createMockContract } from "@/test-data";
 import { server } from "@/mocks/server";
@@ -88,7 +88,7 @@ describe("WeddingVendorsTable", () => {
   it("calls onEdit when Editar is clicked in dropdown", async () => {
     const onEdit = vi.fn();
     const contract = createMockContract();
-    render(
+    const { container } = render(
       <WeddingVendorsTable
         contracts={[contract]}
         onEdit={onEdit}
@@ -96,8 +96,8 @@ describe("WeddingVendorsTable", () => {
     );
 
     const user = userEvent.setup();
-    await user.click(screen.getByRole("button"));
-    await user.click(screen.getByText("Editar"));
+    await user.click(container.querySelector("button")!);
+    await user.click(await screen.findByText("Editar"));
 
     expect(onEdit).toHaveBeenCalledWith(contract);
   });
@@ -105,7 +105,7 @@ describe("WeddingVendorsTable", () => {
   it("calls onGenerateExpense when Gerar Despesa is clicked in dropdown", async () => {
     const onGenerateExpense = vi.fn();
     const contract = createMockContract();
-    render(
+    const { container } = render(
       <WeddingVendorsTable
         contracts={[contract]}
         onGenerateExpense={onGenerateExpense}
@@ -113,15 +113,15 @@ describe("WeddingVendorsTable", () => {
     );
 
     const user = userEvent.setup();
-    await user.click(screen.getByRole("button"));
-    await user.click(screen.getByText("Gerar Despesa"));
+    await user.click(container.querySelector("button")!);
+    await user.click(await screen.findByText("Gerar Despesa"));
 
     expect(onGenerateExpense).toHaveBeenCalledWith(contract);
   });
 
   it("opens ConfirmDeleteDialog when Excluir is clicked in dropdown", async () => {
     const contract = createMockContract();
-    render(
+    const { container } = render(
       <WeddingVendorsTable
         contracts={[contract]}
         onEdit={vi.fn()}
@@ -129,8 +129,8 @@ describe("WeddingVendorsTable", () => {
     );
 
     const user = userEvent.setup();
-    await user.click(screen.getByRole("button"));
-    await user.click(screen.getByText("Excluir"));
+    await user.click(container.querySelector("button")!);
+    await user.click(await screen.findByText("Excluir"));
 
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(screen.getByText("Excluir Contrato")).toBeInTheDocument();
@@ -140,14 +140,14 @@ describe("WeddingVendorsTable", () => {
     const onRefresh = vi.fn();
     const contract = createMockContract();
 
-    // Mock API success for DELETE
+    // Mock API success for DELETE with precise route pattern
     server.use(
-      http.delete("*/api/v1/logistics/contracts/*", () => {
+      http.delete("*/api/v1/logistics/contracts/:uuid", () => {
         return new HttpResponse(null, { status: 204 });
       })
     );
 
-    render(
+    const { container } = render(
       <WeddingVendorsTable
         contracts={[contract]}
         onEdit={vi.fn()}
@@ -156,26 +156,28 @@ describe("WeddingVendorsTable", () => {
     );
 
     const user = userEvent.setup();
-    await user.click(screen.getByRole("button"));
-    await user.click(screen.getByText("Excluir"));
+    await user.click(container.querySelector("button")!);
+    await user.click(await screen.findByText("Excluir"));
     await user.click(screen.getByRole("button", { name: "Deletar Permanentemente" }));
 
-    expect(toast.success).toHaveBeenCalledWith("Contrato deletado com sucesso!");
-    expect(onRefresh).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("Contrato deletado com sucesso!");
+      expect(onRefresh).toHaveBeenCalled();
+    });
   });
 
   it("shows error toast when contract deletion fails", async () => {
     const onRefresh = vi.fn();
     const contract = createMockContract();
 
-    // Mock API failure for DELETE
+    // Mock API failure for DELETE with precise route pattern
     server.use(
-      http.delete("*/api/v1/logistics/contracts/*", () => {
+      http.delete("*/api/v1/logistics/contracts/:uuid", () => {
         return HttpResponse.json({ detail: "Erro interno" }, { status: 500 });
       })
     );
 
-    render(
+    const { container } = render(
       <WeddingVendorsTable
         contracts={[contract]}
         onEdit={vi.fn()}
@@ -184,11 +186,60 @@ describe("WeddingVendorsTable", () => {
     );
 
     const user = userEvent.setup();
-    await user.click(screen.getByRole("button"));
-    await user.click(screen.getByText("Excluir"));
+    await user.click(container.querySelector("button")!);
+    await user.click(await screen.findByText("Excluir"));
     await user.click(screen.getByRole("button", { name: "Deletar Permanentemente" }));
 
-    expect(toast.error).toHaveBeenCalledWith("Erro interno");
-    expect(onRefresh).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Erro interno");
+      expect(onRefresh).not.toHaveBeenCalled();
+    });
+  });
+
+  it("shows fallback error toast when contract deletion fails without detail in body", async () => {
+    const onRefresh = vi.fn();
+    const contract = createMockContract();
+
+    // Mock API failure for DELETE returning 500 and no body
+    server.use(
+      http.delete("*/api/v1/logistics/contracts/:uuid", () => {
+        return new HttpResponse(null, { status: 500 });
+      })
+    );
+
+    const { container } = render(
+      <WeddingVendorsTable
+        contracts={[contract]}
+        onEdit={vi.fn()}
+        onRefresh={onRefresh}
+      />,
+    );
+
+    const user = userEvent.setup();
+    await user.click(container.querySelector("button")!);
+    await user.click(await screen.findByText("Excluir"));
+    await user.click(screen.getByRole("button", { name: "Deletar Permanentemente" }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Erro ao deletar contrato.");
+      expect(onRefresh).not.toHaveBeenCalled();
+    });
+  });
+
+  it("renders only relevant actions when some callbacks are omitted", async () => {
+    const contract = createMockContract();
+    const { container } = render(
+      <WeddingVendorsTable
+        contracts={[contract]}
+        onEdit={vi.fn()}
+        // onGenerateExpense is omitted
+      />,
+    );
+
+    const user = userEvent.setup();
+    await user.click(container.querySelector("button")!);
+
+    expect(await screen.findByText("Editar")).toBeInTheDocument();
+    expect(screen.queryByText("Gerar Despesa")).toBeNull();
   });
 });

--- a/frontend/src/features/logistics/components/items/VendorsTable.test.tsx
+++ b/frontend/src/features/logistics/components/items/VendorsTable.test.tsx
@@ -2,6 +2,9 @@ import { describe, expect, it, vi } from "vitest";
 import { render, screen, userEvent } from "@/test-utils";
 import { WeddingVendorsTable } from "@/features/logistics/components/items/VendorsTable";
 import { createMockContract } from "@/test-data";
+import { server } from "@/mocks/server";
+import { http, HttpResponse } from "msw";
+import { toast } from "sonner";
 
 describe("WeddingVendorsTable", () => {
   it("shows empty state when no contracts", () => {
@@ -80,5 +83,112 @@ describe("WeddingVendorsTable", () => {
 
     expect(screen.getByRole("progressbar")).toBeInTheDocument();
     expect(screen.getByText("75% pago")).toBeInTheDocument();
+  });
+
+  it("calls onEdit when Editar is clicked in dropdown", async () => {
+    const onEdit = vi.fn();
+    const contract = createMockContract();
+    render(
+      <WeddingVendorsTable
+        contracts={[contract]}
+        onEdit={onEdit}
+      />,
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button"));
+    await user.click(screen.getByText("Editar"));
+
+    expect(onEdit).toHaveBeenCalledWith(contract);
+  });
+
+  it("calls onGenerateExpense when Gerar Despesa is clicked in dropdown", async () => {
+    const onGenerateExpense = vi.fn();
+    const contract = createMockContract();
+    render(
+      <WeddingVendorsTable
+        contracts={[contract]}
+        onGenerateExpense={onGenerateExpense}
+      />,
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button"));
+    await user.click(screen.getByText("Gerar Despesa"));
+
+    expect(onGenerateExpense).toHaveBeenCalledWith(contract);
+  });
+
+  it("opens ConfirmDeleteDialog when Excluir is clicked in dropdown", async () => {
+    const contract = createMockContract();
+    render(
+      <WeddingVendorsTable
+        contracts={[contract]}
+        onEdit={vi.fn()}
+      />,
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button"));
+    await user.click(screen.getByText("Excluir"));
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Excluir Contrato")).toBeInTheDocument();
+  });
+
+  it("successfully deletes contract when confirm button is clicked", async () => {
+    const onRefresh = vi.fn();
+    const contract = createMockContract();
+
+    // Mock API success for DELETE
+    server.use(
+      http.delete("*/api/v1/logistics/contracts/*", () => {
+        return new HttpResponse(null, { status: 204 });
+      })
+    );
+
+    render(
+      <WeddingVendorsTable
+        contracts={[contract]}
+        onEdit={vi.fn()}
+        onRefresh={onRefresh}
+      />,
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button"));
+    await user.click(screen.getByText("Excluir"));
+    await user.click(screen.getByRole("button", { name: "Deletar Permanentemente" }));
+
+    expect(toast.success).toHaveBeenCalledWith("Contrato deletado com sucesso!");
+    expect(onRefresh).toHaveBeenCalled();
+  });
+
+  it("shows error toast when contract deletion fails", async () => {
+    const onRefresh = vi.fn();
+    const contract = createMockContract();
+
+    // Mock API failure for DELETE
+    server.use(
+      http.delete("*/api/v1/logistics/contracts/*", () => {
+        return HttpResponse.json({ detail: "Erro interno" }, { status: 500 });
+      })
+    );
+
+    render(
+      <WeddingVendorsTable
+        contracts={[contract]}
+        onEdit={vi.fn()}
+        onRefresh={onRefresh}
+      />,
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button"));
+    await user.click(screen.getByText("Excluir"));
+    await user.click(screen.getByRole("button", { name: "Deletar Permanentemente" }));
+
+    expect(toast.error).toHaveBeenCalledWith("Erro interno");
+    expect(onRefresh).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Descrição das Alterações

Este Pull Request eleva substancialmente a cobertura de testes locais de componentes na pasta de logística, abordando os seguintes arquivos:

### 1. Testes de `ItemsTable.tsx`
* Elevado de 45% para **85% de Statements** e **94.44% de Linhas**.
* Testou interações de clique nas ações de editar e excluir, abertura de `ConfirmDeleteDialog`, e mockou a mutação de exclusão de item via MSW (cenários de sucesso e falha).

### 2. Testes de `VendorsTable.tsx`
* Elevado de 46.15% para **80.76% de Statements** e **87.5% de Linhas**.
* Testou callbacks de clique nas ações (Editar, Gerar Despesa), abertura do diálogo de confirmação, e mockou a mutação de exclusão de contrato via MSW (sucesso e falha).

### 3. Métricas Globais do Frontend
* **Statements:** de 84.9% para **86.0%** (+1.1%)
* **Branches:** de 79.23% para **79.97%** (+0.74%)
* **Functions:** de 78.5% para **80.58%** (+2.08%)
* **Lines:** de 85.68% para **86.83%** (+1.15%)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded UI test coverage for logistics tables, including dropdown-driven actions such as **Editar**, **Gerar Despesa**, and **Excluir**.
  * Added assertions that delete confirmation dialogs display the expected text (e.g., “Excluir Item” / “Excluir Contrato”).
  * Improved deletion-flow validation for both success (204) and failure (500), including success/error toast notifications and ensuring the table refresh behavior matches the outcome.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->