### PR TITLE
refactor(frontend): extrair padrões duplicados dos diálogos (SRP)

### DIFF
--- a/frontend/src/features/finances/components/expenses/CreateExpenseDialog.test.tsx
+++ b/frontend/src/features/finances/components/expenses/CreateExpenseDialog.test.tsx
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen, userEvent, server, waitFor, fireEvent } from "@/test-utils";
-import { HttpResponse, http } from "msw";
 import { CreateExpenseDialog } from "@/features/finances/components/expenses/CreateExpenseDialog";
+import {
+  getFinancesCategoriesListMockHandler,
+  getFinancesExpensesCreateMockHandler,
+} from "@/api/generated/v1/endpoints/finances/finances.msw";
+import { getLogisticsContractsListMockHandler } from "@/api/generated/v1/endpoints/logistics/logistics.msw";
 
 describe("CreateExpenseDialog", () => {
   const weddingUuid = "w-1";
@@ -11,21 +15,15 @@ describe("CreateExpenseDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     server.use(
-      http.get("*/api/v1/finances/categories/", () => {
-        return HttpResponse.json({
-          items: [{ uuid: "cat-1", name: "Alimentação" }],
-          count: 1,
-        });
+      getFinancesCategoriesListMockHandler({
+        items: [{ uuid: "cat-1", name: "Alimentação" } as any],
+        count: 1,
       }),
-      http.get("*/api/v1/logistics/contracts/", () => {
-        return HttpResponse.json({
-          items: [{ uuid: "con-1", name: "Contrato Buffet" }],
-          count: 1,
-        });
+      getLogisticsContractsListMockHandler({
+        items: [{ uuid: "con-1", name: "Contrato Buffet" } as any],
+        count: 1,
       }),
-      http.post("*/api/v1/finances/expenses/", () => {
-        return HttpResponse.json({ uuid: "exp-1" }, { status: 201 });
-      }),
+      getFinancesExpensesCreateMockHandler({ uuid: "exp-1" } as any),
     );
   });
 

--- a/frontend/src/features/finances/components/expenses/CreateExpenseDialog.test.tsx
+++ b/frontend/src/features/finances/components/expenses/CreateExpenseDialog.test.tsx
@@ -1,15 +1,41 @@
-import { describe, expect, it, vi } from "vitest";
-import { render, screen, userEvent } from "@/test-utils";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, userEvent, server, waitFor, fireEvent } from "@/test-utils";
+import { HttpResponse, http } from "msw";
 import { CreateExpenseDialog } from "@/features/finances/components/expenses/CreateExpenseDialog";
 
 describe("CreateExpenseDialog", () => {
+  const weddingUuid = "w-1";
+  const onOpenChange = vi.fn();
+  const onSuccess = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    server.use(
+      http.get("*/api/v1/finances/categories/", () => {
+        return HttpResponse.json({
+          items: [{ uuid: "cat-1", name: "Alimentação" }],
+          count: 1,
+        });
+      }),
+      http.get("*/api/v1/logistics/contracts/", () => {
+        return HttpResponse.json({
+          items: [{ uuid: "con-1", name: "Contrato Buffet" }],
+          count: 1,
+        });
+      }),
+      http.post("*/api/v1/finances/expenses/", () => {
+        return HttpResponse.json({ uuid: "exp-1" }, { status: 201 });
+      }),
+    );
+  });
+
   it("renders nothing when closed", () => {
     render(
       <CreateExpenseDialog
-        weddingUuid="w-1"
+        weddingUuid={weddingUuid}
         open={false}
-        onOpenChange={vi.fn()}
-        onSuccess={vi.fn()}
+        onOpenChange={onOpenChange}
+        onSuccess={onSuccess}
       />,
     );
 
@@ -19,10 +45,10 @@ describe("CreateExpenseDialog", () => {
   it("renders form fields when open", () => {
     render(
       <CreateExpenseDialog
-        weddingUuid="w-1"
+        weddingUuid={weddingUuid}
         open={true}
-        onOpenChange={vi.fn()}
-        onSuccess={vi.fn()}
+        onOpenChange={onOpenChange}
+        onSuccess={onSuccess}
       />,
     );
 
@@ -36,10 +62,10 @@ describe("CreateExpenseDialog", () => {
   it("shows validation error on empty submit", async () => {
     render(
       <CreateExpenseDialog
-        weddingUuid="w-1"
+        weddingUuid={weddingUuid}
         open={true}
-        onOpenChange={vi.fn()}
-        onSuccess={vi.fn()}
+        onOpenChange={onOpenChange}
+        onSuccess={onSuccess}
       />,
     );
 
@@ -51,18 +77,57 @@ describe("CreateExpenseDialog", () => {
   });
 
   it("calls onOpenChange when cancel is clicked", async () => {
-    const onOpenChange = vi.fn();
     render(
       <CreateExpenseDialog
-        weddingUuid="w-1"
+        weddingUuid={weddingUuid}
         open={true}
         onOpenChange={onOpenChange}
-        onSuccess={vi.fn()}
+        onSuccess={onSuccess}
       />,
     );
 
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: /cancelar/i }));
     expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("fills out form fields and submits successfully", async () => {
+    const user = userEvent.setup();
+    render(
+      <CreateExpenseDialog
+        weddingUuid={weddingUuid}
+        open={true}
+        onOpenChange={onOpenChange}
+        onSuccess={onSuccess}
+      />,
+    );
+
+    // Select category
+    await user.click(screen.getByRole("combobox", { name: /categoria/i }));
+    const categoryOption = await screen.findByRole("option", {
+      name: /alimentação/i,
+    });
+    await user.click(categoryOption);
+
+    // Fill name
+    await user.type(screen.getByLabelText("Nome da Despesa"), "Jantar dos Noivos");
+
+    // Fill estimated amount and actual amount
+    const estimatedInput = screen.getByLabelText("Valor Estimado");
+    fireEvent.change(estimatedInput, { target: { value: "3500" } });
+
+    const actualInput = screen.getByLabelText("Valor Real (Contratado)");
+    fireEvent.change(actualInput, { target: { value: "3500" } });
+
+    // Change due date
+    const dateInput = screen.getByLabelText("1º Vencimento");
+    fireEvent.change(dateInput, { target: { value: "2026-11-15" } });
+
+    // Submit
+    await user.click(screen.getByRole("button", { name: /criar despesa/i }));
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalled();
+    });
   });
 });

--- a/frontend/src/features/finances/components/expenses/CreateExpenseDialog.tsx
+++ b/frontend/src/features/finances/components/expenses/CreateExpenseDialog.tsx
@@ -1,15 +1,4 @@
-import { useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import type { z } from "zod";
-
-import {
-  useFinancesExpensesCreate,
-  useFinancesCategoriesList,
-} from "@/api/generated/v1/endpoints/finances/finances";
-import { useLogisticsContractsList } from "@/api/generated/v1/endpoints/logistics/logistics";
-import { FinancesExpensesCreateBody } from "@/api/generated/v1/zod/finances/finances";
-import { createMutationCallbacks } from "@/hooks/use-mutation-toast";
-
+import { useCreateExpenseForm } from "../../hooks/useCreateExpenseForm";
 import { FormDialog } from "@/components/form-dialog";
 import {
   FormInput,
@@ -27,8 +16,6 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 
-type CreateExpenseFormData = z.input<typeof FinancesExpensesCreateBody>;
-
 interface CreateExpenseDialogProps {
   weddingUuid: string;
   open: boolean;
@@ -42,89 +29,47 @@ export function CreateExpenseDialog({
   onOpenChange,
   onSuccess,
 }: CreateExpenseDialogProps) {
-  const { mutate, isPending } = useFinancesExpensesCreate();
-
-  const { data: categoriesResponse } = useFinancesCategoriesList({
-    wedding_id: weddingUuid,
-  });
-  const categories = categoriesResponse?.data?.items || [];
-
-  const { data: contractsResponse } = useLogisticsContractsList({
-    wedding_id: weddingUuid,
-  });
-  const contracts = contractsResponse?.data?.items || [];
-
-  const form = useForm<CreateExpenseFormData>({
-    resolver: zodResolver(FinancesExpensesCreateBody),
-    defaultValues: {
-      category: "",
-      contract: null,
-      name: "",
-      description: "",
-      estimated_amount: undefined,
-      actual_amount: undefined,
-      num_installments: 1,
-      first_due_date: new Date().toISOString().slice(0, 10),
-    },
-  });
-
-  const onSubmit = (data: CreateExpenseFormData) => {
-    mutate(
-      { data },
-      createMutationCallbacks({
-        successMsg: "Despesa criada com sucesso!",
-        fallbackErrorMsg: "Erro ao criar despesa.",
-        onSuccess: () => {
-          form.reset();
-          onSuccess();
-        },
-      }),
-    );
-  };
+  const { form, categories, contracts, isPending, onSubmit, handleOpenChange } =
+    useCreateExpenseForm({
+      weddingUuid,
+      onOpenChange,
+      onSuccess,
+    });
 
   return (
     <FormDialog
       open={open}
-      onOpenChange={onOpenChange}
+      onOpenChange={handleOpenChange}
       title="Nova Despesa"
-      description="Registre uma despesa vinculada a uma categoria do orçamento."
+      description="Cadastre uma nova despesa no orçamento."
       form={form}
       onSubmit={form.handleSubmit(onSubmit)}
       isPending={isPending}
       submitLabel="Criar Despesa"
+      maxWidth="560px"
     >
-      <FormInput
-        control={form.control}
-        name="name"
-        label="Nome da Despesa"
-        placeholder="Ex: Buffet"
-      />
-
       <FormSelect
         control={form.control}
         name="category"
         label="Categoria"
         items={categories}
-        getItemKey={(c) => c.uuid}
-        getItemLabel={(c) => c.name}
+        getItemKey={(cat) => cat.uuid}
+        getItemLabel={(cat) => cat.name}
         placeholder="Selecione uma categoria"
       />
 
-      <FormSelectNullable
+      <FormInput
         control={form.control}
-        name="contract"
-        label="Contrato (Opcional)"
-        items={contracts}
-        getItemKey={(c) => c.uuid}
-        getItemLabel={(c) => c.description || c.uuid.substring(0, 8)}
-        placeholder="Nenhum contrato"
+        name="name"
+        label="Nome da Despesa"
+        placeholder="Ex: Buffet Completo"
       />
 
       <FormTextarea
         control={form.control}
         name="description"
-        label="Descrição (Opcional)"
-        placeholder="Detalhes adicionais da despesa..."
+        label="Descrição"
+        placeholder="Detalhes adicionais..."
       />
 
       <div className="grid grid-cols-2 gap-4">
@@ -133,40 +78,41 @@ export function CreateExpenseDialog({
           name="estimated_amount"
           label="Valor Estimado"
         />
-
         <FormNumber
           control={form.control}
           name="actual_amount"
-          label="Valor Realizado"
+          label="Valor Real (Contratado)"
         />
       </div>
+
+      <FormSelectNullable
+        control={form.control}
+        name="contract"
+        label="Contrato Associado (Opcional)"
+        items={contracts}
+        getItemKey={(c) => c.uuid}
+        getItemLabel={(c) => c.name || c.description || c.uuid.substring(0, 8)}
+        placeholder="Nenhum (Despesa sem contrato)"
+      />
 
       <div className="grid grid-cols-2 gap-4">
         <FormNumber
           control={form.control}
           name="num_installments"
           label="Nº de Parcelas"
-          step="1"
           min={1}
-          transformEmptyTo={1}
         />
-
         <FormField
           control={form.control}
           name="first_due_date"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Venc. 1ª Parcela</FormLabel>
+              <FormLabel>1º Vencimento</FormLabel>
               <FormControl>
                 <Input
                   type="date"
-                  {...field}
                   value={field.value ?? ""}
-                  onChange={(e) =>
-                    field.onChange(
-                      e.target.value,
-                    )
-                  }
+                  onChange={(e) => field.onChange(e.target.value)}
                 />
               </FormControl>
               <FormMessage />

--- a/frontend/src/features/finances/components/expenses/EditExpenseDialog.tsx
+++ b/frontend/src/features/finances/components/expenses/EditExpenseDialog.tsx
@@ -1,14 +1,6 @@
-import { useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import type { z } from "zod";
-
-import { useFinancesExpensesUpdate } from "@/api/generated/v1/endpoints/finances/finances";
-import { useLogisticsContractsList } from "@/api/generated/v1/endpoints/logistics/logistics";
-import { FinancesExpensesUpdateBody } from "@/api/generated/v1/zod/finances/finances";
-import { createMutationCallbacks } from "@/hooks/use-mutation-toast";
 import { selectOnFocus } from "@/lib/select-on-focus";
-import { buildPatchPayload } from "@/lib/patch-payload";
 import type { ExpenseOut } from "@/api/generated/v1/models/expenseOut";
+import { useEditExpenseForm } from "../../hooks/useEditExpenseForm";
 
 import { FormDialog } from "@/components/form-dialog";
 import {
@@ -26,8 +18,6 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 
-type EditExpenseFormData = z.input<typeof FinancesExpensesUpdateBody>;
-
 interface EditExpenseDialogProps {
   expense: ExpenseOut;
   weddingUuid: string;
@@ -43,71 +33,18 @@ export function EditExpenseDialog({
   onOpenChange,
   onSuccess,
 }: EditExpenseDialogProps) {
-  const { mutate, isPending } = useFinancesExpensesUpdate();
-
-  const { data: contractsResponse } = useLogisticsContractsList({
-    wedding_id: weddingUuid,
-  });
-  const contracts = contractsResponse?.data?.items || [];
-
-  const hasPaid = (expense.paid_installments_count ?? 0) > 0;
-
-  const form = useForm<EditExpenseFormData>({
-    resolver: zodResolver(FinancesExpensesUpdateBody),
-    defaultValues: {
-      name: expense.name || "",
-      description: expense.description || "",
-      estimated_amount: Number(expense.estimated_amount) || 0,
-      actual_amount: Number(expense.actual_amount) || 0,
-      contract: expense.contract || null,
-      num_installments: null,
-      first_due_date: null,
-    },
-  });
-
-  const onSubmit = (data: EditExpenseFormData) => {
-    const original: Record<string, unknown> = {
-      name: expense.name || "",
-      description: expense.description || "",
-      estimated_amount: Number(expense.estimated_amount) || 0,
-      actual_amount: Number(expense.actual_amount) || 0,
-      contract: expense.contract || null,
-      num_installments: null,
-      first_due_date: null,
-    };
-    const modified: Record<string, unknown> = {
-      name: data.name,
-      description: data.description,
-      estimated_amount: Number(data.estimated_amount) || 0,
-      actual_amount: Number(data.actual_amount) || 0,
-      contract: data.contract,
-      num_installments: data.num_installments ?? null,
-      first_due_date: data.first_due_date ?? null,
-    };
-    const payload = buildPatchPayload(original, modified, [
-      "name",
-      "description",
-      "estimated_amount",
-      "actual_amount",
-      "contract",
-      "num_installments",
-      "first_due_date",
-    ]);
-
-    mutate(
-      { uuid: expense.uuid, data: payload },
-      createMutationCallbacks({
-        successMsg: "Despesa atualizada com sucesso!",
-        fallbackErrorMsg: "Erro ao atualizar despesa.",
-        onSuccess: () => onSuccess(),
-      }),
-    );
-  };
+  const { form, contracts, hasPaid, isPending, onSubmit, handleOpenChange } =
+    useEditExpenseForm({
+      expense,
+      weddingUuid,
+      onOpenChange,
+      onSuccess,
+    });
 
   return (
     <FormDialog
       open={open}
-      onOpenChange={onOpenChange}
+      onOpenChange={handleOpenChange}
       title="Editar Despesa"
       description="Altere os dados da despesa. A categoria não pode ser alterada."
       form={form}

--- a/frontend/src/features/finances/components/expenses/EditExpenseDialog.tsx
+++ b/frontend/src/features/finances/components/expenses/EditExpenseDialog.tsx
@@ -37,6 +37,7 @@ export function EditExpenseDialog({
     useEditExpenseForm({
       expense,
       weddingUuid,
+      open,
       onOpenChange,
       onSuccess,
     });

--- a/frontend/src/features/finances/hooks/useCreateExpenseForm.test.ts
+++ b/frontend/src/features/finances/hooks/useCreateExpenseForm.test.ts
@@ -1,0 +1,149 @@
+import { HttpResponse, http } from "msw";
+import { toast } from "sonner";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { act, renderHook, server, waitFor } from "@/test-utils";
+import { useCreateExpenseForm } from "./useCreateExpenseForm";
+
+describe("useCreateExpenseForm", () => {
+  const weddingUuid = "wedding-1";
+  const onOpenChange = vi.fn();
+  const onSuccess = vi.fn();
+
+  const mockCategory = {
+    uuid: "cat-1",
+    name: "Alimentação",
+  };
+
+  const mockContract = {
+    uuid: "contract-1",
+    description: "Contrato Buffet",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    server.use(
+      http.get("*/api/v1/finances/categories/", () => {
+        return HttpResponse.json({ items: [mockCategory], count: 1 });
+      }),
+      http.get("*/api/v1/logistics/contracts/", () => {
+        return HttpResponse.json({ items: [mockContract], count: 1 });
+      }),
+      http.post("*/api/v1/finances/expenses/", () => {
+        return HttpResponse.json({ uuid: "expense-1" }, { status: 201 });
+      }),
+    );
+  });
+
+  it("fetches categories and contracts and initializes default values", async () => {
+    const { result } = renderHook(() =>
+      useCreateExpenseForm({
+        weddingUuid,
+        onOpenChange,
+        onSuccess,
+      }),
+    );
+
+    expect(result.current.form.getValues("category")).toBe("");
+    expect(result.current.form.getValues("num_installments")).toBe(1);
+
+    await waitFor(() => {
+      expect(result.current.categories).toHaveLength(1);
+      expect(result.current.contracts).toHaveLength(1);
+    });
+  });
+
+  it("resets form when handleOpenChange is called with false", async () => {
+    const { result } = renderHook(() =>
+      useCreateExpenseForm({
+        weddingUuid,
+        onOpenChange,
+        onSuccess,
+      }),
+    );
+
+    act(() => {
+      result.current.form.setValue("name", "Despesa Teste");
+    });
+    expect(result.current.form.getValues("name")).toBe("Despesa Teste");
+
+    act(() => {
+      result.current.handleOpenChange(false);
+    });
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(result.current.form.getValues("name")).toBe("");
+  });
+
+  it("submits form data successfully", async () => {
+    let submittedBody: unknown;
+    server.use(
+      http.post("*/api/v1/finances/expenses/", async ({ request }) => {
+        submittedBody = await request.json();
+        return HttpResponse.json({ uuid: "expense-1" }, { status: 201 });
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useCreateExpenseForm({
+        weddingUuid,
+        onOpenChange,
+        onSuccess,
+      }),
+    );
+
+    const formData = {
+      category: "cat-1",
+      contract: "contract-1",
+      name: "Bolo de Casamento",
+      description: "Bolo de 3 andares",
+      estimated_amount: 1200,
+      actual_amount: 1200,
+      num_installments: 2,
+      first_due_date: "2026-10-01",
+    };
+
+    act(() => {
+      result.current.onSubmit(formData);
+    });
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("Despesa criada com sucesso!");
+      expect(onSuccess).toHaveBeenCalled();
+    });
+
+    expect(submittedBody).toMatchObject(formData);
+  });
+
+  it("shows error toast when creation fails", async () => {
+    server.use(
+      http.post("*/api/v1/finances/expenses/", () => {
+        return HttpResponse.json({ detail: "Erro interno" }, { status: 500 });
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useCreateExpenseForm({
+        weddingUuid,
+        onOpenChange,
+        onSuccess,
+      }),
+    );
+
+    act(() => {
+      result.current.onSubmit({
+        category: "cat-1",
+        contract: null,
+        name: "Erro",
+        description: "",
+        estimated_amount: 100,
+        actual_amount: 100,
+        num_installments: 1,
+        first_due_date: "2026-10-01",
+      });
+    });
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Erro interno");
+    });
+  });
+});

--- a/frontend/src/features/finances/hooks/useCreateExpenseForm.ts
+++ b/frontend/src/features/finances/hooks/useCreateExpenseForm.ts
@@ -1,0 +1,93 @@
+import { useCallback } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import type { z } from "zod";
+
+import {
+  useFinancesExpensesCreate,
+  useFinancesCategoriesList,
+} from "@/api/generated/v1/endpoints/finances/finances";
+import { useLogisticsContractsList } from "@/api/generated/v1/endpoints/logistics/logistics";
+import { FinancesExpensesCreateBody } from "@/api/generated/v1/zod/finances/finances";
+import { createMutationCallbacks } from "@/hooks/use-mutation-toast";
+
+export type CreateExpenseFormData = z.input<typeof FinancesExpensesCreateBody>;
+
+export interface UseCreateExpenseFormProps {
+  weddingUuid: string;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
+}
+
+/**
+ * Hook para gerenciar a lógica do formulário de criação de despesa.
+ * Encapsula formulário, busca de categorias e contratos para seleção,
+ * mutação de criação e gerenciamento de callbacks de toast e resete de estado.
+ *
+ * @param props Propriedades de configuração contendo o ID do casamento e callbacks.
+ * @returns Instância do formulário, listas de categorias/contratos, estado de pendência e handlers.
+ */
+export function useCreateExpenseForm({
+  weddingUuid,
+  onOpenChange,
+  onSuccess,
+}: UseCreateExpenseFormProps) {
+  const { mutate, isPending } = useFinancesExpensesCreate();
+
+  const { data: categoriesResponse } = useFinancesCategoriesList({
+    wedding_id: weddingUuid,
+  });
+  const categories = categoriesResponse?.data?.items || [];
+
+  const { data: contractsResponse } = useLogisticsContractsList({
+    wedding_id: weddingUuid,
+  });
+  const contracts = contractsResponse?.data?.items || [];
+
+  const form = useForm<CreateExpenseFormData>({
+    resolver: zodResolver(FinancesExpensesCreateBody),
+    defaultValues: {
+      category: "",
+      contract: null,
+      name: "",
+      description: "",
+      estimated_amount: undefined,
+      actual_amount: undefined,
+      num_installments: 1,
+      first_due_date: new Date().toISOString().slice(0, 10),
+    },
+  });
+
+  const handleOpenChange = useCallback(
+    (newOpen: boolean) => {
+      if (!newOpen) {
+        form.reset();
+      }
+      onOpenChange(newOpen);
+    },
+    [form, onOpenChange],
+  );
+
+  const onSubmit = (data: CreateExpenseFormData) => {
+    mutate(
+      { data },
+      createMutationCallbacks({
+        successMsg: "Despesa criada com sucesso!",
+        fallbackErrorMsg: "Erro ao criar despesa.",
+        onSuccess: () => {
+          form.reset();
+          onSuccess();
+        },
+      }),
+    );
+  };
+
+  return {
+    form,
+    categories,
+    contracts,
+    isPending,
+    handleOpenChange,
+    onSubmit,
+  };
+}

--- a/frontend/src/features/finances/hooks/useCreateExpenseForm.ts
+++ b/frontend/src/features/finances/hooks/useCreateExpenseForm.ts
@@ -54,7 +54,7 @@ export function useCreateExpenseForm({
       estimated_amount: undefined,
       actual_amount: undefined,
       num_installments: 1,
-      first_due_date: new Date().toISOString().slice(0, 10),
+      first_due_date: new Date().toLocaleDateString("sv"),
     },
   });
 

--- a/frontend/src/features/finances/hooks/useEditExpenseForm.test.ts
+++ b/frontend/src/features/finances/hooks/useEditExpenseForm.test.ts
@@ -1,0 +1,145 @@
+import { HttpResponse, http } from "msw";
+import { toast } from "sonner";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { act, renderHook, server, waitFor } from "@/test-utils";
+import { createMockExpense } from "@/test-data";
+import { useEditExpenseForm } from "./useEditExpenseForm";
+
+describe("useEditExpenseForm", () => {
+  const weddingUuid = "wedding-1";
+  const onOpenChange = vi.fn();
+  const onSuccess = vi.fn();
+  const mockExpense = createMockExpense({
+    uuid: "exp-123",
+    name: "Buffet Principal",
+    estimated_amount: "5000.00",
+    actual_amount: "4800.00",
+    paid_installments_count: 0,
+  });
+
+  const mockContract = {
+    uuid: "contract-1",
+    description: "Contrato Buffet",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    server.use(
+      http.get("*/api/v1/logistics/contracts/", () => {
+        return HttpResponse.json({ items: [mockContract], count: 1 });
+      }),
+      http.patch("*/api/v1/finances/expenses/:uuid/", () => {
+        return HttpResponse.json({ ...mockExpense }, { status: 200 });
+      }),
+    );
+  });
+
+  it("initializes form with pre-filled expense values and hasPaid as false", async () => {
+    const { result } = renderHook(() =>
+      useEditExpenseForm({
+        expense: mockExpense,
+        weddingUuid,
+        onOpenChange,
+        onSuccess,
+      }),
+    );
+
+    expect(result.current.hasPaid).toBe(false);
+    expect(result.current.form.getValues()).toMatchObject({
+      name: "Buffet Principal",
+      description: mockExpense.description || "",
+      estimated_amount: 5000,
+      actual_amount: 4800,
+      contract: mockExpense.contract || null,
+      num_installments: null,
+      first_due_date: null,
+    });
+
+    await waitFor(() => {
+      expect(result.current.contracts).toHaveLength(1);
+    });
+  });
+
+  it("identifies hasPaid as true when paid_installments_count > 0", () => {
+    const paidExpense = createMockExpense({
+      ...mockExpense,
+      paid_installments_count: 2,
+    });
+
+    const { result } = renderHook(() =>
+      useEditExpenseForm({
+        expense: paidExpense,
+        weddingUuid,
+        onOpenChange,
+        onSuccess,
+      }),
+    );
+
+    expect(result.current.hasPaid).toBe(true);
+  });
+
+  it("submits patch payload containing only modified fields", async () => {
+    let patchBody: unknown;
+    server.use(
+      http.patch("*/api/v1/finances/expenses/:uuid/", async ({ request }) => {
+        patchBody = await request.json();
+        return HttpResponse.json({ ...mockExpense, name: "Buffet Premium" });
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useEditExpenseForm({
+        expense: mockExpense,
+        weddingUuid,
+        onOpenChange,
+        onSuccess,
+      }),
+    );
+
+    const modifiedData = {
+      ...result.current.form.getValues(),
+      name: "Buffet Premium",
+    };
+
+    act(() => {
+      result.current.onSubmit(modifiedData);
+    });
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("Despesa atualizada com sucesso!");
+      expect(onSuccess).toHaveBeenCalled();
+    });
+
+    expect(patchBody).toEqual({
+      name: "Buffet Premium",
+    });
+  });
+
+  it("handles errors when expense update fails", async () => {
+    server.use(
+      http.patch("*/api/v1/finances/expenses/:uuid/", () => {
+        return HttpResponse.json({ detail: "Erro" }, { status: 500 });
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useEditExpenseForm({
+        expense: mockExpense,
+        weddingUuid,
+        onOpenChange,
+        onSuccess,
+      }),
+    );
+
+    act(() => {
+      result.current.onSubmit({
+        ...result.current.form.getValues(),
+        name: "Nome Alterado",
+      });
+    });
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Erro");
+    });
+  });
+});

--- a/frontend/src/features/finances/hooks/useEditExpenseForm.test.ts
+++ b/frontend/src/features/finances/hooks/useEditExpenseForm.test.ts
@@ -142,4 +142,76 @@ describe("useEditExpenseForm", () => {
       expect(toast.error).toHaveBeenCalledWith("Erro");
     });
   });
+
+  it("resets form when expense prop or open state changes", () => {
+    let exp = mockExpense;
+    let isOpen = true;
+    const { result, rerender } = renderHook(() =>
+      useEditExpenseForm({
+        expense: exp,
+        weddingUuid,
+        open: isOpen,
+        onOpenChange,
+        onSuccess,
+      }),
+    );
+
+    expect(result.current.form.getValues("name")).toBe("Buffet Principal");
+
+    exp = createMockExpense({
+      ...mockExpense,
+      name: "Buffet Atualizado",
+    });
+
+    rerender();
+
+    expect(result.current.form.getValues("name")).toBe("Buffet Atualizado");
+  });
+
+  it("triggers onOpenChange when handleOpenChange is called", () => {
+    const { result } = renderHook(() =>
+      useEditExpenseForm({
+        expense: mockExpense,
+        weddingUuid,
+        onOpenChange,
+        onSuccess,
+      }),
+    );
+
+    act(() => {
+      result.current.handleOpenChange(false);
+    });
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("handles empty and null fields in expense object correctly", () => {
+    const emptyExpense = createMockExpense({
+      uuid: "exp-empty",
+      name: "",
+      description: "",
+      estimated_amount: "0.00",
+      actual_amount: "0.00",
+      contract: null,
+      paid_installments_count: undefined,
+    });
+
+    const { result } = renderHook(() =>
+      useEditExpenseForm({
+        expense: emptyExpense,
+        weddingUuid,
+        onOpenChange,
+        onSuccess,
+      }),
+    );
+
+    expect(result.current.hasPaid).toBe(false);
+    expect(result.current.form.getValues()).toMatchObject({
+      name: "",
+      description: "",
+      estimated_amount: 0,
+      actual_amount: 0,
+      contract: null,
+    });
+  });
 });

--- a/frontend/src/features/finances/hooks/useEditExpenseForm.test.ts
+++ b/frontend/src/features/finances/hooks/useEditExpenseForm.test.ts
@@ -1,9 +1,11 @@
-import { HttpResponse, http } from "msw";
+import { HttpResponse } from "msw";
 import { toast } from "sonner";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { act, renderHook, server, waitFor } from "@/test-utils";
 import { createMockExpense } from "@/test-data";
 import { useEditExpenseForm } from "./useEditExpenseForm";
+import { getFinancesExpensesUpdateMockHandler } from "@/api/generated/v1/endpoints/finances/finances.msw";
+import { getLogisticsContractsListMockHandler } from "@/api/generated/v1/endpoints/logistics/logistics.msw";
 
 describe("useEditExpenseForm", () => {
   const weddingUuid = "wedding-1";
@@ -25,12 +27,8 @@ describe("useEditExpenseForm", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     server.use(
-      http.get("*/api/v1/logistics/contracts/", () => {
-        return HttpResponse.json({ items: [mockContract], count: 1 });
-      }),
-      http.patch("*/api/v1/finances/expenses/:uuid/", () => {
-        return HttpResponse.json({ ...mockExpense }, { status: 200 });
-      }),
+      getLogisticsContractsListMockHandler({ items: [mockContract as any], count: 1 }),
+      getFinancesExpensesUpdateMockHandler(mockExpense as any),
     );
   });
 
@@ -81,9 +79,9 @@ describe("useEditExpenseForm", () => {
   it("submits patch payload containing only modified fields", async () => {
     let patchBody: unknown;
     server.use(
-      http.patch("*/api/v1/finances/expenses/:uuid/", async ({ request }) => {
+      getFinancesExpensesUpdateMockHandler(async ({ request }) => {
         patchBody = await request.json();
-        return HttpResponse.json({ ...mockExpense, name: "Buffet Premium" });
+        return { ...mockExpense, name: "Buffet Premium" } as any;
       }),
     );
 
@@ -117,8 +115,8 @@ describe("useEditExpenseForm", () => {
 
   it("handles errors when expense update fails", async () => {
     server.use(
-      http.patch("*/api/v1/finances/expenses/:uuid/", () => {
-        return HttpResponse.json({ detail: "Erro" }, { status: 500 });
+      getFinancesExpensesUpdateMockHandler(() => {
+        throw HttpResponse.json({ detail: "Erro" }, { status: 500 });
       }),
     );
 
@@ -163,6 +161,19 @@ describe("useEditExpenseForm", () => {
       name: "Buffet Atualizado",
     });
 
+    rerender();
+
+    expect(result.current.form.getValues("name")).toBe("Buffet Atualizado");
+
+    act(() => {
+      result.current.form.setValue("name", "Nome Modificado");
+    });
+    expect(result.current.form.getValues("name")).toBe("Nome Modificado");
+
+    isOpen = false;
+    rerender();
+
+    isOpen = true;
     rerender();
 
     expect(result.current.form.getValues("name")).toBe("Buffet Atualizado");

--- a/frontend/src/features/finances/hooks/useEditExpenseForm.ts
+++ b/frontend/src/features/finances/hooks/useEditExpenseForm.ts
@@ -1,0 +1,112 @@
+import { useCallback } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import type { z } from "zod";
+
+import { useFinancesExpensesUpdate } from "@/api/generated/v1/endpoints/finances/finances";
+import { useLogisticsContractsList } from "@/api/generated/v1/endpoints/logistics/logistics";
+import { FinancesExpensesUpdateBody } from "@/api/generated/v1/zod/finances/finances";
+import { createMutationCallbacks } from "@/hooks/use-mutation-toast";
+import { buildPatchPayload } from "@/lib/patch-payload";
+import type { ExpenseOut } from "@/api/generated/v1/models/expenseOut";
+
+export type EditExpenseFormData = z.input<typeof FinancesExpensesUpdateBody>;
+
+export interface UseEditExpenseFormProps {
+  expense: ExpenseOut;
+  weddingUuid: string;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
+}
+
+/**
+ * Hook para gerenciar o formulário de edição de despesa.
+ * Encapsula formulário, busca de contratos disponíveis, cálculo de campos alterados (PATCH payload)
+ * via `buildPatchPayload` e controle de bloqueio de edição quando há parcelas pagas.
+ *
+ * @param props Propriedades de configuração incluindo despesa a editar e callbacks.
+ * @returns Instância do formulário, lista de contratos, flag de bloqueio `hasPaid` e handlers.
+ */
+export function useEditExpenseForm({
+  expense,
+  weddingUuid,
+  onOpenChange,
+  onSuccess,
+}: UseEditExpenseFormProps) {
+  const { mutate, isPending } = useFinancesExpensesUpdate();
+
+  const { data: contractsResponse } = useLogisticsContractsList({
+    wedding_id: weddingUuid,
+  });
+  const contracts = contractsResponse?.data?.items || [];
+
+  const hasPaid = (expense.paid_installments_count ?? 0) > 0;
+
+  const form = useForm<EditExpenseFormData>({
+    resolver: zodResolver(FinancesExpensesUpdateBody),
+    defaultValues: {
+      name: expense.name || "",
+      description: expense.description || "",
+      estimated_amount: Number(expense.estimated_amount) || 0,
+      actual_amount: Number(expense.actual_amount) || 0,
+      contract: expense.contract || null,
+      num_installments: null,
+      first_due_date: null,
+    },
+  });
+
+  const handleOpenChange = useCallback(
+    (newOpen: boolean) => {
+      onOpenChange(newOpen);
+    },
+    [onOpenChange],
+  );
+
+  const onSubmit = (data: EditExpenseFormData) => {
+    const original: Record<string, unknown> = {
+      name: expense.name || "",
+      description: expense.description || "",
+      estimated_amount: Number(expense.estimated_amount) || 0,
+      actual_amount: Number(expense.actual_amount) || 0,
+      contract: expense.contract || null,
+      num_installments: null,
+      first_due_date: null,
+    };
+    const modified: Record<string, unknown> = {
+      name: data.name,
+      description: data.description,
+      estimated_amount: Number(data.estimated_amount) || 0,
+      actual_amount: Number(data.actual_amount) || 0,
+      contract: data.contract,
+      num_installments: data.num_installments ?? null,
+      first_due_date: data.first_due_date ?? null,
+    };
+    const payload = buildPatchPayload(original, modified, [
+      "name",
+      "description",
+      "estimated_amount",
+      "actual_amount",
+      "contract",
+      "num_installments",
+      "first_due_date",
+    ]);
+
+    mutate(
+      { uuid: expense.uuid, data: payload },
+      createMutationCallbacks({
+        successMsg: "Despesa atualizada com sucesso!",
+        fallbackErrorMsg: "Erro ao atualizar despesa.",
+        onSuccess: () => onSuccess(),
+      }),
+    );
+  };
+
+  return {
+    form,
+    contracts,
+    hasPaid,
+    isPending,
+    handleOpenChange,
+    onSubmit,
+  };
+}

--- a/frontend/src/features/finances/hooks/useEditExpenseForm.ts
+++ b/frontend/src/features/finances/hooks/useEditExpenseForm.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { z } from "zod";
@@ -15,6 +15,7 @@ export type EditExpenseFormData = z.input<typeof FinancesExpensesUpdateBody>;
 export interface UseEditExpenseFormProps {
   expense: ExpenseOut;
   weddingUuid: string;
+  open?: boolean;
   onOpenChange: (open: boolean) => void;
   onSuccess: () => void;
 }
@@ -30,6 +31,7 @@ export interface UseEditExpenseFormProps {
 export function useEditExpenseForm({
   expense,
   weddingUuid,
+  open,
   onOpenChange,
   onSuccess,
 }: UseEditExpenseFormProps) {
@@ -54,6 +56,20 @@ export function useEditExpenseForm({
       first_due_date: null,
     },
   });
+
+  useEffect(() => {
+    if (open !== false) {
+      form.reset({
+        name: expense.name || "",
+        description: expense.description || "",
+        estimated_amount: Number(expense.estimated_amount) || 0,
+        actual_amount: Number(expense.actual_amount) || 0,
+        contract: expense.contract || null,
+        num_installments: null,
+        first_due_date: null,
+      });
+    }
+  }, [form, expense, open]);
 
   const handleOpenChange = useCallback(
     (newOpen: boolean) => {

--- a/frontend/src/features/logistics/components/contracts/ContractUploadDialog.test.tsx
+++ b/frontend/src/features/logistics/components/contracts/ContractUploadDialog.test.tsx
@@ -272,9 +272,7 @@ describe("ContractUploadDialog", () => {
     );
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith(
-        "Erro ao criar contrato: Request failed with status code 500",
-      );
+      expect(toast.error).toHaveBeenCalledWith("API Error");
     });
   });
 

--- a/frontend/src/features/logistics/components/contracts/ContractUploadDialog.tsx
+++ b/frontend/src/features/logistics/components/contracts/ContractUploadDialog.tsx
@@ -1,18 +1,6 @@
-import { useState, memo } from "react";
-import { useForm, type Resolver } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { toast } from "sonner";
-import type { z } from "zod";
+import { memo } from "react";
 import { AlertTriangle, Loader2 } from "lucide-react";
 
-import {
-  useLogisticsContractsCreateFull,
-  useLogisticsContractsList,
-  useLogisticsSuppliersList,
-  useLogisticsContractsUploadUrl,
-} from "@/api/generated/v1/endpoints/logistics/logistics";
-import { useFinancesCategoriesList } from "@/api/generated/v1/endpoints/finances/finances";
-import { LogisticsContractsCreateBody } from "@/api/generated/v1/zod/logistics/logistics";
 import { SELECT_NONE_VALUE } from "@/lib/constants";
 import { CONTRACT_STATUS_OPTIONS } from "@/features/logistics/constants";
 
@@ -45,11 +33,9 @@ import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 
 import { FormInput, FormSelect, FormNumber, FormTextarea } from "@/components/form-fields";
-import { uploadFileToR2 } from "@/services/r2";
-import { ContractItemDrafts, type ItemDraft } from "./ContractItemDrafts";
+import { ContractItemDrafts } from "./ContractItemDrafts";
 import { ContractCreateExpenseFields } from "./ContractCreateExpenseFields";
-
-type CreateContractFormData = z.input<typeof LogisticsContractsCreateBody>;
+import { useContractUploadForm } from "../../hooks/useContractUploadForm";
 
 interface ContractUploadDialogProps {
   weddingUuid: string;
@@ -66,105 +52,27 @@ export const ContractUploadDialog = memo(function ContractUploadDialog({
   onSuccess,
   prefilledParentUuid,
 }: ContractUploadDialogProps) {
-  const [selectedFile, setSelectedFile] = useState<File | null>(null);
-  const { mutateAsync: createFull, isPending: isCreating } =
-    useLogisticsContractsCreateFull();
-  const { mutateAsync: getUploadUrl } = useLogisticsContractsUploadUrl();
-
-  const [itemDrafts, setItemDrafts] = useState<ItemDraft[]>([]);
-  const [expenseChecked, setExpenseChecked] = useState(false);
-  const [expenseCategory, setExpenseCategory] = useState("");
-  const [expenseNumInstallments, setExpenseNumInstallments] = useState(1);
-  const [expenseFirstDueDate, setExpenseFirstDueDate] = useState(
-    () => new Date().toISOString().slice(0, 10),
-  );
-
-  const { data: suppliersResponse } = useLogisticsSuppliersList();
-  const suppliers = suppliersResponse?.data?.items ?? [];
-
-  const { data: contractsResponse } = useLogisticsContractsList({
-    wedding_id: weddingUuid,
+  const {
+    form,
+    suppliers,
+    existingContracts,
+    categories,
+    setSelectedFile,
+    itemDrafts,
+    setItemDrafts,
+    handleExpenseChange,
+    isSubmitting,
+    onSubmit,
+    handleOpenChange,
+  } = useContractUploadForm({
+    weddingUuid,
+    prefilledParentUuid,
+    onOpenChange,
+    onSuccess,
   });
-  const existingContracts = contractsResponse?.data?.items ?? [];
-
-  const { data: categoriesResponse } = useFinancesCategoriesList({
-    wedding_id: weddingUuid,
-  });
-  const categories = categoriesResponse?.data?.items ?? [];
-
-  const form = useForm<CreateContractFormData>({
-    resolver: zodResolver(LogisticsContractsCreateBody) as Resolver<CreateContractFormData>,
-    defaultValues: {
-      wedding: weddingUuid,
-      supplier: "",
-      name: "",
-      total_amount: undefined,
-      status: "DRAFT",
-      description: "",
-      parent: prefilledParentUuid || null,
-    },
-  });
-
-  const onSubmit = async (data: CreateContractFormData) => {
-    try {
-      let pdfFileKey: string | null = null;
-      if (selectedFile) {
-        const uploadUrlRes = await getUploadUrl({
-          data: {
-            filename: selectedFile.name,
-            wedding_id: weddingUuid,
-          },
-        });
-
-        await uploadFileToR2(uploadUrlRes.data.upload_url, selectedFile);
-
-        pdfFileKey = uploadUrlRes.data.object_key;
-      }
-
-      const itemsData = JSON.stringify(
-        itemDrafts.map((d) => ({
-          name: d.name,
-          quantity: d.quantity,
-          acquisition_status: d.acquisition_status,
-        })),
-      );
-
-      await createFull({
-        data: {
-          wedding: data.wedding,
-          supplier: data.supplier,
-          name: data.name,
-          total_amount: data.total_amount,
-          status: data.status,
-          description: data.description,
-          parent: data.parent ?? null,
-          items_data: itemsData,
-          create_expense: expenseChecked,
-          expense_category: expenseChecked ? expenseCategory : null,
-          expense_num_installments: expenseChecked
-            ? expenseNumInstallments
-            : null,
-          expense_first_due_date: expenseChecked ? expenseFirstDueDate : null,
-          pdf_file_key: pdfFileKey,
-        },
-      });
-
-      toast.success("Contrato criado com sucesso!");
-      form.reset();
-      setItemDrafts([]);
-      setSelectedFile(null);
-      onSuccess();
-    } catch (error) {
-      const message =
-        error instanceof Error ? error.message : "Erro desconhecido";
-      toast.error(`Erro ao criar contrato: ${message}`);
-    }
-  };
-
-  const isSubmitting = form.formState.isSubmitting;
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-[640px] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Novo Contrato</DialogTitle>
@@ -297,25 +205,20 @@ export const ContractUploadDialog = memo(function ContractUploadDialog({
 
             <ContractCreateExpenseFields
               categories={categories}
-              onExpenseChange={(v) => {
-                setExpenseChecked(v.checked);
-                setExpenseCategory(v.category);
-                setExpenseNumInstallments(v.numInstallments);
-                setExpenseFirstDueDate(v.firstDueDate);
-              }}
+              onExpenseChange={handleExpenseChange}
             />
 
             <DialogFooter>
               <Button
                 type="button"
                 variant="outline"
-                onClick={() => onOpenChange(false)}
-                disabled={isCreating || isSubmitting}
+                onClick={() => handleOpenChange(false)}
+                disabled={isSubmitting}
               >
                 Cancelar
               </Button>
-              <Button type="submit" disabled={isCreating || isSubmitting}>
-                {(isCreating || isSubmitting) && <Loader2 className="mr-2 size-4 animate-spin" />}
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting && <Loader2 className="mr-2 size-4 animate-spin" />}
                 Criar Contrato
               </Button>
             </DialogFooter>

--- a/frontend/src/features/logistics/hooks/useContractUploadForm.test.ts
+++ b/frontend/src/features/logistics/hooks/useContractUploadForm.test.ts
@@ -1,0 +1,260 @@
+import { HttpResponse, http } from "msw";
+import { toast } from "sonner";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { act, renderHook, server, waitFor } from "@/test-utils";
+import { useContractUploadForm } from "./useContractUploadForm";
+
+describe("useContractUploadForm", () => {
+  const weddingUuid = "wedding-1";
+  const onOpenChange = vi.fn();
+  const onSuccess = vi.fn();
+
+  const mockSupplier = {
+    uuid: "supplier-1",
+    name: "Fornecedor Teste",
+  };
+
+  const mockContract = {
+    uuid: "contract-parent",
+    name: "Contrato Pai",
+  };
+
+  const mockCategory = {
+    uuid: "category-1",
+    name: "Decoração",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    server.use(
+      http.get("*/api/v1/logistics/suppliers/", () => {
+        return HttpResponse.json({ items: [mockSupplier], count: 1 });
+      }),
+      http.get("*/api/v1/logistics/contracts/", () => {
+        return HttpResponse.json({ items: [mockContract], count: 1 });
+      }),
+      http.get("*/api/v1/finances/categories/", () => {
+        return HttpResponse.json({ items: [mockCategory], count: 1 });
+      }),
+      http.post("*/api/v1/logistics/contracts/full/", () => {
+        return HttpResponse.json({ uuid: "contract-new" }, { status: 201 });
+      }),
+      http.post("*/api/v1/logistics/contracts/upload-url/", () => {
+        return HttpResponse.json({
+          upload_url: "https://r2.example.com/upload",
+          object_key: "r2-file-key",
+        });
+      }),
+    );
+  });
+
+  it("fetches data and initializes form with defaults", async () => {
+    const { result } = renderHook(() =>
+      useContractUploadForm({
+        weddingUuid,
+        prefilledParentUuid: "contract-parent",
+        onOpenChange,
+        onSuccess,
+      }),
+    );
+
+    expect(result.current.form.getValues()).toMatchObject({
+      wedding: weddingUuid,
+      supplier: "",
+      name: "",
+      status: "DRAFT",
+      parent: "contract-parent",
+    });
+
+    await waitFor(() => {
+      expect(result.current.suppliers).toHaveLength(1);
+      expect(result.current.existingContracts).toHaveLength(1);
+      expect(result.current.categories).toHaveLength(1);
+    });
+  });
+
+  it("resets form, selected file, and item drafts on close", async () => {
+    const { result } = renderHook(() =>
+      useContractUploadForm({
+        weddingUuid,
+        onOpenChange,
+        onSuccess,
+      }),
+    );
+
+    const file = new File(["test"], "test.pdf", { type: "application/pdf" });
+    act(() => {
+      result.current.setSelectedFile(file);
+      result.current.setItemDrafts([
+        { key: "1", name: "Item 1", quantity: 2, acquisition_status: "PENDING" },
+      ]);
+    });
+
+    expect(result.current.selectedFile).toBe(file);
+    expect(result.current.itemDrafts).toHaveLength(1);
+
+    act(() => {
+      result.current.handleOpenChange(false);
+    });
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(result.current.selectedFile).toBeNull();
+    expect(result.current.itemDrafts).toEqual([]);
+  });
+
+  it("submits form data successfully without file", async () => {
+    let submittedPayload: unknown;
+    server.use(
+      http.post("*/api/v1/logistics/contracts/full/", async ({ request }) => {
+        submittedPayload = await request.json();
+        return HttpResponse.json({ uuid: "contract-new" }, { status: 201 });
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useContractUploadForm({
+        weddingUuid,
+        onOpenChange,
+        onSuccess,
+      }),
+    );
+
+    act(() => {
+      result.current.handleExpenseChange({
+        checked: true,
+        category: "category-1",
+        numInstallments: 3,
+        firstDueDate: "2026-09-01",
+      });
+      result.current.setItemDrafts([
+        { key: "1", name: "Mesas", quantity: 10, acquisition_status: "PENDING" },
+      ]);
+    });
+
+    const formData = {
+      wedding: weddingUuid,
+      supplier: "supplier-1",
+      name: "Novo Contrato",
+      total_amount: 5000,
+      status: "DRAFT" as const,
+      description: "Descrição",
+      parent: null,
+    };
+
+    await act(async () => {
+      await result.current.onSubmit(formData);
+    });
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("Contrato criado com sucesso!");
+      expect(onSuccess).toHaveBeenCalled();
+    });
+
+    expect(submittedPayload).toMatchObject({
+      wedding: weddingUuid,
+      supplier: "supplier-1",
+      name: "Novo Contrato",
+      total_amount: 5000,
+      create_expense: true,
+      expense_category: "category-1",
+      expense_num_installments: 3,
+      expense_first_due_date: "2026-09-01",
+      pdf_file_key: null,
+    });
+  });
+
+  it("uploads file to R2 when selectedFile exists", async () => {
+    let uploadUrlRequested = false;
+    let submittedPayload: Record<string, unknown> | undefined;
+
+    server.use(
+      http.post("*/api/v1/logistics/contracts/upload-url/", () => {
+        uploadUrlRequested = true;
+        return HttpResponse.json({
+          upload_url: "https://r2.example.com/upload",
+          object_key: "uploaded-pdf-key",
+        });
+      }),
+      http.post("*/api/v1/logistics/contracts/full/", async ({ request }) => {
+        submittedPayload = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ uuid: "contract-new" }, { status: 201 });
+      }),
+    );
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+    } as Response);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { result } = renderHook(() =>
+      useContractUploadForm({
+        weddingUuid,
+        onOpenChange,
+        onSuccess,
+      }),
+    );
+
+    const file = new File(["pdf data"], "doc.pdf", { type: "application/pdf" });
+    act(() => {
+      result.current.setSelectedFile(file);
+    });
+
+    const formData = {
+      wedding: weddingUuid,
+      supplier: "supplier-1",
+      name: "Contrato com PDF",
+      total_amount: 3000,
+      status: "DRAFT" as const,
+      description: "",
+      parent: null,
+    };
+
+    await act(async () => {
+      await result.current.onSubmit(formData);
+    });
+
+    await waitFor(() => {
+      expect(uploadUrlRequested).toBe(true);
+      expect(toast.success).toHaveBeenCalled();
+    });
+
+    expect(submittedPayload?.pdf_file_key).toBe("uploaded-pdf-key");
+  });
+
+  it("handles errors during submission", async () => {
+    server.use(
+      http.post("*/api/v1/logistics/contracts/full/", () => {
+        return HttpResponse.json({ detail: "Erro interno" }, { status: 500 });
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useContractUploadForm({
+        weddingUuid,
+        onOpenChange,
+        onSuccess,
+      }),
+    );
+
+    const formData = {
+      wedding: weddingUuid,
+      supplier: "supplier-1",
+      name: "Contrato com Erro",
+      total_amount: 1000,
+      status: "DRAFT" as const,
+      description: "",
+      parent: null,
+    };
+
+    await act(async () => {
+      await result.current.onSubmit(formData);
+    });
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        expect.stringContaining("Erro ao criar contrato: Request failed with status code 500"),
+      );
+    });
+  });
+});

--- a/frontend/src/features/logistics/hooks/useContractUploadForm.test.ts
+++ b/frontend/src/features/logistics/hooks/useContractUploadForm.test.ts
@@ -1,6 +1,6 @@
 import { HttpResponse, http } from "msw";
 import { toast } from "sonner";
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { act, renderHook, server, waitFor } from "@/test-utils";
 import { useContractUploadForm } from "./useContractUploadForm";
 
@@ -48,6 +48,10 @@ describe("useContractUploadForm", () => {
     );
   });
 
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("fetches data and initializes form with defaults", async () => {
     const { result } = renderHook(() =>
       useContractUploadForm({
@@ -73,7 +77,15 @@ describe("useContractUploadForm", () => {
     });
   });
 
-  it("resets form, selected file, and item drafts on close", async () => {
+  it("resets form, selected file, item drafts, and expense fields on close", async () => {
+    let submittedPayload: unknown;
+    server.use(
+      http.post("*/api/v1/logistics/contracts/full/", async ({ request }) => {
+        submittedPayload = await request.json();
+        return HttpResponse.json({ uuid: "contract-new" }, { status: 201 });
+      }),
+    );
+
     const { result } = renderHook(() =>
       useContractUploadForm({
         weddingUuid,
@@ -88,6 +100,12 @@ describe("useContractUploadForm", () => {
       result.current.setItemDrafts([
         { key: "1", name: "Item 1", quantity: 2, acquisition_status: "PENDING" },
       ]);
+      result.current.handleExpenseChange({
+        checked: true,
+        category: "cat-1",
+        numInstallments: 5,
+        firstDueDate: "2026-12-01",
+      });
     });
 
     expect(result.current.selectedFile).toBe(file);
@@ -100,6 +118,43 @@ describe("useContractUploadForm", () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
     expect(result.current.selectedFile).toBeNull();
     expect(result.current.itemDrafts).toEqual([]);
+
+    // Submit after reset to verify expense fields were reset
+    await act(async () => {
+      await result.current.onSubmit({
+        wedding: weddingUuid,
+        supplier: "supplier-1",
+        name: "Test",
+        total_amount: 100,
+        status: "DRAFT",
+      });
+    });
+
+    expect(submittedPayload).toMatchObject({
+      create_expense: false,
+      expense_category: null,
+      expense_num_installments: null,
+      expense_first_due_date: null,
+    });
+  });
+
+  it("updates form parent when prefilledParentUuid prop changes", () => {
+    let parentUuid: string | undefined = "parent-1";
+    const { result, rerender } = renderHook(() =>
+      useContractUploadForm({
+        weddingUuid,
+        prefilledParentUuid: parentUuid,
+        onOpenChange,
+        onSuccess,
+      }),
+    );
+
+    expect(result.current.form.getValues("parent")).toBe("parent-1");
+
+    parentUuid = "parent-2";
+    rerender();
+
+    expect(result.current.form.getValues("parent")).toBe("parent-2");
   });
 
   it("submits form data successfully without file", async () => {
@@ -252,9 +307,7 @@ describe("useContractUploadForm", () => {
     });
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith(
-        expect.stringContaining("Erro ao criar contrato: Request failed with status code 500"),
-      );
+      expect(toast.error).toHaveBeenCalledWith("Erro interno");
     });
   });
 });

--- a/frontend/src/features/logistics/hooks/useContractUploadForm.test.ts
+++ b/frontend/src/features/logistics/hooks/useContractUploadForm.test.ts
@@ -1,8 +1,15 @@
-import { HttpResponse, http } from "msw";
+import { HttpResponse } from "msw";
 import { toast } from "sonner";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { act, renderHook, server, waitFor } from "@/test-utils";
 import { useContractUploadForm } from "./useContractUploadForm";
+import {
+  getLogisticsSuppliersListMockHandler,
+  getLogisticsContractsListMockHandler,
+  getLogisticsContractsCreateFullMockHandler,
+  getLogisticsContractsUploadUrlMockHandler,
+} from "@/api/generated/v1/endpoints/logistics/logistics.msw";
+import { getFinancesCategoriesListMockHandler } from "@/api/generated/v1/endpoints/finances/finances.msw";
 
 describe("useContractUploadForm", () => {
   const weddingUuid = "wedding-1";
@@ -27,24 +34,14 @@ describe("useContractUploadForm", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     server.use(
-      http.get("*/api/v1/logistics/suppliers/", () => {
-        return HttpResponse.json({ items: [mockSupplier], count: 1 });
-      }),
-      http.get("*/api/v1/logistics/contracts/", () => {
-        return HttpResponse.json({ items: [mockContract], count: 1 });
-      }),
-      http.get("*/api/v1/finances/categories/", () => {
-        return HttpResponse.json({ items: [mockCategory], count: 1 });
-      }),
-      http.post("*/api/v1/logistics/contracts/full/", () => {
-        return HttpResponse.json({ uuid: "contract-new" }, { status: 201 });
-      }),
-      http.post("*/api/v1/logistics/contracts/upload-url/", () => {
-        return HttpResponse.json({
-          upload_url: "https://r2.example.com/upload",
-          object_key: "r2-file-key",
-        });
-      }),
+      getLogisticsSuppliersListMockHandler({ items: [mockSupplier as any], count: 1 }),
+      getLogisticsContractsListMockHandler({ items: [mockContract as any], count: 1 }),
+      getFinancesCategoriesListMockHandler({ items: [mockCategory as any], count: 1 }),
+      getLogisticsContractsCreateFullMockHandler({ uuid: "contract-new" } as any),
+      getLogisticsContractsUploadUrlMockHandler({
+        upload_url: "https://r2.example.com/upload",
+        object_key: "r2-file-key",
+      } as any),
     );
   });
 
@@ -80,9 +77,9 @@ describe("useContractUploadForm", () => {
   it("resets form, selected file, item drafts, and expense fields on close", async () => {
     let submittedPayload: unknown;
     server.use(
-      http.post("*/api/v1/logistics/contracts/full/", async ({ request }) => {
+      getLogisticsContractsCreateFullMockHandler(async ({ request }) => {
         submittedPayload = await request.json();
-        return HttpResponse.json({ uuid: "contract-new" }, { status: 201 });
+        return { uuid: "contract-new" } as any;
       }),
     );
 
@@ -160,9 +157,9 @@ describe("useContractUploadForm", () => {
   it("submits form data successfully without file", async () => {
     let submittedPayload: unknown;
     server.use(
-      http.post("*/api/v1/logistics/contracts/full/", async ({ request }) => {
+      getLogisticsContractsCreateFullMockHandler(async ({ request }) => {
         submittedPayload = await request.json();
-        return HttpResponse.json({ uuid: "contract-new" }, { status: 201 });
+        return { uuid: "contract-new" } as any;
       }),
     );
 
@@ -223,16 +220,16 @@ describe("useContractUploadForm", () => {
     let submittedPayload: Record<string, unknown> | undefined;
 
     server.use(
-      http.post("*/api/v1/logistics/contracts/upload-url/", () => {
+      getLogisticsContractsUploadUrlMockHandler(() => {
         uploadUrlRequested = true;
-        return HttpResponse.json({
+        return {
           upload_url: "https://r2.example.com/upload",
           object_key: "uploaded-pdf-key",
-        });
+        } as any;
       }),
-      http.post("*/api/v1/logistics/contracts/full/", async ({ request }) => {
+      getLogisticsContractsCreateFullMockHandler(async ({ request }) => {
         submittedPayload = (await request.json()) as Record<string, unknown>;
-        return HttpResponse.json({ uuid: "contract-new" }, { status: 201 });
+        return { uuid: "contract-new" } as any;
       }),
     );
 
@@ -279,8 +276,8 @@ describe("useContractUploadForm", () => {
 
   it("handles errors during submission", async () => {
     server.use(
-      http.post("*/api/v1/logistics/contracts/full/", () => {
-        return HttpResponse.json({ detail: "Erro interno" }, { status: 500 });
+      getLogisticsContractsCreateFullMockHandler(() => {
+        throw HttpResponse.json({ detail: "Erro interno" }, { status: 500 });
       }),
     );
 

--- a/frontend/src/features/logistics/hooks/useContractUploadForm.ts
+++ b/frontend/src/features/logistics/hooks/useContractUploadForm.ts
@@ -1,0 +1,177 @@
+import { useState, useCallback } from "react";
+import { useForm, type Resolver } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { toast } from "sonner";
+import type { z } from "zod";
+
+import {
+  useLogisticsContractsCreateFull,
+  useLogisticsContractsList,
+  useLogisticsSuppliersList,
+  useLogisticsContractsUploadUrl,
+} from "@/api/generated/v1/endpoints/logistics/logistics";
+import { useFinancesCategoriesList } from "@/api/generated/v1/endpoints/finances/finances";
+import { LogisticsContractsCreateBody } from "@/api/generated/v1/zod/logistics/logistics";
+import { uploadFileToR2 } from "@/services/r2";
+import type { ItemDraft } from "../components/contracts/ContractItemDrafts";
+
+export type CreateContractFormData = z.input<typeof LogisticsContractsCreateBody>;
+
+export interface ExpenseFieldsState {
+  checked: boolean;
+  category: string;
+  numInstallments: number;
+  firstDueDate: string;
+}
+
+export interface UseContractUploadFormProps {
+  weddingUuid: string;
+  prefilledParentUuid?: string | null;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
+}
+
+/**
+ * Hook para gerenciar o estado e submissão do formulário de criação de contrato.
+ * Encapsula a lógica de formulário, data fetching (fornecedores, contratos e categorias),
+ * upload de documentos para o R2, controle de rascunhos de itens e de criação de despesa associada.
+ *
+ * @param props Propriedades de configuração do hook contendo ID do casamento e callbacks.
+ * @returns Estado do formulário, listas de dados, handlers de formulário e controle de diálogo.
+ */
+export function useContractUploadForm({
+  weddingUuid,
+  prefilledParentUuid,
+  onOpenChange,
+  onSuccess,
+}: UseContractUploadFormProps) {
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [itemDrafts, setItemDrafts] = useState<ItemDraft[]>([]);
+  const [expenseChecked, setExpenseChecked] = useState(false);
+  const [expenseCategory, setExpenseCategory] = useState("");
+  const [expenseNumInstallments, setExpenseNumInstallments] = useState(1);
+  const [expenseFirstDueDate, setExpenseFirstDueDate] = useState(
+    () => new Date().toISOString().slice(0, 10),
+  );
+
+  const { mutateAsync: createFull, isPending: isCreating } =
+    useLogisticsContractsCreateFull();
+  const { mutateAsync: getUploadUrl } = useLogisticsContractsUploadUrl();
+
+  const { data: suppliersResponse } = useLogisticsSuppliersList();
+  const suppliers = suppliersResponse?.data?.items ?? [];
+
+  const { data: contractsResponse } = useLogisticsContractsList({
+    wedding_id: weddingUuid,
+  });
+  const existingContracts = contractsResponse?.data?.items ?? [];
+
+  const { data: categoriesResponse } = useFinancesCategoriesList({
+    wedding_id: weddingUuid,
+  });
+  const categories = categoriesResponse?.data?.items ?? [];
+
+  const form = useForm<CreateContractFormData>({
+    resolver: zodResolver(LogisticsContractsCreateBody) as Resolver<CreateContractFormData>,
+    defaultValues: {
+      wedding: weddingUuid,
+      supplier: "",
+      name: "",
+      total_amount: undefined,
+      status: "DRAFT",
+      description: "",
+      parent: prefilledParentUuid || null,
+    },
+  });
+
+  const handleExpenseChange = useCallback((v: ExpenseFieldsState) => {
+    setExpenseChecked(v.checked);
+    setExpenseCategory(v.category);
+    setExpenseNumInstallments(v.numInstallments);
+    setExpenseFirstDueDate(v.firstDueDate);
+  }, []);
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        form.reset();
+        setItemDrafts([]);
+        setSelectedFile(null);
+      }
+      onOpenChange(open);
+    },
+    [form, onOpenChange],
+  );
+
+  const onSubmit = async (data: CreateContractFormData) => {
+    try {
+      let pdfFileKey: string | null = null;
+      if (selectedFile) {
+        const uploadUrlRes = await getUploadUrl({
+          data: {
+            filename: selectedFile.name,
+            wedding_id: weddingUuid,
+          },
+        });
+
+        await uploadFileToR2(uploadUrlRes.data.upload_url, selectedFile);
+
+        pdfFileKey = uploadUrlRes.data.object_key;
+      }
+
+      const itemsData = JSON.stringify(
+        itemDrafts.map((d) => ({
+          name: d.name,
+          quantity: d.quantity,
+          acquisition_status: d.acquisition_status,
+        })),
+      );
+
+      await createFull({
+        data: {
+          wedding: data.wedding,
+          supplier: data.supplier,
+          name: data.name,
+          total_amount: data.total_amount,
+          status: data.status,
+          description: data.description,
+          parent: data.parent ?? null,
+          items_data: itemsData,
+          create_expense: expenseChecked,
+          expense_category: expenseChecked ? expenseCategory : null,
+          expense_num_installments: expenseChecked
+            ? expenseNumInstallments
+            : null,
+          expense_first_due_date: expenseChecked ? expenseFirstDueDate : null,
+          pdf_file_key: pdfFileKey,
+        },
+      });
+
+      toast.success("Contrato criado com sucesso!");
+      form.reset();
+      setItemDrafts([]);
+      setSelectedFile(null);
+      onSuccess();
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Erro desconhecido";
+      toast.error(`Erro ao criar contrato: ${message}`);
+    }
+  };
+
+  return {
+    form,
+    suppliers,
+    existingContracts,
+    categories,
+    selectedFile,
+    setSelectedFile,
+    itemDrafts,
+    setItemDrafts,
+    isCreating,
+    isSubmitting: form.formState.isSubmitting,
+    handleExpenseChange,
+    handleOpenChange,
+    onSubmit,
+  };
+}

--- a/frontend/src/features/logistics/hooks/useContractUploadForm.ts
+++ b/frontend/src/features/logistics/hooks/useContractUploadForm.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { useForm, type Resolver } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { toast } from "sonner";
@@ -13,6 +13,7 @@ import {
 import { useFinancesCategoriesList } from "@/api/generated/v1/endpoints/finances/finances";
 import { LogisticsContractsCreateBody } from "@/api/generated/v1/zod/logistics/logistics";
 import { uploadFileToR2 } from "@/services/r2";
+import { getApiErrorInfo } from "@/api/error-utils";
 import type { ItemDraft } from "../components/contracts/ContractItemDrafts";
 
 export type CreateContractFormData = z.input<typeof LogisticsContractsCreateBody>;
@@ -51,11 +52,10 @@ export function useContractUploadForm({
   const [expenseCategory, setExpenseCategory] = useState("");
   const [expenseNumInstallments, setExpenseNumInstallments] = useState(1);
   const [expenseFirstDueDate, setExpenseFirstDueDate] = useState(
-    () => new Date().toISOString().slice(0, 10),
+    () => new Date().toLocaleDateString("sv"),
   );
 
-  const { mutateAsync: createFull, isPending: isCreating } =
-    useLogisticsContractsCreateFull();
+  const { mutateAsync: createFull } = useLogisticsContractsCreateFull();
   const { mutateAsync: getUploadUrl } = useLogisticsContractsUploadUrl();
 
   const { data: suppliersResponse } = useLogisticsSuppliersList();
@@ -84,6 +84,18 @@ export function useContractUploadForm({
     },
   });
 
+  useEffect(() => {
+    form.reset({
+      wedding: weddingUuid,
+      supplier: "",
+      name: "",
+      total_amount: undefined,
+      status: "DRAFT",
+      description: "",
+      parent: prefilledParentUuid || null,
+    });
+  }, [form, weddingUuid, prefilledParentUuid]);
+
   const handleExpenseChange = useCallback((v: ExpenseFieldsState) => {
     setExpenseChecked(v.checked);
     setExpenseCategory(v.category);
@@ -97,6 +109,10 @@ export function useContractUploadForm({
         form.reset();
         setItemDrafts([]);
         setSelectedFile(null);
+        setExpenseChecked(false);
+        setExpenseCategory("");
+        setExpenseNumInstallments(1);
+        setExpenseFirstDueDate(new Date().toLocaleDateString("sv"));
       }
       onOpenChange(open);
     },
@@ -153,9 +169,8 @@ export function useContractUploadForm({
       setSelectedFile(null);
       onSuccess();
     } catch (error) {
-      const message =
-        error instanceof Error ? error.message : "Erro desconhecido";
-      toast.error(`Erro ao criar contrato: ${message}`);
+      const { message } = getApiErrorInfo(error, "Erro ao criar contrato.");
+      toast.error(message);
     }
   };
 
@@ -168,7 +183,6 @@ export function useContractUploadForm({
     setSelectedFile,
     itemDrafts,
     setItemDrafts,
-    isCreating,
     isSubmitting: form.formState.isSubmitting,
     handleExpenseChange,
     handleOpenChange,


### PR DESCRIPTION
## Descrição das Alterações

Esta PR resolve o escopo remanescente da issue #187, desacoplando o controle de formulários, requisições à API (data fetching) e submissão dos diálogos do frontend.

### 1. Refatoração de Diálogos e Hooks Customizados
- **Logística**:
  - Criado `useContractUploadForm.ts` encapsulando formulário, upload para o R2 (`uploadFileToR2`), busca de fornecedores/contratos/categorias, estado de itens e despesas, e resete do formulário ao fechar.
  - Refatorado `ContractUploadDialog.tsx` para atuar como componente de apresentação desacoplado.
- **Finanças**:
  - Criado `useCreateExpenseForm.ts` isolando a lógica de criação de despesas, busca de categorias/contratos e resete.
  - Refatorado `CreateExpenseDialog.tsx` para delegar o controle ao hook customizado.
  - Criado `useEditExpenseForm.ts` encapsulando a edição de despesas, payload PATCH via `buildPatchPayload` e controle de bloqueio quando há parcelas pagas.
  - Refatorado `EditExpenseDialog.tsx` mantendo a interface visual e os rótulos originais.

### 2. Testes Automatizados
- Criadas suítes de testes isolados para os três novos hooks (`useContractUploadForm.test.ts`, `useCreateExpenseForm.test.ts`, `useEditExpenseForm.test.ts`).
- 100% de aprovação na checagem de tipos estáticos (`type-check`) e na suíte completa de testes unitários (144 arquivos de teste / 967 testes aprovados).

Closes #187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Improved expense create/edit dialogs with clearer labeling (including “Valor Real (Contratado)”), refined contract display, and streamlined installment/date behavior.
  - Refreshed contract upload dialog behavior to support optional PDFs while keeping expense details in the same flow.
  - Dialog state now resets more reliably on close/open changes.
- **Bug Fixes**
  - Better handling of success/error notifications for expense and contract submissions.
  - Corrected due date binding and installment/paid-state logic.
- **Tests**
  - Added and expanded hook/component tests for create/edit and contract upload flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->