### PR TITLE
fix(ci): stop E2E server before cache cleanup

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -48,7 +48,8 @@ jobs:
           SECRET_KEY: dummy-ci-key-for-e2e-tests # pragma: allowlist secret
         run: |
           cd backend
-          uv run uvicorn config.asgi:application --host 127.0.0.1 --port 8000 &
+          setsid uv run uvicorn config.asgi:application --host 127.0.0.1 --port 8000 &
+          echo $! > "$RUNNER_TEMP/uvicorn.pid"
           echo "Waiting for Uvicorn ASGI server..."
           SERVER_READY=0
           for i in {1..30}; do
@@ -68,6 +69,10 @@ jobs:
         run: |
           cd frontend
           VITE_API_URL=http://127.0.0.1:8000 pnpm test:e2e --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+
+      - name: Stop ASGI Server
+        if: always()
+        run: kill -- -"$(cat "$RUNNER_TEMP/uvicorn.pid")" 2>/dev/null || true
 
       - name: Upload Playwright Report
         if: failure()


### PR DESCRIPTION
## Contexto

Após o merge do PR #350, os 19 testes E2E passaram, mas os dois shards falharam no pós-job: o processo iniciado por `uv run uvicorn` permaneceu vivo e bloqueou `uv cache prune` por 5 minutos. Isso impediu o job `Deploy Validated Push`.

## Correção

- inicia o backend E2E em um grupo de processos dedicado;
- encerra esse grupo com `if: always()` antes do pós-cache;
- preserva o cache do uv, os shards e a suíte existentes.

## Validação

- `actionlint`
- `git diff --check`
- pre-commit completo no commit