### PR TITLE
fix(cd): keep staging aliases current

### DIFF
--- a/.github/workflows/cd-deploy.yml
+++ b/.github/workflows/cd-deploy.yml
@@ -211,7 +211,12 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_FRONTEND }}
 
       - name: Deploy Artifacts to Vercel
-        run: vercel deploy --prebuilt ${{ steps.env.outputs.flag }} --token=${{ secrets.VERCEL_TOKEN }}
+        run: |
+          deployment_url="$(vercel deploy --prebuilt ${{ steps.env.outputs.flag }} --token=${{ secrets.VERCEL_TOKEN }})"
+          printf '%s\n' "$deployment_url"
+          if [ "${{ github.ref }}" = "refs/heads/develop" ]; then
+            vercel alias set "$deployment_url" wedding-web-app-staging.vercel.app --token=${{ secrets.VERCEL_TOKEN }}
+          fi
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_FRONTEND }}
@@ -264,7 +269,12 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_LANDING }}
 
       - name: Deploy Artifacts to Vercel
-        run: vercel deploy --prebuilt ${{ steps.env.outputs.flag }} --token=${{ secrets.VERCEL_TOKEN }}
+        run: |
+          deployment_url="$(vercel deploy --prebuilt ${{ steps.env.outputs.flag }} --token=${{ secrets.VERCEL_TOKEN }})"
+          printf '%s\n' "$deployment_url"
+          if [ "${{ github.ref }}" = "refs/heads/develop" ]; then
+            vercel alias set "$deployment_url" wedding-landing-staging.vercel.app --token=${{ secrets.VERCEL_TOKEN }}
+          fi
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_LANDING }}


### PR DESCRIPTION
## Contexto

Os deploys Vercel via artefato pré-compilado geram uma URL imutável, mas não atualizam automaticamente um domínio fixo de staging. Assim, os aliases criados manualmente ficariam apontando para uma versão antiga após o próximo merge.

## Correção

Em pushes de `develop`, o CD passa a atualizar automaticamente:

- `wedding-web-app-staging.vercel.app`;
- `wedding-landing-staging.vercel.app`.

Deploys de produção mantêm o comportamento atual de `--prod`.

## Validação

- `actionlint`
- `git diff --check`
- aliases atuais criados e verificados pelo Vercel CLI