### PR TITLE
fix(cd): configure Google client ID

### DIFF
--- a/.github/workflows/cd-deploy.yml
+++ b/.github/workflows/cd-deploy.yml
@@ -149,6 +149,7 @@ jobs:
             DJANGO_SETTINGS_MODULE=config.settings.production
             ALLOWED_HOSTS=${{ steps.env.outputs.allowed_hosts }}
             CORS_ALLOWED_ORIGINS=${{ steps.env.outputs.cors_allowed_origins }}
+            GOOGLE_CLIENT_ID=${{ vars.GOOGLE_CLIENT_ID }}
             R2_ACCESS_KEY_ID="${{ secrets.R2_ACCESS_KEY_ID }}"
             R2_SECRET_ACCESS_KEY="${{ secrets.R2_SECRET_ACCESS_KEY }}"
             R2_BUCKET="${{ secrets.R2_BUCKET }}"


### PR DESCRIPTION
## Contexto

O frontend staging já recebe `VITE_GOOGLE_CLIENT_ID`, mas o Cloud Run não recebia `GOOGLE_CLIENT_ID`. O backend valida o audience do token com essa configuração e rejeitaria todo login Google em staging.

## Correção

- cadastra `GOOGLE_CLIENT_ID` como variável nos Environments Preview e Production;
- injeta a variável no Cloud Run via CD;
- usa o mesmo Client ID público já configurado na Vercel.

## Validação

- `actionlint`
- `git diff --check`
- variável confirmada nos dois GitHub Environments