### PR TITLE
docs: add diátaxis audit report and adr 025

### DIFF
--- a/docs/4-explanation/adr/025-diataxis-atomic-notes.md
+++ b/docs/4-explanation/adr/025-diataxis-atomic-notes.md
@@ -1,0 +1,34 @@
+# ADR-025: Adoção do Framework Diatáxis e Padrão de Anotações Atômicas na Documentação
+
+**Status:** Aceito
+**Data:** 2024-06-13
+**Módulo:** Documentação e Governança
+
+## 1. Contexto e Problema
+
+O projeto tem crescido substancialmente, englobando integrações fullstack (Django, React, Orval, R2, Cloud Run, Neon). Durante esse crescimento, as documentações (READMEs e guias) se tornaram monolíticas, difíceis de ler e misturavam explicações teóricas abstratas com comandos de terminal pontuais.
+
+Isso prejudica a curva de aprendizado de novos desenvolvedores (onboarding) e dificulta encontrar respostas rápidas durante a manutenção do código ou na resolução de incidentes.
+
+## 2. Decisão
+
+Adotamos duas diretrizes rigorosas para governar o ciclo de vida de todo o conhecimento escrito da plataforma:
+
+1. **Framework Diatáxis:** Toda documentação oficial deve ser alocada estritamente em um dos 4 quadrantes definidos pelo framework, correspondentes aos subdiretórios criados em `docs/`:
+   - `1-tutorials/`: Para ensino e onboarding. Orientado ao aprendizado prático passo a passo.
+   - `2-how-to/`: Receitas para resolver um problema pontual do dia a dia. Orientado a tarefas.
+   - `3-reference/`: Especificações técnicas de schemas, classes e dados. Orientado a informações secas.
+   - `4-explanation/`: Porquês arquiteturais, regras de negócios e ADRs. Orientado à compreensão sistêmica.
+2. **Anotações Atômicas (Atomic Notes):** Cada documento no repositório não deve exceder um único escopo de conceito ou regra de negócio. Se um arquivo começar a cruzar múltiplos assuntos ou for maior que ~250 linhas, ele deve ser desmembrado.
+   - *Regra semântica:* Um documento atômico deve ter **somente um cabeçalho H1 (`#`)**.
+
+## 3. Consequências
+
+**Positivas:**
+- Reduz carga cognitiva: desenvolvedores com dúvidas práticas sabem que não precisam ler arquivos da pasta `4-explanation`.
+- Promove a reutilização: anotações atômicas podem ser "linkadas" livremente entre si criando uma rede de conhecimento orgânica, semelhante a um sistema de *Zettelkasten*.
+- Evita que guias rápidos fiquem defasados (fácil manutenção).
+
+**Negativas / Trade-offs:**
+- Um excesso de arquivos e divisões granulares. Desenvolvedores precisarão consultar os arquivos `index.md` / `README.md` regularmente para se localizarem ou usarem uma busca eficiente (`grep` / recursos da IDE).
+- Curva de adaptação: requer disciplina no processo de review de Pull Requests para apontar e exigir correções nos locais em que documentações foram colocadas nos quadrantes errados.

--- a/docs/diataxis-audit-report.md
+++ b/docs/diataxis-audit-report.md
@@ -1,0 +1,45 @@
+# Relatório de Auditoria de Documentação (Diatáxis e Anotações Atômicas)
+
+Esta auditoria analisou a documentação do projeto, que foi recentemente refatorada utilizando o **Framework Diatáxis** e o conceito de **Anotações Atômicas (Atomic Notes)**.
+
+O objetivo foi buscar pontos de melhoria, focando principalmente em:
+- **Categorização Correta:** Garantir que os arquivos estejam nas pastas certas (Tutoriais, How-to, Reference, Explanation).
+- **Atomicidade:** Garantir que cada nota aborde um único conceito, sem misturar ideias ou criar documentos excessivamente longos.
+
+## 1. Melhorias de Atomicidade (Quebra de Arquivos Longos)
+
+Vários arquivos na pasta `docs/4-explanation/` violam a regra de atomicidade, abordando múltiplos temas ou configurando-se como "mega-documentos".
+
+- **`docs/4-explanation/roadmap-pending-migration.md`** (674 linhas, 7 cabeçalhos H2)
+  - **Problema:** Muito extenso, misturando diagnóstico arquitetural, entidades, backlog de tarefas, refatoração de backend e frontend.
+  - **Recomendação:** Extrair o diagnóstico de CRUDs para um documento específico e manter o roadmap em si quebrado em épicos ou fatias menores (ex: `roadmap-frontend.md`, `roadmap-backend.md`, `roadmap-cross-domain.md`).
+
+- **`docs/4-explanation/architecture/ci-cd-pipeline-flow.md`** (246 linhas, múltiplos H1)
+  - **Problema:** A presença de múltiplos cabeçalhos H1 sugere a união de diferentes documentos independentes.
+  - **Recomendação:** Quebrar em conceitos distintos: `ci-overview.md`, `backend-ci-pipeline.md`, `frontend-ci-pipeline.md`.
+
+- **ADRs (Architecture Decision Records)**
+  - *Arquivos afetados:* `010-tolerance-zero.md`, `004-presigned-urls.md`, `007-hybrid-keys.md`, `009-multitenancy.md`, `008-soft-delete.md`, `006-service-layer.md`.
+  - **Problema:** Apesar das ADRs serem documentos densos, muitas possuem múltiplos `H1` (indicando fusão de notas ou quebra de semântica markdown) e excedem 300 linhas, entrando em detalhes de implementação em vez de focar apenas no contexto e decisão.
+  - **Recomendação:** Separar a **decisão arquitetural** (Explanation/ADR) da **especificação de implementação** (Reference) e dos **guias de uso** (How-to/Tutorial).
+
+## 2. Melhorias de Categorização (Diatáxis)
+
+- **`docs/4-explanation/roadmap-pending-migration.md`**
+  - **Problema:** Um Roadmap não é uma explicação conceitual (Explanation).
+  - **Recomendação:** Mover para a raiz de projetos temporários, ou criar uma categoria para "Planejamento/Backlog", fora dos quadrantes Diatáxis clássicos, pois muda frequentemente.
+
+- **`docs/2-how-to/backend/seed-database.md`**
+  - **Problema:** Estrutura e foco conceitual se assemelham muito a uma referência, misturando o "Como fazer" com descrições do domínio.
+
+## 3. Revisão Estrutural (Formatação Markdown)
+
+- Inconsistência de Títulos (H1 Múltiplos):
+  - Muitas anotações (especialmente ADRs e tutoriais como `docs/1-tutorials/onboarding-quickstart.md` e `docs/3-reference/architecture-standards/commenting-standards.md`) possuem vários headers `# ` (`H1`).
+  - **Recomendação:** Cada anotação atômica deve ter estritamente **um único `# H1`**, representando o título do conceito. Subseções devem usar `## H2` ou menores, mantendo a semântica atômica forte.
+
+## 4. Próximos Passos (Ação Recomendada)
+
+1. Adotar um documento ADR (ex: `025-diataxis-atomic-notes.md`) validando o Diatáxis e o princípio de Anotações Atômicas, impondo um "guard-rail" (ex: limite de linhas e 1x H1 por arquivo).
+2. Refatorar os "mega-arquivos" da pasta `4-explanation/` e `adr/` separando teoria, decisão e manuais práticos.
+3. Consertar a hierarquia de cabeçalhos nos arquivos listados acima.


### PR DESCRIPTION
This PR addresses the request to audit the current project documentation for Diátaxis correctness and the adherence to "atomic notes."

**Changes included:**
1. A new report (`docs/diataxis-audit-report.md`) outlining the files in violation, specific to monolithic explanations and categorization mismatches.
2. A new Architecture Decision Record (`docs/4-explanation/adr/025-diataxis-atomic-notes.md`) to cement the Diátaxis pattern and restrict files from expanding beyond one concept per note.

---
*PR created automatically by Jules for task [17286141453253155625](https://jules.google.com/task/17286141453253155625) started by @Rafaelp122*