### PR TITLE
fix(cd): load Vercel branch environment

### DIFF
--- a/.github/workflows/cd-deploy.yml
+++ b/.github/workflows/cd-deploy.yml
@@ -190,13 +190,15 @@ jobs:
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
             echo "type=production" >> "$GITHUB_OUTPUT"
             echo "flag=--prod" >> "$GITHUB_OUTPUT"
+            echo "git_branch_flag=" >> "$GITHUB_OUTPUT"
           else
             echo "type=preview" >> "$GITHUB_OUTPUT"
             echo "flag=" >> "$GITHUB_OUTPUT"
+            echo "git_branch_flag=--git-branch=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Pull Vercel Environment Information
-        run: vercel pull --yes --environment=${{ steps.env.outputs.type }} --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=${{ steps.env.outputs.type }} ${{ steps.env.outputs.git_branch_flag }} --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_FRONTEND }}


### PR DESCRIPTION
## Contexto

O deploy de frontend usa artefatos pré-compilados. Sem `--git-branch`, `vercel pull --environment=preview` ignora variáveis Preview específicas da branch e compilava `develop` com a URL de produção.

## Correção

- informa `--git-branch=develop` nos deploys Preview do frontend;
- mantém produção sem filtro de branch;
- preserva a variável Preview global para outros previews.

A variável `VITE_API_URL` de `develop` já está configurada com o Cloud Run staging saudável.

## Validação

- `actionlint`
- `git diff --check`
- `vercel env ls preview develop`