### PR TITLE
fix(auth): exclude all auth endpoints from token refresh interceptor

### DIFF
--- a/frontend/src/api/interceptors/auth-refresh.test.ts
+++ b/frontend/src/api/interceptors/auth-refresh.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Axios, { AxiosError, type AxiosInstance, type InternalAxiosRequestConfig } from "axios";
+import { addAuthRefreshInterceptor } from "@/api/interceptors/auth-refresh";
+import { useAuthStore } from "@/stores/authStore";
+
+vi.mock("axios", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("axios")>();
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      post: vi.fn(),
+    },
+  };
+});
+
+function createMockInstance() {
+  const handlers = {
+    responseSuccess: null as ((response: unknown) => unknown) | null,
+    responseError: null as ((error: unknown) => unknown) | null,
+  };
+
+  const instance = vi.fn().mockImplementation(() => Promise.resolve({ data: "retry-ok" })) as unknown as AxiosInstance;
+  instance.interceptors = {
+    response: {
+      use(
+        onSuccess: (response: unknown) => unknown,
+        onError: (error: unknown) => unknown,
+      ) {
+        handlers.responseSuccess = onSuccess;
+        handlers.responseError = onError;
+        return 0;
+      },
+    },
+  } as never;
+
+  addAuthRefreshInterceptor(instance);
+
+  return { handlers, instance };
+}
+
+describe("addAuthRefreshInterceptor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuthStore.setState({
+      accessToken: null,
+      refreshToken: null,
+      user: null,
+      isAuthenticated: false,
+    });
+  });
+
+  describe("Regression Tests — Auth endpoints exclusion", () => {
+    it("does not attempt refresh when 401 occurs on /api/v1/auth/google/", async () => {
+      const { handlers } = createMockInstance();
+      const config = { url: "/api/v1/auth/google/" } as InternalAxiosRequestConfig;
+      const error = new AxiosError("Unauthorized", "ERR_BAD_REQUEST", config, undefined, {
+        status: 401,
+        data: { message: "Token do Google inválido" },
+        statusText: "Unauthorized",
+        headers: {} as never,
+        config,
+      });
+
+      const result = handlers.responseError?.(error);
+      await expect(result).rejects.toBe(error);
+
+      expect(Axios.post).not.toHaveBeenCalled();
+    });
+
+    it("does not attempt refresh when 401 occurs on /api/v1/auth/token/", async () => {
+      const { handlers } = createMockInstance();
+      const config = { url: "/api/v1/auth/token/" } as InternalAxiosRequestConfig;
+      const error = new AxiosError("Unauthorized", "ERR_BAD_REQUEST", config, undefined, {
+        status: 401,
+        data: { message: "Credenciais inválidas" },
+        statusText: "Unauthorized",
+        headers: {} as never,
+        config,
+      });
+
+      const result = handlers.responseError?.(error);
+      await expect(result).rejects.toBe(error);
+
+      expect(Axios.post).not.toHaveBeenCalled();
+    });
+
+    it("does not attempt refresh when 401 occurs on /api/v1/auth/register/", async () => {
+      const { handlers } = createMockInstance();
+      const config = { url: "/api/v1/auth/register/" } as InternalAxiosRequestConfig;
+      const error = new AxiosError("Unauthorized", "ERR_BAD_REQUEST", config, undefined, {
+        status: 401,
+        data: { message: "Erro no cadastro" },
+        statusText: "Unauthorized",
+        headers: {} as never,
+        config,
+      });
+
+      const result = handlers.responseError?.(error);
+      await expect(result).rejects.toBe(error);
+
+      expect(Axios.post).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Non-401 and Non-Auth handling", () => {
+    it("passes non-401 errors through without attempting refresh", async () => {
+      const { handlers } = createMockInstance();
+      const config = { url: "/api/v1/weddings/" } as InternalAxiosRequestConfig;
+      const error = new AxiosError("Not Found", "ERR_BAD_REQUEST", config, undefined, {
+        status: 404,
+        data: {},
+        statusText: "Not Found",
+        headers: {} as never,
+        config,
+      });
+
+      const result = handlers.responseError?.(error);
+      await expect(result).rejects.toBe(error);
+
+      expect(Axios.post).not.toHaveBeenCalled();
+    });
+
+    it("logs out and rejects normalized error when 401 on protected route and refreshToken is absent", async () => {
+      const { handlers } = createMockInstance();
+      const config = { url: "/api/v1/weddings/" } as InternalAxiosRequestConfig;
+      const error = new AxiosError("Unauthorized", "ERR_BAD_REQUEST", config, undefined, {
+        status: 401,
+        data: {},
+        statusText: "Unauthorized",
+        headers: {} as never,
+        config,
+      });
+
+      const result = handlers.responseError?.(error);
+      await expect(result).rejects.toSatisfy((err: Error) => {
+        return err.message.includes("Sessão irrecuperável: Refresh token ausente");
+      });
+
+      expect(useAuthStore.getState().isAuthenticated).toBe(false);
+      expect(useAuthStore.getState().accessToken).toBeNull();
+    });
+
+    it("refreshes token successfully when 401 occurs on protected endpoint with valid refreshToken", async () => {
+      useAuthStore.setState({
+        accessToken: "old-access",
+        refreshToken: "valid-refresh",
+        user: { id: "123-uuid", email: "user@test.com", first_name: "Test", last_name: "User" },
+        isAuthenticated: true,
+      });
+
+      vi.mocked(Axios.post).mockResolvedValueOnce({
+        data: { access: "new-access", refresh: "new-refresh" },
+      });
+
+      const { handlers } = createMockInstance();
+      const mockConfig = {
+        url: "/api/v1/weddings/",
+        headers: {},
+      } as InternalAxiosRequestConfig;
+
+      const error = new AxiosError("Unauthorized", "ERR_BAD_REQUEST", mockConfig, undefined, {
+        status: 401,
+        data: {},
+        statusText: "Unauthorized",
+        headers: {} as never,
+        config: mockConfig,
+      });
+
+      const result = await handlers.responseError?.(error);
+
+      expect(Axios.post).toHaveBeenCalledWith(
+        "/api/v1/auth/refresh/",
+        { refresh: "valid-refresh" },
+        expect.objectContaining({ timeout: 5000 }),
+      );
+
+      expect(useAuthStore.getState().accessToken).toBe("new-access");
+      expect(useAuthStore.getState().refreshToken).toBe("new-refresh");
+      expect(result).toEqual({ data: "retry-ok" });
+    });
+  });
+});

--- a/frontend/src/api/interceptors/auth-refresh.test.ts
+++ b/frontend/src/api/interceptors/auth-refresh.test.ts
@@ -3,17 +3,6 @@ import Axios, { AxiosError, type AxiosInstance, type InternalAxiosRequestConfig 
 import { addAuthRefreshInterceptor } from "@/api/interceptors/auth-refresh";
 import { useAuthStore } from "@/stores/authStore";
 
-vi.mock("axios", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("axios")>();
-  return {
-    ...actual,
-    default: {
-      ...actual.default,
-      post: vi.fn(),
-    },
-  };
-});
-
 function createMockInstance() {
   const handlers = {
     responseSuccess: null as ((response: unknown) => unknown) | null,
@@ -41,7 +30,7 @@ function createMockInstance() {
 
 describe("addAuthRefreshInterceptor", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
     useAuthStore.setState({
       accessToken: null,
       refreshToken: null,
@@ -52,6 +41,7 @@ describe("addAuthRefreshInterceptor", () => {
 
   describe("Regression Tests — Auth endpoints exclusion", () => {
     it("does not attempt refresh when 401 occurs on /api/v1/auth/google/", async () => {
+      const postSpy = vi.spyOn(Axios, "post");
       const { handlers } = createMockInstance();
       const config = { url: "/api/v1/auth/google/" } as InternalAxiosRequestConfig;
       const error = new AxiosError("Unauthorized", "ERR_BAD_REQUEST", config, undefined, {
@@ -65,10 +55,11 @@ describe("addAuthRefreshInterceptor", () => {
       const result = handlers.responseError?.(error);
       await expect(result).rejects.toBe(error);
 
-      expect(Axios.post).not.toHaveBeenCalled();
+      expect(postSpy).not.toHaveBeenCalled();
     });
 
     it("does not attempt refresh when 401 occurs on /api/v1/auth/token/", async () => {
+      const postSpy = vi.spyOn(Axios, "post");
       const { handlers } = createMockInstance();
       const config = { url: "/api/v1/auth/token/" } as InternalAxiosRequestConfig;
       const error = new AxiosError("Unauthorized", "ERR_BAD_REQUEST", config, undefined, {
@@ -82,10 +73,11 @@ describe("addAuthRefreshInterceptor", () => {
       const result = handlers.responseError?.(error);
       await expect(result).rejects.toBe(error);
 
-      expect(Axios.post).not.toHaveBeenCalled();
+      expect(postSpy).not.toHaveBeenCalled();
     });
 
     it("does not attempt refresh when 401 occurs on /api/v1/auth/register/", async () => {
+      const postSpy = vi.spyOn(Axios, "post");
       const { handlers } = createMockInstance();
       const config = { url: "/api/v1/auth/register/" } as InternalAxiosRequestConfig;
       const error = new AxiosError("Unauthorized", "ERR_BAD_REQUEST", config, undefined, {
@@ -99,12 +91,13 @@ describe("addAuthRefreshInterceptor", () => {
       const result = handlers.responseError?.(error);
       await expect(result).rejects.toBe(error);
 
-      expect(Axios.post).not.toHaveBeenCalled();
+      expect(postSpy).not.toHaveBeenCalled();
     });
   });
 
   describe("Non-401 and Non-Auth handling", () => {
     it("passes non-401 errors through without attempting refresh", async () => {
+      const postSpy = vi.spyOn(Axios, "post");
       const { handlers } = createMockInstance();
       const config = { url: "/api/v1/weddings/" } as InternalAxiosRequestConfig;
       const error = new AxiosError("Not Found", "ERR_BAD_REQUEST", config, undefined, {
@@ -118,7 +111,7 @@ describe("addAuthRefreshInterceptor", () => {
       const result = handlers.responseError?.(error);
       await expect(result).rejects.toBe(error);
 
-      expect(Axios.post).not.toHaveBeenCalled();
+      expect(postSpy).not.toHaveBeenCalled();
     });
 
     it("logs out and rejects normalized error when 401 on protected route and refreshToken is absent", async () => {
@@ -145,11 +138,11 @@ describe("addAuthRefreshInterceptor", () => {
       useAuthStore.setState({
         accessToken: "old-access",
         refreshToken: "valid-refresh",
-        user: { id: "123-uuid", email: "user@test.com", first_name: "Test", last_name: "User" },
+        user: { id: 1, email: "user@test.com", first_name: "Test", last_name: "User" },
         isAuthenticated: true,
       });
 
-      vi.mocked(Axios.post).mockResolvedValueOnce({
+      const postSpy = vi.spyOn(Axios, "post").mockResolvedValueOnce({
         data: { access: "new-access", refresh: "new-refresh" },
       });
 
@@ -169,7 +162,7 @@ describe("addAuthRefreshInterceptor", () => {
 
       const result = await handlers.responseError?.(error);
 
-      expect(Axios.post).toHaveBeenCalledWith(
+      expect(postSpy).toHaveBeenCalledWith(
         "/api/v1/auth/refresh/",
         { refresh: "valid-refresh" },
         expect.objectContaining({ timeout: 5000 }),

--- a/frontend/src/api/interceptors/auth-refresh.ts
+++ b/frontend/src/api/interceptors/auth-refresh.ts
@@ -93,11 +93,11 @@ export function addAuthRefreshInterceptor(instance: AxiosInstance) {
     async (error) => {
       const originalRequest = error.config as InternalAxiosRequestConfig;
 
-      const isLoginRequest = originalRequest.url?.includes("/auth/token/");
+      const isAuthEndpoint = originalRequest.url?.includes("/auth/");
       if (
         error.response?.status !== 401 ||
         originalRequest._retry ||
-        isLoginRequest
+        isAuthEndpoint
       ) {
         return Promise.reject(error);
       }

--- a/frontend/src/api/interceptors/auth-refresh.ts
+++ b/frontend/src/api/interceptors/auth-refresh.ts
@@ -92,8 +92,11 @@ export function addAuthRefreshInterceptor(instance: AxiosInstance) {
     (response) => response,
     async (error) => {
       const originalRequest = error.config as InternalAxiosRequestConfig;
+      if (!originalRequest) {
+        return Promise.reject(error);
+      }
 
-      const isAuthEndpoint = originalRequest.url?.includes("/auth/");
+      const isAuthEndpoint = /\/auth\//.test(originalRequest.url || "");
       if (
         error.response?.status !== 401 ||
         originalRequest._retry ||


### PR DESCRIPTION
## Summary
Fixes an issue where 401 Unauthorized responses from authentication endpoints (e.g. `/api/v1/auth/google/`, `/api/v1/auth/register/`) triggered the Axios response interceptor's token refresh mechanism. When no active `refreshToken` was present in local storage, this threw an unhandled internal exception `Sessão irrecuperável: Refresh token ausente.`, masking the actual API error message on screen.

## Root Cause
In `frontend/src/api/interceptors/auth-refresh.ts`, line 96 checked:
```ts
const isLoginRequest = originalRequest.url?.includes("/auth/token/");
```
Because this check only excluded `/auth/token/`, 401s from other initial authentication endpoints (such as Google OAuth `/auth/google/` or registration `/auth/register/`) were mistakenly treated as expired sessions of an already logged-in user, attempting a token refresh without a valid refresh token.

## Changes Made
- Updated `auth-refresh.ts` to check `const isAuthEndpoint = originalRequest.url?.includes("/auth/");`.
- Excluded all `/auth/*` endpoints from triggering the token refresh interceptor.

## Verification
- Ran frontend typecheck (`pnpm run type-check`).
- Ran frontend lint (`pnpm run lint`).
- Ran full Vitest test suite (`pnpm test`), passing all 974 tests across 144 test files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication error handling by preventing refresh attempts for all authentication-related requests.
  * Preserved existing retry, request queuing, token refresh, and logout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->