### PR TITLE
chore(dependabot): update backend package-ecosystem to uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   # 1. Monitorar o Backend Python (Django Ninja)
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/backend" # Aponta direto para a pasta do backend onde estão o pyproject.toml ou requirements
     schedule:
       interval: "weekly"


### PR DESCRIPTION
This PR modifies `.github/dependabot.yml` to specify `uv` as the `package-ecosystem` instead of `pip` for the python backend. This ensures Dependabot correctly parses `uv.lock` and opens valid pull requests for updates.

---
*PR created automatically by Jules for task [9086673886362516686](https://jules.google.com/task/9086673886362516686) started by @Rafaelp122*