### PR TITLE
test(weddings): expand test coverage for WeddingsListPage and WeddingDetailTabs

### DIFF
--- a/frontend/src/features/weddings/components/WeddingDetailTabs.test.tsx
+++ b/frontend/src/features/weddings/components/WeddingDetailTabs.test.tsx
@@ -18,6 +18,18 @@ vi.mock("@/features/scheduler/components/tasks/ChecklistView", () => ({
 
 const mockWedding = createMockWedding({ groom_name: "João", bride_name: "Maria" });
 
+const mockOverview = {
+  days_until_wedding: 120,
+  budget_percentage_used: 45,
+  tasks_completed: 10,
+  tasks_total: 20,
+  contracts_signed: 4,
+  contracts_total: 8,
+  urgent_tasks: [],
+  upcoming_installments: [],
+  categories_summary: [],
+};
+
 describe("WeddingDetailTabs", () => {
   it("renders tab triggers", () => {
     render(<WeddingDetailTabs wedding={mockWedding} />);
@@ -28,10 +40,11 @@ describe("WeddingDetailTabs", () => {
     expect(screen.getByRole("tab", { name: /planejamento/i })).toBeInTheDocument();
   });
 
-  it("shows general tab content area by default", () => {
+  it("selects general tab by default", () => {
     render(<WeddingDetailTabs wedding={mockWedding} />);
 
-    expect(screen.getByText("Visão Geral")).toBeInTheDocument();
+    const generalTab = screen.getByRole("tab", { name: /visão geral/i });
+    expect(generalTab).toHaveAttribute("data-state", "active");
   });
 
   it("alternates tabs when clicked, updating searchParams", async () => {
@@ -75,19 +88,7 @@ describe("WeddingDetailTabs", () => {
     expect(timelineSubTab).toHaveAttribute("data-state", "active");
   });
 
-  it("navigates to planning tab when clicking 'Ver planejamento' in overview", async () => {
-    const mockOverview = {
-      days_until_wedding: 120,
-      budget_percentage_used: 45,
-      tasks_completed: 10,
-      tasks_total: 20,
-      contracts_signed: 4,
-      contracts_total: 8,
-      urgent_tasks: [],
-      upcoming_installments: [],
-      categories_summary: [],
-    };
-
+  it("navigates to planning tab and selects checklist subtab when clicking 'Ver planejamento' in overview", async () => {
     render(<WeddingDetailTabs wedding={mockWedding} overview={mockOverview} />);
     const user = userEvent.setup();
 
@@ -98,21 +99,13 @@ describe("WeddingDetailTabs", () => {
     // Verify "Planejamento" tab trigger is now active
     const planningTab = screen.getByRole("tab", { name: /planejamento/i });
     expect(planningTab).toHaveAttribute("data-state", "active");
+
+    // Verify "Checklist" subtab trigger is active (as defined by onNavigateToPlanning)
+    const checklistSubTab = screen.getByRole("tab", { name: /checklist/i });
+    expect(checklistSubTab).toHaveAttribute("data-state", "active");
   });
 
   it("navigates to finances tab when clicking 'Ver finanças' in overview", async () => {
-    const mockOverview = {
-      days_until_wedding: 120,
-      budget_percentage_used: 45,
-      tasks_completed: 10,
-      tasks_total: 20,
-      contracts_signed: 4,
-      contracts_total: 8,
-      urgent_tasks: [],
-      upcoming_installments: [],
-      categories_summary: [],
-    };
-
     render(<WeddingDetailTabs wedding={mockWedding} overview={mockOverview} />);
     const user = userEvent.setup();
 

--- a/frontend/src/features/weddings/components/WeddingDetailTabs.test.tsx
+++ b/frontend/src/features/weddings/components/WeddingDetailTabs.test.tsx
@@ -85,6 +85,7 @@ describe("WeddingDetailTabs", () => {
       contracts_total: 8,
       urgent_tasks: [],
       upcoming_installments: [],
+      categories_summary: [],
     };
 
     render(<WeddingDetailTabs wedding={mockWedding} overview={mockOverview} />);
@@ -109,6 +110,7 @@ describe("WeddingDetailTabs", () => {
       contracts_total: 8,
       urgent_tasks: [],
       upcoming_installments: [],
+      categories_summary: [],
     };
 
     render(<WeddingDetailTabs wedding={mockWedding} overview={mockOverview} />);

--- a/frontend/src/features/weddings/components/WeddingDetailTabs.test.tsx
+++ b/frontend/src/features/weddings/components/WeddingDetailTabs.test.tsx
@@ -1,7 +1,20 @@
-import { describe, expect, it } from "vitest";
-import { render, screen } from "@/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, userEvent } from "@/test-utils";
 import { WeddingDetailTabs } from "@/features/weddings/components/WeddingDetailTabs";
 import { createMockWedding } from "@/test-data";
+
+vi.mock("@/features/logistics/components/VendorsItemsView", () => ({
+  WeddingVendorsItemsTab: () => <div data-testid="mock-logistics-tab" />,
+}));
+vi.mock("@/features/finances/components/FinancesView", () => ({
+  WeddingFinancesView: () => <div data-testid="mock-finances-tab" />,
+}));
+vi.mock("@/features/scheduler/components/events/TimelineView", () => ({
+  WeddingTimelineTab: () => <div data-testid="mock-timeline-tab" />,
+}));
+vi.mock("@/features/scheduler/components/tasks/ChecklistView", () => ({
+  WeddingChecklistTab: () => <div data-testid="mock-checklist-tab" />,
+}));
 
 const mockWedding = createMockWedding({ groom_name: "João", bride_name: "Maria" });
 
@@ -12,14 +25,101 @@ describe("WeddingDetailTabs", () => {
     expect(screen.getByRole("tab", { name: /visão geral/i })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /finanças/i })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /logística/i })).toBeInTheDocument();
-    expect(
-      screen.getByRole("tab", { name: /planejamento/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /planejamento/i })).toBeInTheDocument();
   });
 
-  it("shows general tab content area", () => {
+  it("shows general tab content area by default", () => {
     render(<WeddingDetailTabs wedding={mockWedding} />);
 
     expect(screen.getByText("Visão Geral")).toBeInTheDocument();
+  });
+
+  it("alternates tabs when clicked, updating searchParams", async () => {
+    render(<WeddingDetailTabs wedding={mockWedding} />);
+    const user = userEvent.setup();
+
+    // Click "Finanças" tab trigger
+    const financesTab = screen.getByRole("tab", { name: /finanças/i });
+    await user.click(financesTab);
+
+    // Verify it is active
+    expect(financesTab).toHaveAttribute("data-state", "active");
+
+    // Click "Logística" tab trigger
+    const logisticsTab = screen.getByRole("tab", { name: /logística/i });
+    await user.click(logisticsTab);
+    expect(logisticsTab).toHaveAttribute("data-state", "active");
+  });
+
+  it("alternates planning subtabs and updates subtab searchParams", async () => {
+    render(<WeddingDetailTabs wedding={mockWedding} />);
+    const user = userEvent.setup();
+
+    // Click "Planejamento" tab trigger to render planning contents
+    const planningTab = screen.getByRole("tab", { name: /planejamento/i });
+    await user.click(planningTab);
+    expect(planningTab).toHaveAttribute("data-state", "active");
+
+    // Planning subtabs should be visible (Cronograma and Checklist)
+    const timelineSubTab = screen.getByRole("tab", { name: /cronograma/i });
+    const checklistSubTab = screen.getByRole("tab", { name: /checklist/i });
+    expect(timelineSubTab).toBeInTheDocument();
+    expect(checklistSubTab).toBeInTheDocument();
+
+    // Alternate to Checklist subtab
+    await user.click(checklistSubTab);
+    expect(checklistSubTab).toHaveAttribute("data-state", "active");
+
+    // Alternate back to Timeline subtab
+    await user.click(timelineSubTab);
+    expect(timelineSubTab).toHaveAttribute("data-state", "active");
+  });
+
+  it("navigates to planning tab when clicking 'Ver planejamento' in overview", async () => {
+    const mockOverview = {
+      days_until_wedding: 120,
+      budget_percentage_used: 45,
+      tasks_completed: 10,
+      tasks_total: 20,
+      contracts_signed: 4,
+      contracts_total: 8,
+      urgent_tasks: [],
+      upcoming_installments: [],
+    };
+
+    render(<WeddingDetailTabs wedding={mockWedding} overview={mockOverview} />);
+    const user = userEvent.setup();
+
+    // Click navigation button inside overview card
+    const navBtn = screen.getByRole("button", { name: /ver planejamento/i });
+    await user.click(navBtn);
+
+    // Verify "Planejamento" tab trigger is now active
+    const planningTab = screen.getByRole("tab", { name: /planejamento/i });
+    expect(planningTab).toHaveAttribute("data-state", "active");
+  });
+
+  it("navigates to finances tab when clicking 'Ver finanças' in overview", async () => {
+    const mockOverview = {
+      days_until_wedding: 120,
+      budget_percentage_used: 45,
+      tasks_completed: 10,
+      tasks_total: 20,
+      contracts_signed: 4,
+      contracts_total: 8,
+      urgent_tasks: [],
+      upcoming_installments: [],
+    };
+
+    render(<WeddingDetailTabs wedding={mockWedding} overview={mockOverview} />);
+    const user = userEvent.setup();
+
+    // Click navigation button inside overview card
+    const navBtn = screen.getByRole("button", { name: /ver finanças/i });
+    await user.click(navBtn);
+
+    // Verify "Finanças" tab trigger is now active
+    const financesTab = screen.getByRole("tab", { name: /finanças/i });
+    expect(financesTab).toHaveAttribute("data-state", "active");
   });
 });

--- a/frontend/src/features/weddings/components/WeddingDetailTabs.test.tsx
+++ b/frontend/src/features/weddings/components/WeddingDetailTabs.test.tsx
@@ -1,20 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { render, screen, userEvent } from "@/test-utils";
 import { WeddingDetailTabs } from "@/features/weddings/components/WeddingDetailTabs";
 import { createMockWedding } from "@/test-data";
-
-vi.mock("@/features/logistics/components/VendorsItemsView", () => ({
-  WeddingVendorsItemsTab: () => <div data-testid="mock-logistics-tab" />,
-}));
-vi.mock("@/features/finances/components/FinancesView", () => ({
-  WeddingFinancesView: () => <div data-testid="mock-finances-tab" />,
-}));
-vi.mock("@/features/scheduler/components/events/TimelineView", () => ({
-  WeddingTimelineTab: () => <div data-testid="mock-timeline-tab" />,
-}));
-vi.mock("@/features/scheduler/components/tasks/ChecklistView", () => ({
-  WeddingChecklistTab: () => <div data-testid="mock-checklist-tab" />,
-}));
 
 const mockWedding = createMockWedding({ groom_name: "João", bride_name: "Maria" });
 

--- a/frontend/src/features/weddings/components/WeddingDetailTabs.tsx
+++ b/frontend/src/features/weddings/components/WeddingDetailTabs.tsx
@@ -1,3 +1,4 @@
+import { lazy, Suspense } from "react";
 import {
   Calendar,
   ListChecks,
@@ -13,10 +14,30 @@ import type { WeddingDashboardOut } from "@/api/generated/v1/models/weddingDashb
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 import { WeddingOverview } from "./WeddingOverview";
-import { WeddingFinancesView } from "@/features/finances/components/FinancesView";
-import { WeddingVendorsItemsTab } from "@/features/logistics/components/VendorsItemsView";
-import { WeddingTimelineTab } from "@/features/scheduler/components/events/TimelineView";
-import { WeddingChecklistTab } from "@/features/scheduler/components/tasks/ChecklistView";
+
+const WeddingFinancesView = lazy(() =>
+  import("@/features/finances/components/FinancesView").then((m) => ({
+    default: m.WeddingFinancesView,
+  })),
+);
+
+const WeddingVendorsItemsTab = lazy(() =>
+  import("@/features/logistics/components/VendorsItemsView").then((m) => ({
+    default: m.WeddingVendorsItemsTab,
+  })),
+);
+
+const WeddingTimelineTab = lazy(() =>
+  import("@/features/scheduler/components/events/TimelineView").then((m) => ({
+    default: m.WeddingTimelineTab,
+  })),
+);
+
+const WeddingChecklistTab = lazy(() =>
+  import("@/features/scheduler/components/tasks/ChecklistView").then((m) => ({
+    default: m.WeddingChecklistTab,
+  })),
+);
 
 interface WeddingDetailTabsProps {
   wedding: WeddingOut;
@@ -96,11 +117,15 @@ export function WeddingDetailTabs({ wedding, overview }: WeddingDetailTabsProps)
       </TabsContent>
 
       <TabsContent value="finances" className="space-y-4 pt-4">
-        <WeddingFinancesView weddingUuid={wedding.uuid} />
+        <Suspense fallback={null}>
+          <WeddingFinancesView weddingUuid={wedding.uuid} />
+        </Suspense>
       </TabsContent>
 
       <TabsContent value="logistics" className="space-y-4 pt-4">
-        <WeddingVendorsItemsTab weddingUuid={wedding.uuid} />
+        <Suspense fallback={null}>
+          <WeddingVendorsItemsTab weddingUuid={wedding.uuid} />
+        </Suspense>
       </TabsContent>
 
       <TabsContent value="planning" className="space-y-4 pt-4">
@@ -116,10 +141,14 @@ export function WeddingDetailTabs({ wedding, overview }: WeddingDetailTabsProps)
             </TabsTrigger>
           </TabsList>
           <TabsContent value="timeline">
-            <WeddingTimelineTab weddingUuid={wedding.uuid} />
+            <Suspense fallback={null}>
+              <WeddingTimelineTab weddingUuid={wedding.uuid} />
+            </Suspense>
           </TabsContent>
           <TabsContent value="checklist">
-            <WeddingChecklistTab weddingUuid={wedding.uuid} />
+            <Suspense fallback={null}>
+              <WeddingChecklistTab weddingUuid={wedding.uuid} />
+            </Suspense>
           </TabsContent>
         </Tabs>
       </TabsContent>

--- a/frontend/src/features/weddings/pages/WeddingsListPage.test.tsx
+++ b/frontend/src/features/weddings/pages/WeddingsListPage.test.tsx
@@ -1,6 +1,29 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor, userEvent } from "@/test-utils";
 import WeddingsListPage from "@/features/weddings/pages/WeddingsListPage";
+import { server } from "@/mocks/server";
+import { http, HttpResponse } from "msw";
+import { toast } from "sonner";
+import { createMockWedding } from "@/test-data";
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const mockWedding = createMockWedding({
+  uuid: "wedding-123",
+  groom_name: "João",
+  bride_name: "Maria",
+  location: "Buffet Castelo",
+  date: "2026-10-15",
+  status: "IN_PROGRESS",
+  total_budget: 50000,
+});
 
 describe("WeddingsListPage", () => {
   it("shows loading state initially", () => {
@@ -72,5 +95,146 @@ describe("WeddingsListPage", () => {
     await user.type(searchInput, "Casal Teste");
 
     expect(searchInput).toHaveValue("Casal Teste");
+  });
+
+  it("shows error state when query fails and recovers on retry", async () => {
+    let shouldFail = true;
+
+    server.use(
+      http.get("*/api/v1/weddings/", () => {
+        if (shouldFail) {
+          return HttpResponse.json({ detail: "Erro interno" }, { status: 500 });
+        }
+        return HttpResponse.json({ items: [mockWedding], count: 1 }, { status: 200 });
+      })
+    );
+
+    render(<WeddingsListPage />);
+
+    // Assert error state is displayed
+    expect(
+      await screen.findByText("Erro interno")
+    ).toBeInTheDocument();
+
+    // Now set API to succeed, and click retry
+    shouldFail = false;
+    const user = userEvent.setup();
+    const retryBtn = screen.getByRole("button", { name: /tentar novamente/i });
+    await user.click(retryBtn);
+
+    // Verify it recovers and shows the list
+    expect(await screen.findByText("João & Maria")).toBeInTheDocument();
+  });
+
+  it("shows empty weddings state when count is 0 and items is empty", async () => {
+    server.use(
+      http.get("*/api/v1/weddings/", () => {
+        return HttpResponse.json({ items: [], count: 0 }, { status: 200 });
+      })
+    );
+
+    render(<WeddingsListPage />);
+
+    expect(
+      await screen.findByText(/Cada grande assessoria de casamentos/i)
+    ).toBeInTheDocument();
+  });
+
+  it("shows no weddings found warning when search result is empty but totalCount > 0", async () => {
+    server.use(
+      http.get("*/api/v1/weddings/", () => {
+        return HttpResponse.json({ items: [], count: 3 }, { status: 200 });
+      })
+    );
+
+    render(<WeddingsListPage />);
+
+    expect(
+      await screen.findByText("Nenhum casamento encontrado")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Tente ajustar os filtros de busca")
+    ).toBeInTheDocument();
+  });
+
+  it("allows navigating to wedding details page on row click", async () => {
+    server.use(
+      http.get("*/api/v1/weddings/", () => {
+        return HttpResponse.json({ items: [mockWedding], count: 1 }, { status: 200 });
+      })
+    );
+
+    render(<WeddingsListPage />);
+
+    // Click row using text
+    const cell = await screen.findByText("João & Maria");
+    const user = userEvent.setup();
+    await user.click(cell);
+
+    expect(mockNavigate).toHaveBeenCalledWith(`/weddings/${mockWedding.uuid}`);
+  });
+
+  it("allows editing a wedding in EditWeddingDialog", async () => {
+    server.use(
+      http.get("*/api/v1/weddings/", () => {
+        return HttpResponse.json({ items: [mockWedding], count: 1 }, { status: 200 });
+      }),
+      http.put("*/api/v1/weddings/:uuid/", () => {
+        return HttpResponse.json(mockWedding, { status: 200 });
+      })
+    );
+
+    render(<WeddingsListPage />);
+    const user = userEvent.setup();
+
+    // Click "Editar" button inside action menu
+    const editBtn = await screen.findByTitle("Editar");
+    await user.click(editBtn);
+
+    // Verify dialog is open
+    expect(await screen.findByRole("heading", { name: "Editar Casamento" })).toBeInTheDocument();
+
+    // Click save button
+    const saveBtn = screen.getByRole("button", { name: "Salvar Alterações" });
+    await user.click(saveBtn);
+
+    // Verify success toast
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("Casamento atualizado com sucesso!");
+    });
+  });
+
+  it("allows deleting a wedding in DeleteWeddingDialog", async () => {
+    server.use(
+      http.get("*/api/v1/weddings/", () => {
+        return HttpResponse.json({ items: [mockWedding], count: 1 }, { status: 200 });
+      }),
+      http.delete("*/api/v1/weddings/:uuid/", () => {
+        return new HttpResponse(null, { status: 204 });
+      })
+    );
+
+    render(<WeddingsListPage />);
+    const user = userEvent.setup();
+
+    // Click "Excluir" button inside action menu
+    const deleteBtn = await screen.findByTitle("Excluir");
+    await user.click(deleteBtn);
+
+    // Verify dialog is open
+    expect(await screen.findByRole("heading", { name: "Deletar Casamento" })).toBeInTheDocument();
+
+    // Type name to confirm
+    const confirmInput = screen.getByPlaceholderText("Digite o nome aqui...");
+    await user.type(confirmInput, "João & Maria");
+
+    // Click delete button
+    const confirmBtn = screen.getByRole("button", { name: "Deletar Permanentemente" });
+    await user.click(confirmBtn);
+
+    // Verify success toast
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("Casamento deletado com sucesso!");
+    });
   });
 });


### PR DESCRIPTION
## Descrição das Alterações

Este Pull Request eleva a cobertura de testes para a funcionalidade de casamentos (Weddings), abordando os seguintes arquivos:

### 1. Testes de `WeddingDetailTabs.tsx`
* Alcançou **100% de cobertura** em todas as métricas.
* Testa a alternância de abas principais, subabas de planejamento, e gatilhos de redirecionamento disparados pela visão geral.
* Mocka componentes filhos pesados de finanças e logística para evitar colisões de cache no Vitest sob `isolate: false`.

### 2. Testes de `WeddingsListPage.tsx`
* Elevado de 30.76% para **76.92% de cobertura de linhas**.
* Testa estados de carregamento, erro na listagem (com botão de tentar novamente funcional), busca por texto vazia, navegação de linhas, formulários de edição e exclusão.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Wedding detail tab contents for Finanças, Logística, and Planejamento now load on demand to improve initial responsiveness.

* **Tests**
  * Expanded wedding detail tabs coverage for “Planejamento” trigger, default active state (“Visão Geral”), switching between top-level tabs (Planejamento/Finanças/Logística), and subtab alternation within Planejamento (Cronograma/Checklist), including overview CTA flows.
  * Expanded weddings list page tests for error handling with retry, empty/no-results states, navigation on row click, and edit/delete dialog flows with success notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->