### PR TITLE
test(finances): increase test coverage for ExpensesTab and ExpenseDetailSheet

### DIFF
--- a/frontend/src/features/finances/components/FinancesView.test.tsx
+++ b/frontend/src/features/finances/components/FinancesView.test.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, expect, it, vi, beforeEach } from "vitest";
+vi.unmock("@/features/finances/components/FinancesView");
 import { render, screen, waitFor, server } from "@/test-utils";
 import { http, HttpResponse } from "msw";
 import { WeddingFinancesView } from "@/features/finances/components/FinancesView";

--- a/frontend/src/features/finances/components/expenses/ExpenseDetailSheet.test.tsx
+++ b/frontend/src/features/finances/components/expenses/ExpenseDetailSheet.test.tsx
@@ -1,16 +1,35 @@
-
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen, userEvent, waitFor, server } from "@/test-utils";
 import { http, HttpResponse } from "msw";
+import { toast } from "sonner";
 import { ExpenseDetailSheet } from "./ExpenseDetailSheet";
-import { createMockExpense } from "@/test-data";
+import { createMockExpense, createMockInstallment } from "@/test-data";
 
 vi.mock("./ExpenseInstallmentRow", () => ({
-  ExpenseInstallmentRow: ({ installment }: { installment: { installment_number: number } }) => (
-    <tr data-testid="expense-installment-row">
-      <td>{installment.installment_number}</td>
-    </tr>
-  ),
+  ExpenseInstallmentRow: ({
+    installment,
+    onTogglePayment,
+    isPaying,
+  }: {
+    installment: { uuid: string; installment_number: number; status: string };
+    onTogglePayment: (uuid: string, isPaid: boolean) => void;
+    isPaying: boolean;
+  }) => {
+    const isPaid = installment.status === "PAID";
+    return (
+      <tr data-testid="expense-installment-row">
+        <td>{installment.installment_number}</td>
+        <td>
+          <button
+            onClick={() => onTogglePayment(installment.uuid, isPaid)}
+            disabled={isPaying}
+          >
+            {isPaid ? "Desmarcar" : "Marcar como Pago"}
+          </button>
+        </td>
+      </tr>
+    );
+  },
 }));
 
 vi.mock("./ExpenseRedistributeForm", () => ({
@@ -18,8 +37,6 @@ vi.mock("./ExpenseRedistributeForm", () => ({
     <div data-testid="expense-redistribute-form" />
   ),
 }));
-
-
 
 describe("ExpenseDetailSheet", () => {
   beforeEach(() => {
@@ -207,6 +224,146 @@ describe("ExpenseDetailSheet", () => {
       expect(
         screen.getByText("Nenhuma parcela encontrada."),
       ).toBeInTheDocument();
+    });
+  });
+
+  it("allows marking an installment as paid successfully", async () => {
+    const expense = createMockExpense({ uuid: "exp-1" });
+    const installment = createMockInstallment({
+      uuid: "inst-1",
+      installment_number: 1,
+      status: "PENDING",
+    });
+
+    server.use(
+      http.get("*/api/v1/finances/expenses/:uuid/", () =>
+        HttpResponse.json(expense),
+      ),
+      http.get("*/api/v1/finances/installments/", () =>
+        HttpResponse.json({ items: [installment], count: 1 }),
+      ),
+      http.post("*/api/v1/finances/installments/:uuid/mark-as-paid/", () => {
+        return HttpResponse.json(installment, { status: 200 });
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(
+      <ExpenseDetailSheet expense={expense} open={true} onOpenChange={vi.fn()} />,
+    );
+
+    // Click "Marcar como Pago" button
+    const payBtn = await screen.findByRole("button", { name: "Marcar como Pago" });
+    await user.click(payBtn);
+
+    // Verify success toast and reload
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("Parcela marcada como paga!");
+    });
+  });
+
+  it("allows unmarking an installment as paid successfully", async () => {
+    const expense = createMockExpense({ uuid: "exp-1" });
+    const installment = createMockInstallment({
+      uuid: "inst-1",
+      installment_number: 1,
+      status: "PAID",
+    });
+
+    server.use(
+      http.get("*/api/v1/finances/expenses/:uuid/", () =>
+        HttpResponse.json(expense),
+      ),
+      http.get("*/api/v1/finances/installments/", () =>
+        HttpResponse.json({ items: [installment], count: 1 }),
+      ),
+      http.post("*/api/v1/finances/installments/:uuid/unmark-as-paid/", () => {
+        return HttpResponse.json(installment, { status: 200 });
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(
+      <ExpenseDetailSheet expense={expense} open={true} onOpenChange={vi.fn()} />,
+    );
+
+    // Click "Desmarcar" button
+    const unpayBtn = await screen.findByRole("button", { name: "Desmarcar" });
+    await user.click(unpayBtn);
+
+    // Verify success toast and reload
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("Parcela desmarcada como paga.");
+    });
+  });
+
+  it("shows error toast when marking installment fails", async () => {
+    const expense = createMockExpense({ uuid: "exp-1" });
+    const installment = createMockInstallment({
+      uuid: "inst-1",
+      installment_number: 1,
+      status: "PENDING",
+    });
+
+    server.use(
+      http.get("*/api/v1/finances/expenses/:uuid/", () =>
+        HttpResponse.json(expense),
+      ),
+      http.get("*/api/v1/finances/installments/", () =>
+        HttpResponse.json({ items: [installment], count: 1 }),
+      ),
+      http.post("*/api/v1/finances/installments/:uuid/mark-as-paid/", () => {
+        return HttpResponse.json({ detail: "Operação inválida" }, { status: 400 });
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(
+      <ExpenseDetailSheet expense={expense} open={true} onOpenChange={vi.fn()} />,
+    );
+
+    // Click "Marcar como Pago" button
+    const payBtn = await screen.findByRole("button", { name: "Marcar como Pago" });
+    await user.click(payBtn);
+
+    // Verify error toast has API error message
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Operação inválida");
+    });
+  });
+
+  it("shows fallback error toast when unmarking installment fails without message detail", async () => {
+    const expense = createMockExpense({ uuid: "exp-1" });
+    const installment = createMockInstallment({
+      uuid: "inst-1",
+      installment_number: 1,
+      status: "PAID",
+    });
+
+    server.use(
+      http.get("*/api/v1/finances/expenses/:uuid/", () =>
+        HttpResponse.json(expense),
+      ),
+      http.get("*/api/v1/finances/installments/", () =>
+        HttpResponse.json({ items: [installment], count: 1 }),
+      ),
+      http.post("*/api/v1/finances/installments/:uuid/unmark-as-paid/", () => {
+        return new HttpResponse(null, { status: 500 });
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(
+      <ExpenseDetailSheet expense={expense} open={true} onOpenChange={vi.fn()} />,
+    );
+
+    // Click "Desmarcar" button
+    const unpayBtn = await screen.findByRole("button", { name: "Desmarcar" });
+    await user.click(unpayBtn);
+
+    // Verify fallback error toast
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Erro ao desmarcar parcela.");
     });
   });
 });

--- a/frontend/src/features/finances/components/expenses/ExpenseDetailSheet.test.tsx
+++ b/frontend/src/features/finances/components/expenses/ExpenseDetailSheet.test.tsx
@@ -40,8 +40,6 @@ vi.mock("./ExpenseRedistributeForm", () => ({
 
 describe("ExpenseDetailSheet", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-
     // Default MSW handlers
     server.use(
       http.get("*/api/v1/finances/installments/", () =>

--- a/frontend/src/features/finances/components/expenses/ExpensesTab.test.tsx
+++ b/frontend/src/features/finances/components/expenses/ExpensesTab.test.tsx
@@ -3,9 +3,9 @@ import { render, screen, waitFor, userEvent, server } from "@/test-utils";
 import { http, HttpResponse } from "msw";
 import { WeddingExpensesTab } from "@/features/finances/components/expenses/ExpensesTab";
 import { createMockExpense } from "@/test-data";
-import { ExpenseDetailSheet } from "./ExpenseDetailSheet";
-// Accessing ExpenseDetailSheet directly in imports ensures it is pre-loaded
-// in the test module registry, preventing async Suspense delay during test execution.
+
+// Pre-load ExpenseDetailSheet module into Vite registry to ensure lazy Suspense resolves synchronously in tests
+import "./ExpenseDetailSheet";
 
 const mockExpense = createMockExpense({
   uuid: "expense-1",
@@ -19,9 +19,6 @@ const mockExpense = createMockExpense({
 });
 
 describe("WeddingExpensesTab", () => {
-  it("ensures detail sheet component is loaded", () => {
-    expect(ExpenseDetailSheet).toBeDefined();
-  });
   it("shows loading state initially", () => {
     render(<WeddingExpensesTab weddingUuid="w-1" />);
 

--- a/frontend/src/features/finances/components/expenses/ExpensesTab.test.tsx
+++ b/frontend/src/features/finances/components/expenses/ExpensesTab.test.tsx
@@ -1,8 +1,27 @@
 import { describe, expect, it } from "vitest";
-import { render, screen, waitFor } from "@/test-utils";
+import { render, screen, waitFor, userEvent, server } from "@/test-utils";
+import { http, HttpResponse } from "msw";
 import { WeddingExpensesTab } from "@/features/finances/components/expenses/ExpensesTab";
+import { createMockExpense } from "@/test-data";
+import { ExpenseDetailSheet } from "./ExpenseDetailSheet";
+// Accessing ExpenseDetailSheet directly in imports ensures it is pre-loaded
+// in the test module registry, preventing async Suspense delay during test execution.
+
+const mockExpense = createMockExpense({
+  uuid: "expense-1",
+  name: "Banda Musical",
+  description: "Banda do Casamento",
+  estimated_amount: "3000.00",
+  actual_amount: "3500.00",
+  status: "PARTIALLY_PAID",
+  paid_installments_count: 1,
+  installments_count: 3,
+});
 
 describe("WeddingExpensesTab", () => {
+  it("ensures detail sheet component is loaded", () => {
+    expect(ExpenseDetailSheet).toBeDefined();
+  });
   it("shows loading state initially", () => {
     render(<WeddingExpensesTab weddingUuid="w-1" />);
 
@@ -11,22 +30,128 @@ describe("WeddingExpensesTab", () => {
   });
 
   it("renders expenses card after loading", async () => {
+    server.use(
+      http.get("*/api/v1/finances/expenses/", () => {
+        return HttpResponse.json({ items: [mockExpense], count: 1 });
+      }),
+    );
+
+    render(<WeddingExpensesTab weddingUuid="w-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Despesas Registradas")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Banda Musical")).toBeInTheDocument();
+  });
+
+  it("shows error state when query fails", async () => {
+    server.use(
+      http.get("*/api/v1/finances/expenses/", () => {
+        return new HttpResponse(null, { status: 500 });
+      }),
+    );
+
     render(<WeddingExpensesTab weddingUuid="w-1" />);
 
     await waitFor(() => {
       expect(
-        screen.getByText(/despesas registradas/i),
+        screen.getByText("Não foi possível carregar as despesas deste casamento."),
       ).toBeInTheDocument();
     });
   });
 
-  it("shows new expense button", async () => {
+  it("opens CreateExpenseDialog when clicking Nova Despesa button", async () => {
+    server.use(
+      http.get("*/api/v1/finances/expenses/", () => {
+        return HttpResponse.json({ items: [], count: 0 });
+      }),
+      http.get("*/api/v1/finances/categories/", () => {
+        return HttpResponse.json({ items: [], count: 0 });
+      }),
+      http.get("*/api/v1/logistics/contracts/", () => {
+        return HttpResponse.json({ items: [], count: 0 });
+      }),
+    );
+
+    const user = userEvent.setup();
     render(<WeddingExpensesTab weddingUuid="w-1" />);
 
-    await waitFor(() => {
-      expect(
-        screen.getByRole("button", { name: /nova despesa/i }),
-      ).toBeInTheDocument();
-    });
+    // Wait for card to load
+    const createBtn = await screen.findByRole("button", { name: /nova despesa/i });
+    await user.click(createBtn);
+
+    // Verify dialog opens
+    expect(await screen.findByRole("heading", { name: "Nova Despesa" })).toBeInTheDocument();
+  });
+
+  it("opens EditExpenseDialog when clicking Editar in action menu", async () => {
+    server.use(
+      http.get("*/api/v1/finances/expenses/", () => {
+        return HttpResponse.json({ items: [mockExpense], count: 1 });
+      }),
+      http.get("*/api/v1/logistics/contracts/", () => {
+        return HttpResponse.json({ items: [], count: 0 });
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<WeddingExpensesTab weddingUuid="w-1" />);
+
+    // Click actions menu button
+    const actionsBtn = await screen.findByRole("button", { name: "Ações da despesa" });
+    await user.click(actionsBtn);
+
+    // Click "Editar" menu item
+    const editMenuItem = await screen.findByText("Editar");
+    await user.click(editMenuItem);
+
+    // Verify Edit dialog is open
+    expect(await screen.findByRole("heading", { name: "Editar Despesa" })).toBeInTheDocument();
+  });
+
+  it("opens DeleteExpenseDialog when clicking Excluir in action menu", async () => {
+    server.use(
+      http.get("*/api/v1/finances/expenses/", () => {
+        return HttpResponse.json({ items: [mockExpense], count: 1 });
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<WeddingExpensesTab weddingUuid="w-1" />);
+
+    // Click actions menu button
+    const actionsBtn = await screen.findByRole("button", { name: "Ações da despesa" });
+    await user.click(actionsBtn);
+
+    // Click "Excluir" menu item
+    const deleteMenuItem = await screen.findByText("Excluir");
+    await user.click(deleteMenuItem);
+
+    // Verify Delete dialog is open
+    expect(await screen.findByRole("heading", { name: "Deletar Despesa" })).toBeInTheDocument();
+  });
+
+  it("opens ExpenseDetailSheet when clicking expense name", async () => {
+    server.use(
+      http.get("*/api/v1/finances/expenses/", () => {
+        return HttpResponse.json({ items: [mockExpense], count: 1 });
+      }),
+      http.get("*/api/v1/finances/expenses/*", () => {
+        return HttpResponse.json(mockExpense);
+      }),
+      http.get("*/api/v1/finances/installments*", () => {
+        return HttpResponse.json({ items: [], count: 0 });
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<WeddingExpensesTab weddingUuid="w-1" />);
+
+    // Click expense name link
+    const nameLink = await screen.findByRole("button", { name: "Banda Musical" });
+    await user.click(nameLink);
+
+    // Verify details sheet is open
+    expect(await screen.findByRole("heading", { name: /Banda Musical/i })).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/logistics/components/VendorsItemsView.test.tsx
+++ b/frontend/src/features/logistics/components/VendorsItemsView.test.tsx
@@ -1,5 +1,5 @@
- 
 import { describe, expect, it, vi, beforeEach } from "vitest";
+vi.unmock("@/features/logistics/components/VendorsItemsView");
 import { render, screen, userEvent } from "@/test-utils";
 import { WeddingVendorsItemsTab } from "./VendorsItemsView";
 import { createMockContract, createMockItem } from "@/test-data";

--- a/frontend/src/features/scheduler/components/events/TimelineView.test.tsx
+++ b/frontend/src/features/scheduler/components/events/TimelineView.test.tsx
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+vi.unmock("@/features/scheduler/components/events/TimelineView");
 import { render, screen, waitFor } from "@/test-utils";
 import { WeddingTimelineTab } from "@/features/scheduler/components/events/TimelineView";
 

--- a/frontend/src/features/scheduler/components/tasks/ChecklistView.test.tsx
+++ b/frontend/src/features/scheduler/components/tasks/ChecklistView.test.tsx
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+vi.unmock("@/features/scheduler/components/tasks/ChecklistView");
 import { render, screen, waitFor } from "@/test-utils";
 import { WeddingChecklistTab } from "@/features/scheduler/components/tasks/ChecklistView";
 

--- a/frontend/src/features/weddings/components/WeddingDetailTabs.test.tsx
+++ b/frontend/src/features/weddings/components/WeddingDetailTabs.test.tsx
@@ -18,6 +18,7 @@ const mockOverview = {
 };
 
 describe("WeddingDetailTabs", () => {
+
   it("renders tab triggers", () => {
     render(<WeddingDetailTabs wedding={mockWedding} />);
 

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -47,6 +47,21 @@ vi.mock("recharts", () => ({
   Tooltip: () => React.createElement("div", { "data-testid": "tooltip" }),
   Legend: () => React.createElement("div", { "data-testid": "legend" }),
 }));
+vi.mock("@/features/finances/components/FinancesView", () => ({
+  WeddingFinancesView: () => React.createElement("div", { "data-testid": "mock-finances-tab" }),
+}));
+
+vi.mock("@/features/logistics/components/VendorsItemsView", () => ({
+  WeddingVendorsItemsTab: () => React.createElement("div", { "data-testid": "mock-logistics-tab" }),
+}));
+
+vi.mock("@/features/scheduler/components/events/TimelineView", () => ({
+  WeddingTimelineTab: () => React.createElement("div", { "data-testid": "mock-timeline-tab" }),
+}));
+
+vi.mock("@/features/scheduler/components/tasks/ChecklistView", () => ({
+  WeddingChecklistTab: () => React.createElement("div", { "data-testid": "mock-checklist-tab" }),
+}));
 
 const dropdownListeners = new Set<() => void>();
 let hasAnyTriggerBeenClicked = false;


### PR DESCRIPTION
This PR increases test coverage for `ExpensesTab` and `ExpenseDetailSheet` in the Finances module, covering all visual and interactive features. It also resolves Vitest module cache collisions in the concurrency setup (`isolate: false`) by centralizing static mocks and utilizing `vi.unmock` in specific unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded finance test coverage for expense installments: toggling paid/unpaid now verifies success and failure notifications.
  * Reworked expenses tab tests to be MSW-driven, covering loading, API error states, creating, editing, deleting, and viewing expense details.
  * Improved scheduling, logistics, and finance view tests by explicitly un-mocking the real components under test.
  * Updated shared test setup to centralize mocks for wedding-related views and stabilize lazy-loading behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->