### PR TITLE
refactor: enforce strict mypy typing

### DIFF
--- a/.agents/skills/wedding-backend-testing/SKILL.md
+++ b/.agents/skills/wedding-backend-testing/SKILL.md
@@ -15,6 +15,7 @@ Operational checklist for backend test suites (`pytest` + Django).
 - [ ] **Directory & File Layout**: Follow standard placement (`apps/<app>/tests/test_models.py`, `test_services.py`, `test_apis.py`). Include `__init__.py` in nested entity test subdirectories.
 - [ ] **Multi-Tenancy Test Isolation**: Verify that API endpoints return `404 Not Found` (never 403 or raw exceptions) when attempting to access another tenant company's resources.
 - [ ] **Test Naming Convention**: Class `Test<Name>`, method `test_<behavior>_<scenario>_<expected_outcome>`.
+- [ ] **Strict Typing in Tests (`mypy`)**: All test functions and methods must declare explicit return types (`-> None`) and typed fixture parameters (`disallow_untyped_defs = true`, `check_untyped_defs = true`).
 - [ ] **No Empty Stubs or Debug Files**: Do not leave `pass` stubs or debug files with `breakpoint()`/`print()` in test packages; use `@pytest.mark.skip(reason=...)` when skipping tests.
 - [ ] **Execution & Standards Reference**:
   - Running pytest suite & test markers: [Run Pytest Suite Guide](../../../docs/2-how-to/backend/run-pytest-suite.md)

--- a/backend/apps/core/decorators.py
+++ b/backend/apps/core/decorators.py
@@ -3,7 +3,7 @@ from collections.abc import Callable
 from functools import wraps
 from typing import Any
 
-from django.http import HttpRequest, HttpResponse
+from django.http import HttpRequest
 
 from apps.core.exceptions import AuthenticationFailedError, PermissionDeniedError
 from apps.core.services import get_oidc_verifier
@@ -12,7 +12,7 @@ from apps.core.services import get_oidc_verifier
 logger = logging.getLogger(__name__)
 
 
-def require_oidc_auth(view_func: Callable[..., Any]) -> Callable[..., Any]:
+def require_oidc_auth[R](view_func: Callable[..., R]) -> Callable[..., R]:
     """
     Decorator limpo para exigir autenticação OIDC service-to-service (ADR-005).
     Delega a injeção de dependência para get_oidc_verifier().
@@ -20,7 +20,7 @@ def require_oidc_auth(view_func: Callable[..., Any]) -> Callable[..., Any]:
     """
 
     @wraps(view_func)
-    def wrapper(request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
+    def wrapper(request: HttpRequest, *args: Any, **kwargs: Any) -> R:
         auth_header = request.META.get("HTTP_AUTHORIZATION", "")
 
         if not auth_header.startswith("Bearer "):

--- a/backend/apps/core/logging.py
+++ b/backend/apps/core/logging.py
@@ -14,6 +14,6 @@ class RequestIDFilter(logging.Filter):
     assume o valor 'system'.
     """
 
-    def filter(self, record):
+    def filter(self, record: logging.LogRecord) -> bool:
         record.request_id = getattr(_thread_locals, "request_id", "system")
         return True

--- a/backend/apps/core/management/commands/seed_db.py
+++ b/backend/apps/core/management/commands/seed_db.py
@@ -72,7 +72,9 @@ class Command(BaseCommand):
         )
 
         if (
-            not AdminFactory._get_manager(AdminFactory._meta.model)
+            not AdminFactory._get_manager(  # type: ignore[no-untyped-call]
+                AdminFactory._meta.model
+            )
             .filter(is_superuser=True)
             .exists()
         ):

--- a/backend/apps/core/management/commands/seed_e2e.py
+++ b/backend/apps/core/management/commands/seed_e2e.py
@@ -13,6 +13,7 @@ Uso:
 
 from datetime import date, timedelta
 from decimal import Decimal
+from typing import Any
 
 from django.contrib.auth import get_user_model
 from django.core.files.base import ContentFile
@@ -46,7 +47,7 @@ class Command(BaseCommand):
     help = "Popula o banco com dados mínimos e determinísticos para a suíte E2E"
 
     @transaction.atomic
-    def handle(self, *args, **kwargs) -> None:
+    def handle(self, *args: Any, **kwargs: Any) -> None:
         """Executa a rotina de criação determinística de dados para E2E.
 
         Args:

--- a/backend/apps/core/models.py
+++ b/backend/apps/core/models.py
@@ -1,4 +1,4 @@
-from typing import Any, Self
+from typing import Any, Self, cast
 from uuid import UUID, uuid4
 
 from django.db import models
@@ -32,4 +32,4 @@ class BaseModel(models.Model):
     @classmethod
     def get_by_uuid(cls, uuid_value: UUID | str) -> Self | None:
         """Busca rápida por identificador público."""
-        return cls.objects.filter(uuid=uuid_value).first()  # type: ignore[attr-defined]
+        return cast(Self | None, cls.objects.filter(uuid=uuid_value).first())  # type: ignore[attr-defined]

--- a/backend/apps/core/services/oidc/base.py
+++ b/backend/apps/core/services/oidc/base.py
@@ -1,4 +1,12 @@
-from typing import Any, Protocol
+from typing import Protocol, TypedDict
+
+
+class OIDCClaims(TypedDict, total=False):
+    """Claims usadas pelo fluxo OIDC de autenticação entre serviços."""
+
+    iss: str
+    aud: str
+    email: str
 
 
 class OIDCVerifier(Protocol):
@@ -6,7 +14,7 @@ class OIDCVerifier(Protocol):
     Protocolo definindo a interface para serviços de verificação OIDC (ADR-005).
     """
 
-    def verify_token(self, token: str) -> dict[str, Any]:
+    def verify_token(self, token: str) -> OIDCClaims:
         """
         Valida o token OIDC e retorna as claims contidas no token.
 

--- a/backend/apps/core/services/oidc/gcp.py
+++ b/backend/apps/core/services/oidc/gcp.py
@@ -1,9 +1,11 @@
 import logging
-from typing import Any
+from typing import cast
 
 from django.conf import settings
 from google.auth.transport import requests as google_requests
 from google.oauth2 import id_token
+
+from .base import OIDCClaims
 
 
 logger = logging.getLogger(__name__)
@@ -24,7 +26,7 @@ class GCPOIDCVerifier:
             settings, "SCHEDULER_SERVICE_ACCOUNT", None
         )
 
-    def verify_token(self, token: str) -> dict[str, Any]:
+    def verify_token(self, token: str) -> OIDCClaims:
         """
         Valida o token OIDC criptograficamente contra o emissor Google.
 
@@ -37,10 +39,13 @@ class GCPOIDCVerifier:
         Raises:
             PermissionError: Se a service account não for autorizada.
         """
-        claim = id_token.verify_oauth2_token(
-            token,
-            google_requests.Request(),
-            audience=self.audience,
+        claim = cast(
+            OIDCClaims,
+            id_token.verify_oauth2_token(  # type: ignore[no-untyped-call]
+                token,
+                google_requests.Request(),
+                audience=self.audience,
+            ),
         )
 
         if (

--- a/backend/apps/core/services/oidc/mock.py
+++ b/backend/apps/core/services/oidc/mock.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Any
+
+from .base import OIDCClaims
 
 
 logger = logging.getLogger(__name__)
@@ -10,7 +11,7 @@ class MockOIDCVerifier:
     Implementação mock do OIDCVerifier para Dev e Testes (Pytest).
     """
 
-    def verify_token(self, token: str) -> dict[str, Any]:
+    def verify_token(self, token: str) -> OIDCClaims:
         """
         Retorna claims simuladas para ambiente de testes e desenvolvimento.
 

--- a/backend/apps/core/services/social_auth/base.py
+++ b/backend/apps/core/services/social_auth/base.py
@@ -1,5 +1,15 @@
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Protocol, TypedDict
+
+
+class GoogleIDTokenClaims(TypedDict, total=False):
+    """Claims consumidas após a validação do ID token do Google."""
+
+    email: str
+    email_verified: bool
+    given_name: str
+    family_name: str
+    sub: str
 
 
 @dataclass(frozen=True)

--- a/backend/apps/core/services/social_auth/google_provider.py
+++ b/backend/apps/core/services/social_auth/google_provider.py
@@ -1,12 +1,12 @@
 import logging
-from typing import Any
+from typing import cast
 
 from django.conf import settings
 from google.auth.transport import requests
 from google.oauth2 import id_token as google_id_token
 from ninja.errors import HttpError
 
-from .base import OAuthUserInfo
+from .base import GoogleIDTokenClaims, OAuthUserInfo
 
 
 logger = logging.getLogger(__name__)
@@ -39,10 +39,13 @@ class GoogleOAuthProvider:
             raise HttpError(401, "Configuração do Google OAuth ausente no servidor.")
 
         try:
-            id_info: dict[str, Any] = google_id_token.verify_oauth2_token(
-                token,
-                requests.Request(),
-                client_id,
+            id_info = cast(
+                GoogleIDTokenClaims,
+                google_id_token.verify_oauth2_token(  # type: ignore[no-untyped-call]
+                    token,
+                    requests.Request(),
+                    client_id,
+                ),
             )
         except Exception as e:
             logger.warning(f"Falha ao validar token do Google: {e}")

--- a/backend/apps/core/tests/base.py
+++ b/backend/apps/core/tests/base.py
@@ -31,7 +31,7 @@ class BaseTenantIsolationTest:
     """
 
     model_class: ClassVar[type[models.Model] | None] = None
-    factory_class: ClassVar[type[factory.django.DjangoModelFactory] | None] = None
+    factory_class: ClassVar[type[factory.django.DjangoModelFactory[Any]] | None] = None
 
     def create_company(self) -> Company:
         """
@@ -44,7 +44,7 @@ class BaseTenantIsolationTest:
 
     def create_factory_instance(
         self,
-        factory_cls: type[factory.django.DjangoModelFactory],
+        factory_cls: type[factory.django.DjangoModelFactory[Any]],
         company: Company,
         **kwargs: Any,
     ) -> models.Model:
@@ -100,7 +100,7 @@ class BaseTenantIsolationTest:
     def assert_for_tenant_isolation(
         self,
         model_cls: type[models.Model],
-        factory_cls: type[factory.django.DjangoModelFactory],
+        factory_cls: type[factory.django.DjangoModelFactory[Any]],
     ) -> None:
         """
         Valida que Model.objects.for_tenant(company) filtra rigorosamente por tenant.
@@ -138,7 +138,7 @@ class BaseTenantIsolationTest:
     def assert_get_object_or_404_for_tenant_isolation(
         self,
         model_cls: type[models.Model],
-        factory_cls: type[factory.django.DjangoModelFactory],
+        factory_cls: type[factory.django.DjangoModelFactory[Any]],
     ) -> None:
         """
         Valida que get_object_or_404_for_tenant nega acesso cross-tenant com 404.
@@ -168,7 +168,7 @@ class BaseTenantIsolationTest:
     def assert_resolve_tenant_resource_isolation(
         self,
         model_cls: type[models.Model],
-        factory_cls: type[factory.django.DjangoModelFactory],
+        factory_cls: type[factory.django.DjangoModelFactory[Any]],
     ) -> None:
         """
         Valida que resolve_tenant_resource bloqueia acessos cross-tenant.
@@ -203,7 +203,7 @@ class BaseTenantIsolationTest:
     def assert_tenant_isolation(
         self,
         model_cls: type[models.Model],
-        factory_cls: type[factory.django.DjangoModelFactory],
+        factory_cls: type[factory.django.DjangoModelFactory[Any]],
     ) -> None:
         """
         Executa a suíte completa de testes de isolamento multi-tenant para um modelo.

--- a/backend/apps/core/tests/test_commands.py
+++ b/backend/apps/core/tests/test_commands.py
@@ -18,18 +18,18 @@ from apps.weddings.models import Wedding
 
 @pytest.mark.django_db
 class TestSeedDbCommand:
-    def test_seed_db_creates_superuser(self):
+    def test_seed_db_creates_superuser(self) -> None:
         call_command("seed_db", planners=0, weddings=0)
 
         assert User.objects.filter(is_superuser=True).exists()
 
-    def test_seed_db_creates_planners(self):
+    def test_seed_db_creates_planners(self) -> None:
         call_command("seed_db", planners=3, weddings=0)
 
         planners = User.objects.filter(is_superuser=False, is_staff=False)
         assert planners.count() == 4  # 3 batch + 1 E2E
 
-    def test_seed_db_creates_weddings_with_mixed_statuses(self):
+    def test_seed_db_creates_weddings_with_mixed_statuses(self) -> None:
         call_command("seed_db", planners=1, weddings=3)
 
         weddings = Wedding.objects.order_by("-created_at")[:3]
@@ -40,7 +40,9 @@ class TestSeedDbCommand:
         assert Wedding.StatusChoices.IN_PROGRESS in statuses
 
     @pytest.mark.parametrize("num_weddings", [1, 3])
-    def test_seed_db_creates_critical_wedding_for_each_planner(self, num_weddings):
+    def test_seed_db_creates_critical_wedding_for_each_planner(
+        self, num_weddings: int
+    ) -> None:
         call_command("seed_db", planners=1, weddings=num_weddings)
 
         planners = User.objects.filter(is_superuser=False, is_staff=False)
@@ -56,7 +58,7 @@ class TestSeedDbCommand:
             assert wedding is not None
             assert date.today() <= wedding.date <= date.today() + timedelta(days=90)
 
-    def test_seed_db_creates_suppliers_with_tenant_context(self):
+    def test_seed_db_creates_suppliers_with_tenant_context(self) -> None:
         call_command("seed_db", planners=1, weddings=1)
 
         wedding = Wedding.objects.order_by("-created_at").first()
@@ -65,7 +67,7 @@ class TestSeedDbCommand:
         suppliers = Supplier.objects.filter(company=wedding.company)
         assert suppliers.count() == 5
 
-    def test_seed_db_creates_contracts_with_mixed_statuses(self):
+    def test_seed_db_creates_contracts_with_mixed_statuses(self) -> None:
         call_command("seed_db", planners=1, weddings=1)
 
         wedding = Wedding.objects.order_by("-created_at").first()
@@ -77,7 +79,7 @@ class TestSeedDbCommand:
         assert Contract.StatusChoices.SIGNED in statuses
         assert Contract.StatusChoices.DRAFT in statuses
 
-    def test_seed_db_creates_items_for_contracts(self):
+    def test_seed_db_creates_items_for_contracts(self) -> None:
         call_command("seed_db", planners=1, weddings=1)
 
         wedding = Wedding.objects.order_by("-created_at").first()
@@ -85,7 +87,7 @@ class TestSeedDbCommand:
 
         assert items.count() == 6
 
-    def test_seed_db_creates_expenses_linked_to_contracts(self):
+    def test_seed_db_creates_expenses_linked_to_contracts(self) -> None:
         call_command("seed_db", planners=1, weddings=1)
 
         wedding = Wedding.objects.order_by("-created_at").first()
@@ -95,7 +97,7 @@ class TestSeedDbCommand:
         for expense in expenses:
             assert expense.contract is not None
 
-    def test_seed_db_creates_installments_with_mixed_statuses(self):
+    def test_seed_db_creates_installments_with_mixed_statuses(self) -> None:
         call_command("seed_db", planners=1, weddings=1)
 
         wedding = Wedding.objects.order_by("-created_at").first()
@@ -108,7 +110,7 @@ class TestSeedDbCommand:
         assert Installment.StatusChoices.PENDING in statuses
         assert Installment.StatusChoices.OVERDUE in statuses
 
-    def test_seed_db_creates_budget_and_categories(self):
+    def test_seed_db_creates_budget_and_categories(self) -> None:
         call_command("seed_db", planners=1, weddings=1)
 
         wedding = Wedding.objects.order_by("-created_at").first()
@@ -118,7 +120,7 @@ class TestSeedDbCommand:
         assert budgets.count() == 1
         assert categories.count() == 3
 
-    def test_seed_db_creates_tasks_with_mixed_completion(self):
+    def test_seed_db_creates_tasks_with_mixed_completion(self) -> None:
         call_command("seed_db", planners=1, weddings=1)
 
         wedding = Wedding.objects.order_by("-created_at").first()
@@ -128,7 +130,7 @@ class TestSeedDbCommand:
         assert tasks.filter(is_completed=True).count() == 3
         assert tasks.filter(is_completed=False).count() == 2
 
-    def test_seed_db_creates_calendar_events(self):
+    def test_seed_db_creates_calendar_events(self) -> None:
         call_command("seed_db", planners=1, weddings=1)
 
         wedding = Wedding.objects.order_by("-created_at").first()
@@ -136,13 +138,13 @@ class TestSeedDbCommand:
 
         assert events.count() == 4
 
-    def test_seed_db_generates_no_errors_on_default_run(self):
+    def test_seed_db_generates_no_errors_on_default_run(self) -> None:
         call_command("seed_db")
 
         assert Wedding.objects.count() > 0
         assert User.objects.filter(is_superuser=True).exists()
 
-    def test_seed_db_creates_e2e_planner(self):
+    def test_seed_db_creates_e2e_planner(self) -> None:
         call_command("seed_db", planners=0, weddings=0)
 
         e2e = User.objects.filter(email="planner@example.com").first()
@@ -151,7 +153,7 @@ class TestSeedDbCommand:
         assert e2e.is_staff is False
         assert e2e.is_superuser is False
 
-    def test_seed_db_is_idempotent(self):
+    def test_seed_db_is_idempotent(self) -> None:
         call_command("seed_db", planners=1, weddings=1)
         call_command("seed_db", planners=1, weddings=1)
 
@@ -164,7 +166,7 @@ class TestSeedDbCommand:
 
 @pytest.mark.django_db
 class TestSeedE2ECommand:
-    def test_seed_e2e_creates_expected_entities(self):
+    def test_seed_e2e_creates_expected_entities(self) -> None:
         call_command("seed_e2e")
 
         assert User.objects.filter(email="admin@admin.com", is_superuser=True).exists()
@@ -200,7 +202,7 @@ class TestSeedE2ECommand:
         tasks = Task.objects.filter(wedding=active_wedding)
         assert tasks.filter(is_completed=False).count() == 2
 
-    def test_seed_e2e_is_idempotent(self):
+    def test_seed_e2e_is_idempotent(self) -> None:
         call_command("seed_e2e")
         call_command("seed_e2e")
 

--- a/backend/apps/core/tests/test_exceptions.py
+++ b/backend/apps/core/tests/test_exceptions.py
@@ -18,7 +18,7 @@ from apps.core.exceptions import (
 class TestExceptionHierarchy:
     """Testes para a hierarquia de exceções da aplicação."""
 
-    def test_application_error_base_class(self):
+    def test_application_error_base_class(self) -> None:
         """Teste CRÍTICO: ApplicationError é a classe base para todas."""
         # Testar instanciação básica
         error = ApplicationError()
@@ -33,7 +33,7 @@ class TestExceptionHierarchy:
         assert custom_error.code == "custom_code"
         assert str(custom_error) == "Erro personalizado"
 
-    def test_object_not_found_error(self):
+    def test_object_not_found_error(self) -> None:
         """Teste CRÍTICO: ObjectNotFoundError mapeia para 404."""
         error = ObjectNotFoundError()
         assert error.status_code == 404
@@ -46,7 +46,7 @@ class TestExceptionHierarchy:
         assert custom_error.detail == "Usuário não encontrado"
         assert custom_error.status_code == 404  # Sempre 404
 
-    def test_business_rule_violation(self):
+    def test_business_rule_violation(self) -> None:
         """Teste CRÍTICO: BusinessRuleViolation mapeia para 422."""
         error = BusinessRuleViolation()
         assert error.status_code == 422
@@ -59,7 +59,7 @@ class TestExceptionHierarchy:
         assert custom_error.detail == "Data não pode ser no passado"
         assert custom_error.status_code == 422
 
-    def test_domain_integrity_error(self):
+    def test_domain_integrity_error(self) -> None:
         """Teste CRÍTICO: DomainIntegrityError mapeia para 409."""
         error = DomainIntegrityError()
         assert error.status_code == 409
@@ -72,7 +72,7 @@ class TestExceptionHierarchy:
         assert custom_error.detail == "Conflito de dados detectado"
         assert custom_error.status_code == 409
 
-    def test_exception_hierarchy_inheritance(self):
+    def test_exception_hierarchy_inheritance(self) -> None:
         """Teste CRÍTICO: Verificar herança correta da hierarquia."""
         # Todas as exceções específicas herdam de ApplicationError
         assert issubclass(ObjectNotFoundError, ApplicationError)
@@ -84,7 +84,7 @@ class TestExceptionHierarchy:
         assert not issubclass(BusinessRuleViolation, DomainIntegrityError)
         assert not issubclass(DomainIntegrityError, ObjectNotFoundError)
 
-    def test_exception_http_status_mapping(self):
+    def test_exception_http_status_mapping(self) -> None:
         """Teste CRÍTICO: Mapeamento correto de status HTTP."""
         # Este teste garante que os códigos HTTP estão corretos para a API
         errors = [
@@ -102,7 +102,7 @@ class TestExceptionHierarchy:
                 f"mas retornou {error.status_code}"
             )
 
-    def test_exception_serialization_consistency(self):
+    def test_exception_serialization_consistency(self) -> None:
         """Teste CRÍTICO: Exceções serializam consistentemente para APIs."""
         # Testar que todas as exceções podem ser serializadas de forma consistente
         test_cases = [
@@ -129,7 +129,7 @@ class TestExceptionHierarchy:
 class TestExceptionIntegration:
     """Testes de integração para verificar exceções em contexto real."""
 
-    def test_service_raises_correct_exception_types(self):
+    def test_service_raises_correct_exception_types(self) -> None:
         """Serviços lançam tipos corretos de exceção com atributos esperados."""
         errors = [
             (ObjectNotFoundError, "Recurso não encontrado", 404),

--- a/backend/apps/core/tests/test_health.py
+++ b/backend/apps/core/tests/test_health.py
@@ -4,14 +4,14 @@ from django.test import Client
 
 @pytest.mark.django_db
 class TestHealthCheck:
-    def test_health_check_healthy(self, client: Client):
+    def test_health_check_healthy(self, client: Client) -> None:
         response = client.get("/api/v1/health")
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "healthy"
         assert data["database"] == "up"
 
-    def test_health_check_requires_no_auth(self, client: Client):
+    def test_health_check_requires_no_auth(self, client: Client) -> None:
         response = client.get("/api/v1/health")
         assert response.status_code != 401
         assert response.status_code != 403

--- a/backend/apps/core/tests/test_middleware.py
+++ b/backend/apps/core/tests/test_middleware.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import patch
 
 from django.http import HttpRequest, HttpResponse
@@ -6,7 +7,7 @@ from apps.core.middleware import RequestIDMiddleware
 
 
 class TestRequestIDMiddleware:
-    def test_generates_request_id_when_none_provided(self):
+    def test_generates_request_id_when_none_provided(self) -> None:
         def get_response(request: HttpRequest) -> HttpResponse:
             return HttpResponse("ok")
 
@@ -19,28 +20,26 @@ class TestRequestIDMiddleware:
         assert "X-Request-ID" in response
         assert response["X-Request-ID"]
 
-    def test_uses_provided_request_id_header(self):
+    def test_uses_provided_request_id_header(self) -> None:
         def get_response(request: HttpRequest) -> HttpResponse:
             return HttpResponse("ok")
 
         middleware = RequestIDMiddleware(get_response)
         request = HttpRequest()
-        request.META = {}
-        request.headers = {"X-Request-ID": "custom-id-123"}
+        request.META = {"HTTP_X_REQUEST_ID": "custom-id-123"}
 
         response = middleware(request)
 
         assert response["X-Request-ID"] == "custom-id-123"
 
     @patch("apps.core.middleware.sentry_sdk.set_context")
-    def test_sets_sentry_context_with_request_id(self, mock_set_context):
+    def test_sets_sentry_context_with_request_id(self, mock_set_context: Any) -> None:
         def get_response(request: HttpRequest) -> HttpResponse:
             return HttpResponse("ok")
 
         middleware = RequestIDMiddleware(get_response)
         request = HttpRequest()
-        request.META = {}
-        request.headers = {"X-Request-ID": "test-id-456"}
+        request.META = {"HTTP_X_REQUEST_ID": "test-id-456"}
 
         middleware(request)
 
@@ -49,7 +48,7 @@ class TestRequestIDMiddleware:
         )
 
     @patch("apps.core.middleware.sentry_sdk.set_context")
-    def test_sets_sentry_context_with_generated_id(self, mock_set_context):
+    def test_sets_sentry_context_with_generated_id(self, mock_set_context: Any) -> None:
         def get_response(request: HttpRequest) -> HttpResponse:
             return HttpResponse("ok")
 

--- a/backend/apps/core/tests/test_mixins.py
+++ b/backend/apps/core/tests/test_mixins.py
@@ -5,14 +5,26 @@ O clean() do mixin impede vazamento de dados entre tenants e entre
 casamentos, garantindo isolamento multitenant completo.
 """
 
+from typing import Any, cast
+
 import pytest
 from django.core.exceptions import ValidationError
 from django.db import models
 
 from apps.core.mixins import WeddingOwnedMixin
 from apps.core.models import BaseModel
-from apps.core.tests.factories import WeddingFactory
-from apps.tenants.tests.factories import CompanyFactory
+from apps.core.tests.factories import WeddingFactory as _WeddingFactory
+from apps.tenants.models import Company
+from apps.tenants.tests.factories import CompanyFactory as _CompanyFactory
+from apps.weddings.models import Wedding
+
+
+def CompanyFactory(*args: Any, **kwargs: Any) -> Company:
+    return cast(Company, _CompanyFactory(*args, **kwargs))
+
+
+def WeddingFactory(*args: Any, **kwargs: Any) -> Wedding:
+    return cast(Wedding, _WeddingFactory(*args, **kwargs))
 
 
 class WeddingOwnedStub(BaseModel, WeddingOwnedMixin):
@@ -34,14 +46,14 @@ class WeddingOwnedStub(BaseModel, WeddingOwnedMixin):
 class TestWeddingOwnedMixinCrossTenant:
     """Blindagem vertical: impede que um recurso use casamento de outra empresa."""
 
-    def test_same_company_passes(self):
+    def test_same_company_passes(self) -> None:
         company = CompanyFactory()
         wedding = WeddingFactory(company=company)
 
         stub = WeddingOwnedStub(name="válido", company=company, wedding=wedding)
         stub.full_clean()
 
-    def test_different_company_raises_validation_error(self):
+    def test_different_company_raises_validation_error(self) -> None:
         company_a = CompanyFactory()
         company_b = CompanyFactory()
         wedding_b = WeddingFactory(company=company_b)
@@ -54,7 +66,7 @@ class TestWeddingOwnedMixinCrossTenant:
         assert "wedding" in exc_info.value.message_dict
         assert "outra organização" in str(exc_info.value)
 
-    def test_save_triggers_clean(self):
+    def test_save_triggers_clean(self) -> None:
         company_a = CompanyFactory()
         company_b = CompanyFactory()
         wedding_b = WeddingFactory(company=company_b)
@@ -69,7 +81,7 @@ class TestWeddingOwnedMixinCrossTenant:
 class TestWeddingOwnedMixinCrossWedding:
     """Consistência horizontal: FK de um recurso deve apontar para o mesmo casamento."""
 
-    def test_same_wedding_fk_passes(self):
+    def test_same_wedding_fk_passes(self) -> None:
         company = CompanyFactory()
         wedding = WeddingFactory(company=company)
 
@@ -81,7 +93,7 @@ class TestWeddingOwnedMixinCrossWedding:
         stub1.related_item = stub2
         stub1.full_clean()
 
-    def test_different_wedding_fk_raises_validation_error(self):
+    def test_different_wedding_fk_raises_validation_error(self) -> None:
         company = CompanyFactory()
         wedding_a = WeddingFactory(company=company)
         wedding_b = WeddingFactory(company=company)
@@ -102,7 +114,7 @@ class TestWeddingOwnedMixinCrossWedding:
 
 @pytest.mark.django_db
 class TestWeddingOwnedMixinEdgeCases:
-    def test_related_obj_none_skips_cross_wedding_check(self):
+    def test_related_obj_none_skips_cross_wedding_check(self) -> None:
         """FK nula (related_item=None) não dispara validação horizontal."""
         company = CompanyFactory()
         wedding = WeddingFactory(company=company)
@@ -113,7 +125,7 @@ class TestWeddingOwnedMixinEdgeCases:
 
         stub.full_clean()
 
-    def test_vertical_guard_fires_before_horizontal(self):
+    def test_vertical_guard_fires_before_horizontal(self) -> None:
         """Erro cross-tenant é detectado antes da validação cross-wedding."""
         company = CompanyFactory()
         company_b = CompanyFactory()
@@ -131,7 +143,7 @@ class TestWeddingOwnedMixinEdgeCases:
 
 @pytest.mark.django_db
 class TestWeddingOwnedMixinPerformance:
-    def test_null_fk_does_not_cause_extra_query(self):
+    def test_null_fk_does_not_cause_extra_query(self) -> None:
         """FK nula não dispara query extra durante full_clean()."""
         company = CompanyFactory()
         wedding = WeddingFactory(company=company)
@@ -142,7 +154,7 @@ class TestWeddingOwnedMixinPerformance:
 
         stub.full_clean()
 
-    def test_cross_wedding_fk_still_detected(self):
+    def test_cross_wedding_fk_still_detected(self) -> None:
         """FK não-nula com wedding diferente ainda é detectada e rejeitada."""
         company = CompanyFactory()
         wedding_a = WeddingFactory(company=company)

--- a/backend/apps/core/tests/test_storage_service.py
+++ b/backend/apps/core/tests/test_storage_service.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -13,7 +14,9 @@ class TestCloudflareR2StorageService:
     """Testes unitários isolados do CloudflareR2StorageService."""
 
     @patch("boto3.client")
-    def test_generate_presigned_put_url_success(self, mock_boto3_client, settings):
+    def test_generate_presigned_put_url_success(
+        self, mock_boto3_client: Any, settings: Any
+    ) -> None:
         settings.R2_ENDPOINT_URL = "https://r2-endpoint.com"
         settings.R2_ACCESS_KEY_ID = "test-key-id"
         settings.R2_SECRET_ACCESS_KEY = "test-secret-key"
@@ -49,7 +52,9 @@ class TestCloudflareR2StorageService:
             ExpiresIn=900,
         )
 
-    def test_generate_presigned_put_url_configuration_incomplete(self, settings):
+    def test_generate_presigned_put_url_configuration_incomplete(
+        self, settings: Any
+    ) -> None:
         settings.R2_ENDPOINT_URL = ""
         settings.AWS_S3_ENDPOINT_URL = ""
 
@@ -66,12 +71,12 @@ class TestCloudflareR2StorageService:
 class TestGetStorageService:
     """Testes da factory function get_storage_service."""
 
-    def test_get_storage_service_r2_success(self, settings):
+    def test_get_storage_service_r2_success(self, settings: Any) -> None:
         settings.STORAGE_PROVIDER = "R2"
         service = get_storage_service()
         assert isinstance(service, CloudflareR2StorageService)
 
-    def test_get_storage_service_unsupported_raises_error(self, settings):
+    def test_get_storage_service_unsupported_raises_error(self, settings: Any) -> None:
         settings.STORAGE_PROVIDER = "GCS"
         with pytest.raises(BusinessRuleViolation) as exc_info:
             get_storage_service()

--- a/backend/apps/core/tests/test_tenant_isolation.py
+++ b/backend/apps/core/tests/test_tenant_isolation.py
@@ -10,6 +10,8 @@ Destaques Técnicos:
 - Cobre modelos de weddings, finances, logistics e scheduler.
 """
 
+from typing import Any
+
 import factory
 import pytest
 from django.db import models
@@ -62,7 +64,7 @@ class TestTenantIsolation(BaseTenantIsolationTest):
     def test_model_tenant_isolation(
         self,
         model_cls: type[models.Model],
-        factory_cls: type[factory.django.DjangoModelFactory],
+        factory_cls: type[factory.django.DjangoModelFactory[Any]],
     ) -> None:
         """
         Executa os testes de isolamento de tenant para o modelo e fábrica especificados.

--- a/backend/apps/core/tests/test_validators.py
+++ b/backend/apps/core/tests/test_validators.py
@@ -7,21 +7,21 @@ from apps.core.validators import MaxFileSizeValidator
 
 
 class TestMaxFileSizeValidator:
-    def test_valid_file_under_limit_passes(self):
+    def test_valid_file_under_limit_passes(self) -> None:
         validator = MaxFileSizeValidator(max_size=10 * 1024 * 1024)
         file_mock = MagicMock()
         file_mock.size = 5 * 1024 * 1024
 
         validator(file_mock)
 
-    def test_file_exactly_at_limit_passes(self):
+    def test_file_exactly_at_limit_passes(self) -> None:
         validator = MaxFileSizeValidator(max_size=10 * 1024 * 1024)
         file_mock = MagicMock()
         file_mock.size = 10 * 1024 * 1024
 
         validator(file_mock)
 
-    def test_file_over_limit_raises_validation_error(self):
+    def test_file_over_limit_raises_validation_error(self) -> None:
         validator = MaxFileSizeValidator(max_size=10 * 1024 * 1024)
         file_mock = MagicMock()
         file_mock.size = 15 * 1024 * 1024
@@ -32,21 +32,21 @@ class TestMaxFileSizeValidator:
         assert exc_info.value.code == "max_file_size"
         assert "10MB" in str(exc_info.value)
 
-    def test_size_none_bypasses_validation(self):
+    def test_size_none_bypasses_validation(self) -> None:
         validator = MaxFileSizeValidator(max_size=10 * 1024 * 1024)
         file_mock = MagicMock()
         file_mock.size = None
 
         validator(file_mock)
 
-    def test_oserror_bypasses_validation(self):
+    def test_oserror_bypasses_validation(self) -> None:
         validator = MaxFileSizeValidator(max_size=10 * 1024 * 1024)
         file_mock = MagicMock()
         type(file_mock).size = PropertyMock(side_effect=OSError("storage offline"))
 
         validator(file_mock)
 
-    def test_filenotfounderror_bypasses_validation(self):
+    def test_filenotfounderror_bypasses_validation(self) -> None:
         validator = MaxFileSizeValidator(max_size=10 * 1024 * 1024)
         file_mock = MagicMock()
         type(file_mock).size = PropertyMock(
@@ -55,24 +55,24 @@ class TestMaxFileSizeValidator:
 
         validator(file_mock)
 
-    def test_equality_same_max_size(self):
+    def test_equality_same_max_size(self) -> None:
         v1 = MaxFileSizeValidator(max_size=10 * 1024 * 1024)
         v2 = MaxFileSizeValidator(max_size=10 * 1024 * 1024)
 
         assert v1 == v2
 
-    def test_equality_different_max_size(self):
+    def test_equality_different_max_size(self) -> None:
         v1 = MaxFileSizeValidator(max_size=10 * 1024 * 1024)
         v2 = MaxFileSizeValidator(max_size=5 * 1024 * 1024)
 
         assert v1 != v2
 
-    def test_equality_different_type(self):
+    def test_equality_different_type(self) -> None:
         v1 = MaxFileSizeValidator(max_size=10 * 1024 * 1024)
 
         assert v1 != "not a validator"
 
-    def test_deconstruct_returns_path_args_kwargs(self):
+    def test_deconstruct_returns_path_args_kwargs(self) -> None:
         validator = MaxFileSizeValidator(max_size=10 * 1024 * 1024)
 
         path, args, kwargs = validator.deconstruct()

--- a/backend/apps/core/validators.py
+++ b/backend/apps/core/validators.py
@@ -1,4 +1,12 @@
+from typing import Protocol
+
 from django.core.exceptions import ValidationError
+
+
+class _FileLike(Protocol):
+    """Arquivo com atributo ``size`` (ex.: ``UploadedFile`` do Django)."""
+
+    size: int | None
 
 
 class MaxFileSizeValidator:
@@ -13,7 +21,7 @@ class MaxFileSizeValidator:
     def __init__(self, max_size: int) -> None:
         self.max_size = max_size
 
-    def __call__(self, value) -> None:
+    def __call__(self, value: _FileLike) -> None:
         try:
             size = value.size
         except OSError:
@@ -31,8 +39,8 @@ class MaxFileSizeValidator:
             return self.max_size == other.max_size
         return False
 
-    def deconstruct(self) -> tuple:
+    def deconstruct(self) -> tuple[str, tuple[int], dict[str, int]]:
         path = "apps.core.validators.MaxFileSizeValidator"
         args = (self.max_size,)
-        kwargs: dict = {}
+        kwargs: dict[str, int] = {}
         return path, args, kwargs

--- a/backend/apps/finances/admin.py
+++ b/backend/apps/finances/admin.py
@@ -4,14 +4,14 @@ from django.contrib import admin
 from .models import Budget, BudgetCategory, Expense, Installment
 
 
-class BudgetCategoryInline(admin.TabularInline):
+class BudgetCategoryInline(admin.TabularInline):  # type: ignore[type-arg]
     model = BudgetCategory
     extra = 1
     fields = ["name", "allocated_budget", "description"]
     show_change_link = True
 
 
-class ExpenseInline(admin.TabularInline):
+class ExpenseInline(admin.TabularInline):  # type: ignore[type-arg]
     # AJUSTE: Removido estimated_amount se ele não existir mais no model
     model = Expense
     extra = 0
@@ -20,7 +20,7 @@ class ExpenseInline(admin.TabularInline):
 
 
 @admin.register(Budget)
-class BudgetAdmin(admin.ModelAdmin):
+class BudgetAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
     # AJUSTE: search_fields corrigido para o novo modelo de Wedding
     list_display = ["wedding", "created_at"]
     list_filter = ["created_at"]
@@ -33,7 +33,7 @@ class BudgetAdmin(admin.ModelAdmin):
 
 
 @admin.register(BudgetCategory)
-class BudgetCategoryAdmin(admin.ModelAdmin):
+class BudgetCategoryAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
     list_display = ["name", "budget", "allocated_budget"]
     list_filter = ["budget", "created_at"]
     # AJUSTE: search_fields corrigido
@@ -49,14 +49,14 @@ class BudgetCategoryAdmin(admin.ModelAdmin):
         return False
 
 
-class InstallmentInline(admin.TabularInline):
+class InstallmentInline(admin.TabularInline):  # type: ignore[type-arg]
     model = Installment
     extra = 1
     fields = ["installment_number", "due_date", "amount", "paid_date", "status"]
 
 
 @admin.register(Expense)
-class ExpenseAdmin(admin.ModelAdmin):
+class ExpenseAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
     list_display = [
         "description",
         "category",
@@ -79,7 +79,7 @@ class ExpenseAdmin(admin.ModelAdmin):
 
 
 @admin.register(Installment)
-class InstallmentAdmin(admin.ModelAdmin):
+class InstallmentAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
     list_display = ["expense", "installment_number", "due_date", "amount", "status"]
     list_filter = ["status", "due_date"]
     search_fields = ["expense__description"]

--- a/backend/apps/finances/managers.py
+++ b/backend/apps/finances/managers.py
@@ -5,6 +5,7 @@ QuerySet e Manager customizados para o domínio financeiro.
 from __future__ import annotations
 
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
 from django.db.models import Count, Q, Sum
 from django.db.models.functions import Coalesce
@@ -13,7 +14,14 @@ from apps.finances.models.installment import Installment
 from apps.tenants.managers import TenantManager, TenantQuerySet
 
 
-class BudgetQuerySet(TenantQuerySet):
+if TYPE_CHECKING:
+    from apps.finances.models.budget import Budget  # noqa: F401
+    from apps.finances.models.budget_category import BudgetCategory  # noqa: F401
+    from apps.finances.models.expense import Expense  # noqa: F401
+    from apps.tenants.models import Company
+
+
+class BudgetQuerySet(TenantQuerySet["Budget"]):
     """QuerySet customizado para Budget."""
 
     def with_total_spent(self) -> BudgetQuerySet:
@@ -31,18 +39,21 @@ class BudgetQuerySet(TenantQuerySet):
         )
 
 
-class BudgetManager(TenantManager):
+class BudgetManager(TenantManager["Budget"]):
     """Manager customizado para Budget."""
 
     def get_queryset(self) -> BudgetQuerySet:
         return BudgetQuerySet(self.model, using=self._db)
+
+    def for_tenant(self, company: Company) -> BudgetQuerySet:
+        return self.get_queryset().filter(company=company)
 
     def with_total_spent(self) -> BudgetQuerySet:
         """Anota cada orçamento com o total geral pago."""
         return self.get_queryset().with_total_spent()
 
 
-class BudgetCategoryQuerySet(TenantQuerySet):
+class BudgetCategoryQuerySet(TenantQuerySet["BudgetCategory"]):
     """QuerySet customizado para BudgetCategory."""
 
     def with_total_spent(self) -> BudgetCategoryQuerySet:
@@ -60,18 +71,21 @@ class BudgetCategoryQuerySet(TenantQuerySet):
         )
 
 
-class BudgetCategoryManager(TenantManager):
+class BudgetCategoryManager(TenantManager["BudgetCategory"]):
     """Manager customizado para BudgetCategory."""
 
     def get_queryset(self) -> BudgetCategoryQuerySet:
         return BudgetCategoryQuerySet(self.model, using=self._db)
+
+    def for_tenant(self, company: Company) -> BudgetCategoryQuerySet:
+        return self.get_queryset().filter(company=company)
 
     def with_total_spent(self) -> BudgetCategoryQuerySet:
         """Anota cada categoria com o total pago (soma de parcelas PAID)."""
         return self.get_queryset().with_total_spent()
 
 
-class ExpenseQuerySet(TenantQuerySet):
+class ExpenseQuerySet(TenantQuerySet["Expense"]):
     """QuerySet customizado para Expense."""
 
     def with_details(self) -> ExpenseQuerySet:
@@ -104,11 +118,14 @@ class ExpenseQuerySet(TenantQuerySet):
         )
 
 
-class ExpenseManager(TenantManager):
+class ExpenseManager(TenantManager["Expense"]):
     """Manager customizado para Expense."""
 
     def get_queryset(self) -> ExpenseQuerySet:
         return ExpenseQuerySet(self.model, using=self._db)
+
+    def for_tenant(self, company: Company) -> ExpenseQuerySet:
+        return self.get_queryset().filter(company=company)
 
     def with_details(self) -> ExpenseQuerySet:
         """Anota cada despesa com contagem de parcelas e valores totais."""

--- a/backend/apps/finances/schemas.py
+++ b/backend/apps/finances/schemas.py
@@ -1,6 +1,6 @@
 from datetime import date
 from decimal import Decimal
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from ninja import Schema
 from pydantic import UUID4, Field
@@ -40,7 +40,7 @@ class BudgetOut(Schema):
         """Expõe o computed property ``Budget.total_overall_spent`` no payload JSON."""
         val = getattr(obj, "_total_overall_spent", None)
         if val is not None:
-            return val
+            return cast(Decimal, val)
         return obj.total_overall_spent
 
 
@@ -80,7 +80,7 @@ class BudgetCategoryOut(Schema):
         """Expõe o computed property ``BudgetCategory.total_spent`` no payload JSON."""
         val = getattr(obj, "_total_spent", None)
         if val is not None:
-            return val
+            return cast(Decimal, val)
         return obj.total_spent
 
 

--- a/backend/apps/finances/services/budget_category_service.py
+++ b/backend/apps/finances/services/budget_category_service.py
@@ -1,6 +1,5 @@
 import logging
 from decimal import Decimal
-from typing import cast
 from uuid import UUID
 
 from django.db import transaction
@@ -12,7 +11,6 @@ from apps.core.exceptions import (
 )
 from apps.core.shortcuts import resolve_tenant_resource
 from apps.core.tenant import validate_tenant_ownership
-from apps.finances.managers import BudgetCategoryQuerySet
 from apps.finances.models import Budget, BudgetCategory
 from apps.finances.schemas import BudgetCategoryIn, BudgetCategoryPatchIn
 from apps.tenants.models import Company
@@ -76,7 +74,7 @@ class BudgetCategoryService:
             QuerySet[BudgetCategory]: QuerySet com as categorias de orçamento.
         """
         qs = (
-            cast(BudgetCategoryQuerySet, BudgetCategory.objects.for_tenant(company))
+            BudgetCategory.objects.for_tenant(company)
             .with_total_spent()
             .select_related("budget", "wedding")
         )
@@ -104,7 +102,7 @@ class BudgetCategoryService:
 
         try:
             return (
-                cast(BudgetCategoryQuerySet, BudgetCategory.objects.for_tenant(company))
+                BudgetCategory.objects.for_tenant(company)
                 .with_total_spent()
                 .select_related("budget", "wedding")
                 .get(uuid=uuid)

--- a/backend/apps/finances/services/budget_service.py
+++ b/backend/apps/finances/services/budget_service.py
@@ -1,5 +1,4 @@
 import logging
-from typing import cast
 from uuid import UUID
 
 from django.core.exceptions import ValidationError
@@ -9,7 +8,6 @@ from django.db.models import ProtectedError, QuerySet
 from apps.core.exceptions import DomainIntegrityError
 from apps.core.shortcuts import get_object_or_404_for_tenant, resolve_tenant_resource
 from apps.core.tenant import validate_tenant_ownership
-from apps.finances.managers import BudgetQuerySet
 from apps.finances.models import Budget
 from apps.finances.schemas import BudgetIn, BudgetPatchIn
 from apps.tenants.models import Company
@@ -37,7 +35,7 @@ class BudgetService:
             QuerySet[Budget]: QuerySet com os orçamentos contendo o gasto total.
         """
         return (
-            cast(BudgetQuerySet, Budget.objects.for_tenant(company))
+            Budget.objects.for_tenant(company)
             .with_total_spent()
             .select_related("wedding")
         )
@@ -58,7 +56,7 @@ class BudgetService:
         """
         try:
             return (
-                cast(BudgetQuerySet, Budget.objects.for_tenant(company))
+                Budget.objects.for_tenant(company)
                 .with_total_spent()
                 .select_related("wedding")
                 .get(uuid=uuid)

--- a/backend/apps/finances/services/expense_service.py
+++ b/backend/apps/finances/services/expense_service.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import date
-from typing import Any, cast
+from typing import Any
 from uuid import UUID
 
 from django.core.exceptions import ValidationError
@@ -15,7 +15,6 @@ from apps.core.exceptions import (
 )
 from apps.core.shortcuts import get_object_or_404_for_tenant, resolve_tenant_resource
 from apps.core.tenant import validate_tenant_ownership
-from apps.finances.managers import ExpenseQuerySet
 from apps.finances.models import BudgetCategory, Expense
 from apps.finances.schemas import ExpenseIn, ExpensePatchIn
 from apps.finances.services.installment_service import InstallmentService
@@ -68,7 +67,7 @@ class ExpenseService:
         Returns:
             QuerySet[Expense]: QuerySet com as despesas filtradas e detalhadas.
         """
-        qs = cast(ExpenseQuerySet, Expense.objects.for_tenant(company)).with_details()
+        qs = Expense.objects.for_tenant(company).with_details()
         if wedding_id:
             qs = qs.filter(wedding__uuid=wedding_id)
         return qs
@@ -92,11 +91,7 @@ class ExpenseService:
         # Para manter with_details(), vamos fazer manualmente ou garantir que
         # with_details() seja chamado no queryset.
         try:
-            return (
-                cast(ExpenseQuerySet, Expense.objects.for_tenant(company))
-                .with_details()
-                .get(uuid=uuid)
-            )
+            return Expense.objects.for_tenant(company).with_details().get(uuid=uuid)
         except (Expense.DoesNotExist, ValueError, ValidationError) as e:
             from apps.finances.models import Installment
 
@@ -108,7 +103,7 @@ class ExpenseService:
             )
             if installment and installment.expense:
                 return (
-                    cast(ExpenseQuerySet, Expense.objects.for_tenant(company))
+                    Expense.objects.for_tenant(company)
                     .with_details()
                     .get(pk=installment.expense_id)
                 )

--- a/backend/apps/finances/tests/budgets/test_models.py
+++ b/backend/apps/finances/tests/budgets/test_models.py
@@ -1,24 +1,45 @@
 from decimal import Decimal
+from typing import Any, cast
 
 import pytest
 from django.core.exceptions import ValidationError
 
-from apps.finances.models import Budget
-from apps.finances.models.installment import Installment
+from apps.finances.models import Budget, BudgetCategory, Expense, Installment
 from apps.finances.tests.factories import (
-    BudgetCategoryFactory,
-    BudgetFactory,
-    ExpenseFactory,
-    InstallmentFactory,
+    BudgetCategoryFactory as _BudgetCategoryFactory,
 )
-from apps.weddings.tests.factories import WeddingFactory
+from apps.finances.tests.factories import BudgetFactory as _BudgetFactory
+from apps.finances.tests.factories import ExpenseFactory as _ExpenseFactory
+from apps.finances.tests.factories import InstallmentFactory as _InstallmentFactory
+from apps.weddings.models import Wedding
+from apps.weddings.tests.factories import WeddingFactory as _WeddingFactory
+
+
+def BudgetCategoryFactory(*args: Any, **kwargs: Any) -> BudgetCategory:
+    return cast(BudgetCategory, _BudgetCategoryFactory(*args, **kwargs))
+
+
+def BudgetFactory(*args: Any, **kwargs: Any) -> Budget:
+    return cast(Budget, _BudgetFactory(*args, **kwargs))
+
+
+def ExpenseFactory(*args: Any, **kwargs: Any) -> Expense:
+    return cast(Expense, _ExpenseFactory(*args, **kwargs))
+
+
+def InstallmentFactory(*args: Any, **kwargs: Any) -> Installment:
+    return cast(Installment, _InstallmentFactory(*args, **kwargs))
+
+
+def WeddingFactory(*args: Any, **kwargs: Any) -> Wedding:
+    return cast(Wedding, _WeddingFactory(*args, **kwargs))
 
 
 @pytest.mark.django_db
 class TestBudgetModelMetadata:
     """Testes de representação e metadados do modelo Budget."""
 
-    def test_budget_str_representation(self, user):
+    def test_budget_str_representation(self, user: Any) -> None:
         """__str__ deve conter o nome do casamento e o total_estimated."""
         wedding = WeddingFactory(
             user_context=user, bride_name="Maria", groom_name="João"
@@ -30,7 +51,7 @@ class TestBudgetModelMetadata:
         assert "João" in result
         assert "50000.00" in result
 
-    def test_budget_ordering_by_created_at_descending(self, user):
+    def test_budget_ordering_by_created_at_descending(self, user: Any) -> None:
         """Ordenação padrão deve ser por -created_at."""
         w1 = WeddingFactory(user_context=user)
         w2 = WeddingFactory(user_context=user)
@@ -41,7 +62,7 @@ class TestBudgetModelMetadata:
         assert budgets[0] == b2
         assert budgets[1] == b1
 
-    def test_budget_total_estimated_min_value(self, user):
+    def test_budget_total_estimated_min_value(self, user: Any) -> None:
         """total_estimated não pode ser negativo (MinValueValidator 0.00)."""
         wedding = WeddingFactory(user_context=user)
         budget = Budget(
@@ -51,7 +72,7 @@ class TestBudgetModelMetadata:
         with pytest.raises(ValidationError):
             budget.full_clean()
 
-    def test_budget_total_estimated_zero_is_valid(self, user):
+    def test_budget_total_estimated_zero_is_valid(self, user: Any) -> None:
         """total_estimated = 0 é permitido."""
         wedding = WeddingFactory(user_context=user)
         budget = Budget(
@@ -64,13 +85,13 @@ class TestBudgetModelMetadata:
 class TestBudgetTotalOverallSpent:
     """Testes da computed property total_overall_spent."""
 
-    def test_total_overall_spent_with_no_expenses(self, user):
+    def test_total_overall_spent_with_no_expenses(self, user: Any) -> None:
         """Sem despesas, total_overall_spent = 0."""
         wedding = WeddingFactory(user_context=user)
         budget = BudgetFactory(wedding=wedding)
         assert budget.total_overall_spent == Decimal("0.00")
 
-    def test_total_overall_spent_only_paid_installments(self, user):
+    def test_total_overall_spent_only_paid_installments(self, user: Any) -> None:
         """total_overall_spent soma apenas parcelas PAID, ignorando PENDING."""
         wedding = WeddingFactory(user_context=user)
         budget = BudgetFactory(wedding=wedding)
@@ -96,7 +117,7 @@ class TestBudgetTotalOverallSpent:
 
         assert budget.total_overall_spent == Decimal("3000.00")
 
-    def test_total_overall_spent_all_pending_returns_zero(self, user):
+    def test_total_overall_spent_all_pending_returns_zero(self, user: Any) -> None:
         """Todas as parcelas PENDING: total_overall_spent = 0."""
         wedding = WeddingFactory(user_context=user)
         budget = BudgetFactory(wedding=wedding)
@@ -116,7 +137,9 @@ class TestBudgetTotalOverallSpent:
 
         assert budget.total_overall_spent == Decimal("0.00")
 
-    def test_total_overall_spent_multiple_categories_mixed_status(self, user):
+    def test_total_overall_spent_multiple_categories_mixed_status(
+        self, user: Any
+    ) -> None:
         """Soma PAID de múltiplas categorias, ignorando PENDING de todas."""
         wedding = WeddingFactory(user_context=user)
         budget = BudgetFactory(wedding=wedding)

--- a/backend/apps/finances/tests/budgets/test_services.py
+++ b/backend/apps/finances/tests/budgets/test_services.py
@@ -8,32 +8,59 @@ Estes testes cobrem as áreas de maior risco identificadas na análise:
 4. Atomicidade de transações
 """
 
+from datetime import date
 from decimal import Decimal
-from typing import no_type_check
+from typing import Any, cast, no_type_check
 from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
 
 from apps.core.exceptions import DomainIntegrityError, ObjectNotFoundError
-from apps.finances.models import Budget, BudgetCategory
+from apps.finances.models import Budget, BudgetCategory, Expense
 from apps.finances.schemas import BudgetIn, BudgetPatchIn
 from apps.finances.services.budget_category_service import BudgetCategoryService
 from apps.finances.services.budget_service import BudgetService
 from apps.finances.tests.factories import (
-    BudgetCategoryFactory,
-    BudgetFactory,
-    ExpenseFactory,
+    BudgetCategoryFactory as _BudgetCategoryFactory,
 )
-from apps.users.tests.factories import UserFactory
-from apps.weddings.tests.factories import WeddingFactory
+from apps.finances.tests.factories import (
+    BudgetFactory as _BudgetFactory,
+)
+from apps.finances.tests.factories import (
+    ExpenseFactory as _ExpenseFactory,
+)
+from apps.users.models import User
+from apps.users.tests.factories import UserFactory as _UserFactory
+from apps.weddings.models import Wedding
+from apps.weddings.tests.factories import WeddingFactory as _WeddingFactory
+
+
+def BudgetCategoryFactory(*args: Any, **kwargs: Any) -> BudgetCategory:
+    return cast(BudgetCategory, _BudgetCategoryFactory(*args, **kwargs))
+
+
+def BudgetFactory(*args: Any, **kwargs: Any) -> Budget:
+    return cast(Budget, _BudgetFactory(*args, **kwargs))
+
+
+def ExpenseFactory(*args: Any, **kwargs: Any) -> Expense:
+    return cast(Expense, _ExpenseFactory(*args, **kwargs))
+
+
+def UserFactory(*args: Any, **kwargs: Any) -> User:
+    return cast(User, _UserFactory(*args, **kwargs))
+
+
+def WeddingFactory(*args: Any, **kwargs: Any) -> Wedding:
+    return cast(Wedding, _WeddingFactory(*args, **kwargs))
 
 
 @pytest.mark.django_db
 class TestBudgetServiceCritical:
     """Testes CRÍTICOS para BudgetService."""
 
-    def test_get_or_create_for_wedding_lazy_loading(self, user):
+    def test_get_or_create_for_wedding_lazy_loading(self, user: Any) -> None:
         """
         Teste CRÍTICO: Lazy loading funciona corretamente.
 
@@ -64,7 +91,7 @@ class TestBudgetServiceCritical:
         assert budget2.id == budget1.id  # Mesmo objeto
         assert Budget.objects.filter(wedding=wedding).count() == 1  # Ainda apenas 1
 
-    def test_get_or_create_for_wedding_multi_tenancy(self):
+    def test_get_or_create_for_wedding_multi_tenancy(self) -> None:
         """
         Teste CRÍTICO: Isolamento completo entre usuários.
 
@@ -102,7 +129,9 @@ class TestBudgetServiceCritical:
 
         assert exc_info.value.code == "wedding_not_found_or_denied"
 
-    def test_get_or_create_for_wedding_with_nonexistent_wedding(self, user):
+    def test_get_or_create_for_wedding_with_nonexistent_wedding(
+        self, user: Any
+    ) -> None:
         """
         Teste CRÍTICO: UUID de wedding não existente.
 
@@ -117,7 +146,7 @@ class TestBudgetServiceCritical:
 
         assert "não encontrado ou acesso negado" in str(exc_info.value.detail).lower()
 
-    def test_get_or_create_for_wedding_atomic_transaction(self, user):
+    def test_get_or_create_for_wedding_atomic_transaction(self, user: Any) -> None:
         """
         Teste CRÍTICO: Atomicidade da transação.
 
@@ -141,7 +170,9 @@ class TestBudgetServiceCritical:
         assert Budget.objects.filter(wedding=wedding).count() == 0
         assert BudgetCategory.objects.filter(budget__wedding=wedding).count() == 0
 
-    def test_get_or_create_for_wedding_creates_default_categories(self, user):
+    def test_get_or_create_for_wedding_creates_default_categories(
+        self, user: Any
+    ) -> None:
         """
         Teste CRÍTICO: Categorias padrão são criadas automaticamente.
 
@@ -167,7 +198,7 @@ class TestBudgetServiceCritical:
         # Pelo menos uma das categorias esperadas deve estar presente
         assert any(expected in category_names for expected in expected_categories)
 
-    def test_get_budget_success(self, user):
+    def test_get_budget_success(self, user: Any) -> None:
         """get() retorna budget por UUID com select_related."""
         wedding = WeddingFactory(company=user.company)
         budget = BudgetFactory(wedding=wedding)
@@ -177,7 +208,7 @@ class TestBudgetServiceCritical:
         assert result.uuid == budget.uuid
         assert result.wedding == wedding
 
-    def test_get_budget_multi_tenancy(self):
+    def test_get_budget_multi_tenancy(self) -> None:
         """
         Teste CRÍTICO: get() respeita multi-tenancy.
 
@@ -198,7 +229,7 @@ class TestBudgetServiceCritical:
 
         assert "Orçamento não encontrado" in str(exc_info.value.detail)
 
-    def test_get_budget_not_found(self, user):
+    def test_get_budget_not_found(self, user: Any) -> None:
         """get() lança ObjectNotFoundError para UUID inexistente."""
         invalid_uuid = uuid4()
 
@@ -209,7 +240,7 @@ class TestBudgetServiceCritical:
             exc_info.value.detail
         )
 
-    def test_get_budget_invalid_uuid_format(self, user):
+    def test_get_budget_invalid_uuid_format(self, user: Any) -> None:
         """get() lança ObjectNotFoundError para formato de UUID inválido."""
         invalid_format = "not-a-uuid"
 
@@ -220,7 +251,7 @@ class TestBudgetServiceCritical:
             exc_info.value.detail
         )
 
-    def test_list_budgets_multi_tenancy(self):
+    def test_list_budgets_multi_tenancy(self) -> None:
         """
         Teste CRÍTICO: list() retorna apenas budgets do usuário.
 
@@ -243,14 +274,18 @@ class TestBudgetServiceCritical:
         # User A vê apenas seu budget
         budgets_a = BudgetService.list(user_a.company)
         assert budgets_a.count() == 1
-        assert budgets_a.first().uuid == budget_a.uuid
+        listed_budget_a = budgets_a.first()
+        assert listed_budget_a is not None
+        assert listed_budget_a.uuid == budget_a.uuid
 
         # User B vê apenas seu budget
         budgets_b = BudgetService.list(user_b.company)
         assert budgets_b.count() == 1
-        assert budgets_b.first().uuid == budget_b.uuid
+        listed_budget_b = budgets_b.first()
+        assert listed_budget_b is not None
+        assert listed_budget_b.uuid == budget_b.uuid
 
-    def test_create_budget_duplicate_prevention(self, user):
+    def test_create_budget_duplicate_prevention(self, user: Any) -> None:
         """
         Teste CRÍTICO: Impedir criação de múltiplos budgets para mesmo wedding.
 
@@ -259,16 +294,19 @@ class TestBudgetServiceCritical:
         wedding = WeddingFactory(company=user.company)
 
         # Criar primeiro budget
-        budget1_data = {"wedding": wedding.uuid, "total_estimated": Decimal("50000.00")}
-        BudgetService.create(user.company, BudgetIn(**budget1_data))
+        BudgetService.create(
+            user.company,
+            BudgetIn(wedding=wedding.uuid, total_estimated=Decimal("50000.00")),
+        )
 
         # Tentar criar segundo budget para mesmo wedding
-        budget2_data = {"wedding": wedding.uuid, "total_estimated": Decimal("75000.00")}
-
         from apps.core.exceptions import DomainIntegrityError
 
         with pytest.raises(DomainIntegrityError) as exc_info:
-            BudgetService.create(user.company, BudgetIn(**budget2_data))
+            BudgetService.create(
+                user.company,
+                BudgetIn(wedding=wedding.uuid, total_estimated=Decimal("75000.00")),
+            )
 
         assert "já possui um orçamento definido" in str(exc_info.value.detail)
 
@@ -278,7 +316,7 @@ class TestBudgetServiceCritical:
             "50000.00"
         )
 
-    def test_budget_creation_with_invalid_wedding_uuid(self, user):
+    def test_budget_creation_with_invalid_wedding_uuid(self, user: Any) -> None:
         """
         Teste CRÍTICO: Tentativa de criar budget com wedding UUID inválido.
 
@@ -288,14 +326,15 @@ class TestBudgetServiceCritical:
 
         invalid_uuid = uuid4()
 
-        budget_data = {"wedding": invalid_uuid, "total_estimated": Decimal("50000.00")}
-
         with pytest.raises(ObjectNotFoundError) as exc_info:
-            BudgetService.create(user.company, BudgetIn(**budget_data))
+            BudgetService.create(
+                user.company,
+                BudgetIn(wedding=invalid_uuid, total_estimated=Decimal("50000.00")),
+            )
 
         assert "não encontrado ou acesso negado" in str(exc_info.value.detail).lower()
 
-    def test_budget_service_requires_authenticated_user(self):
+    def test_budget_service_requires_authenticated_user(self) -> None:
         """
         Teste CRÍTICO: Serviços requerem usuário autenticado.
 
@@ -310,14 +349,16 @@ class TestBudgetServiceCritical:
 
         # Todas as operações devem falhar com usuário anônimo
         with pytest.raises(TypeError):
-            BudgetService.get_or_create_for_wedding(anonymous_user, some_uuid)
+            BudgetService.get_or_create_for_wedding(
+                cast(Any, anonymous_user), some_uuid
+            )
 
 
 @pytest.mark.django_db
 class TestBudgetServiceIntegration:
     """Testes de integração entre WeddingService e BudgetService."""
 
-    def test_wedding_creation_does_not_create_budget_eagerly(self, user):
+    def test_wedding_creation_does_not_create_budget_eagerly(self, user: Any) -> None:
         """
         Teste CRÍTICO: Criação de wedding NÃO cria budget automaticamente.
 
@@ -326,15 +367,17 @@ class TestBudgetServiceIntegration:
         from apps.weddings.schemas import WeddingIn
         from apps.weddings.services import WeddingService
 
-        wedding_payload = {
-            "bride_name": "Maria",
-            "groom_name": "João",
-            "date": "2026-12-31",
-            "location": "São Paulo",
-            "expected_guests": 150,
-        }
-
-        wedding = WeddingService.create(user.company, WeddingIn(**wedding_payload))
+        wedding = WeddingService.create(
+            user.company,
+            WeddingIn(
+                bride_name="Maria",
+                groom_name="João",
+                date=date(2026, 12, 31),
+                location="São Paulo",
+                expected_guests=150,
+                template=None,
+            ),
+        )
 
         # Verificar que wedding foi criado mas budget NÃO
         assert wedding is not None
@@ -345,7 +388,7 @@ class TestBudgetServiceIntegration:
         assert budget is not None
         assert Budget.objects.filter(wedding=wedding).count() == 1
 
-    def test_wedding_delete_cascades_to_budget(self, user):
+    def test_wedding_delete_cascades_to_budget(self, user: Any) -> None:
         """
         Teste CRÍTICO: Deleção de wedding deleta budget automaticamente (CASCADE).
 
@@ -367,7 +410,7 @@ class TestBudgetServiceIntegration:
         # Usamos uuid pois em Django 5.2 instance.delete() limpa o estado da pk
         assert Budget.objects.filter(wedding__uuid=wedding.uuid).count() == 0
 
-    def test_budget_create_with_wedding_instance(self, user):
+    def test_budget_create_with_wedding_instance(self, user: Any) -> None:
         """
         BudgetService.create() aceita instância de Wedding, não só UUID.
         """
@@ -381,7 +424,7 @@ class TestBudgetServiceIntegration:
         assert budget.wedding == wedding
         assert budget.total_estimated == Decimal("30000.00")
 
-    def test_budget_update_success(self, user):
+    def test_budget_update_success(self, user: Any) -> None:
         """
         BudgetService.update() permite alterar total_estimated e notes.
         """
@@ -397,7 +440,7 @@ class TestBudgetServiceIntegration:
         assert updated.total_estimated == Decimal("80000.00")
         assert updated.notes == "Nova observação"
 
-    def test_budget_update_cannot_change_wedding(self, user):
+    def test_budget_update_cannot_change_wedding(self, user: Any) -> None:
         """
         Wedding é bloqueado no update — campo estrutural.
         """
@@ -406,12 +449,14 @@ class TestBudgetServiceIntegration:
         budget = BudgetService.get_or_create_for_wedding(user.company, wedding1.uuid)
 
         updated = BudgetService.update(
-            user.company, budget, BudgetPatchIn(wedding=wedding2.uuid)
+            user.company,
+            budget,
+            BudgetPatchIn.model_construct(wedding=wedding2.uuid),
         )
 
         assert updated.wedding == wedding1
 
-    def test_update_budget_cross_tenant(self, user):
+    def test_update_budget_cross_tenant(self, user: Any) -> None:
         """Orçamento de outro tenant não pode ser atualizado."""
         other_user = UserFactory()
         other_wedding = WeddingFactory(company=other_user.company)
@@ -422,7 +467,7 @@ class TestBudgetServiceIntegration:
                 user.company, other_budget, BudgetPatchIn(notes="Hack")
             )
 
-    def test_budget_delete_success(self, user):
+    def test_budget_delete_success(self, user: Any) -> None:
         """
         BudgetService.delete() remove o orçamento se não houver categorias.
         """
@@ -438,7 +483,7 @@ class TestBudgetServiceIntegration:
 
         assert BudgetModel.objects.filter(uuid=budget.uuid).count() == 0
 
-    def test_budget_delete_cascades_to_categories(self, user):
+    def test_budget_delete_cascades_to_categories(self, user: Any) -> None:
         """
         Budget com categorias: CASCADE deleta categorias junto.
         BudgetCategory.on_delete=CASCADE para Budget, sem proteção.
@@ -450,7 +495,7 @@ class TestBudgetServiceIntegration:
 
         assert Budget.objects.filter(uuid=budget.uuid).count() == 0
 
-    def test_delete_budget_protected_by_expenses(self, user):
+    def test_delete_budget_protected_by_expenses(self, user: Any) -> None:
         """Deleção de orçamento com despesas vinculadas deve falhar."""
         wedding = WeddingFactory(user_context=user)
         budget = BudgetFactory(wedding=wedding)
@@ -465,7 +510,7 @@ class TestBudgetServiceIntegration:
         assert "Não é possível apagar este orçamento" in str(exc_info.value)
         assert Budget.objects.filter(uuid=budget.uuid).exists()
 
-    def test_delete_budget_cross_tenant(self, user):
+    def test_delete_budget_cross_tenant(self, user: Any) -> None:
         """Orçamento de outro tenant não pode ser deletado."""
         other_user = UserFactory()
         other_wedding = WeddingFactory(company=other_user.company)

--- a/backend/apps/finances/tests/categories/test_models.py
+++ b/backend/apps/finances/tests/categories/test_models.py
@@ -1,24 +1,45 @@
 from decimal import Decimal
+from typing import Any, cast
 
 import pytest
 from django.core.exceptions import ValidationError
 
-from apps.finances.models import BudgetCategory
-from apps.finances.models.installment import Installment
+from apps.finances.models import Budget, BudgetCategory, Expense, Installment
 from apps.finances.tests.factories import (
-    BudgetCategoryFactory,
-    BudgetFactory,
-    ExpenseFactory,
-    InstallmentFactory,
+    BudgetCategoryFactory as _BudgetCategoryFactory,
 )
-from apps.weddings.tests.factories import WeddingFactory
+from apps.finances.tests.factories import BudgetFactory as _BudgetFactory
+from apps.finances.tests.factories import ExpenseFactory as _ExpenseFactory
+from apps.finances.tests.factories import InstallmentFactory as _InstallmentFactory
+from apps.weddings.models import Wedding
+from apps.weddings.tests.factories import WeddingFactory as _WeddingFactory
+
+
+def BudgetCategoryFactory(*args: Any, **kwargs: Any) -> BudgetCategory:
+    return cast(BudgetCategory, _BudgetCategoryFactory(*args, **kwargs))
+
+
+def BudgetFactory(*args: Any, **kwargs: Any) -> Budget:
+    return cast(Budget, _BudgetFactory(*args, **kwargs))
+
+
+def ExpenseFactory(*args: Any, **kwargs: Any) -> Expense:
+    return cast(Expense, _ExpenseFactory(*args, **kwargs))
+
+
+def InstallmentFactory(*args: Any, **kwargs: Any) -> Installment:
+    return cast(Installment, _InstallmentFactory(*args, **kwargs))
+
+
+def WeddingFactory(*args: Any, **kwargs: Any) -> Wedding:
+    return cast(Wedding, _WeddingFactory(*args, **kwargs))
 
 
 @pytest.mark.django_db
 class TestBudgetCategoryModelMetadata:
     """Testes de representação e metadados do modelo BudgetCategory."""
 
-    def test_budget_category_str_representation(self, user):
+    def test_budget_category_str_representation(self, user: Any) -> None:
         """__str__ deve conter o nome e o wedding."""
         wedding = WeddingFactory(
             user_context=user, bride_name="Ana", groom_name="Pedro"
@@ -35,7 +56,7 @@ class TestBudgetCategoryModelMetadata:
         assert "Decoração" in result
         assert "Ana" in result
 
-    def test_budget_category_ordering_by_name(self, user):
+    def test_budget_category_ordering_by_name(self, user: Any) -> None:
         """Ordenação padrão deve ser por name alfabético."""
         wedding = WeddingFactory(user_context=user)
         budget = BudgetFactory(wedding=wedding)
@@ -49,7 +70,7 @@ class TestBudgetCategoryModelMetadata:
         assert categories[1].name == "Beta"
         assert categories[2].name == "Zeta"
 
-    def test_budget_category_unique_name_per_budget(self, user):
+    def test_budget_category_unique_name_per_budget(self, user: Any) -> None:
         """Nome deve ser único dentro do mesmo budget."""
         wedding = WeddingFactory(user_context=user)
         budget = BudgetFactory(wedding=wedding)
@@ -61,7 +82,7 @@ class TestBudgetCategoryModelMetadata:
         with pytest.raises(ValidationError):
             BudgetCategoryFactory(budget=budget, wedding=wedding, name="Decoração")
 
-    def test_budget_category_allocated_budget_not_negative(self, user):
+    def test_budget_category_allocated_budget_not_negative(self, user: Any) -> None:
         """allocated_budget não pode ser negativo."""
         wedding = WeddingFactory(user_context=user)
         budget = BudgetFactory(wedding=wedding)
@@ -81,7 +102,7 @@ class TestBudgetCategoryModelMetadata:
 class TestBudgetCategoryClean:
     """Testes das validações do método clean()."""
 
-    def test_clean_fails_when_budget_wedding_mismatch(self, user):
+    def test_clean_fails_when_budget_wedding_mismatch(self, user: Any) -> None:
         """TRAVA: orçamento pai deve pertencer ao mesmo casamento da categoria.
         O WeddingOwnedMixin captura essa violação antes do clean() customizado."""
         wedding1 = WeddingFactory(user_context=user)
@@ -106,14 +127,14 @@ class TestBudgetCategoryClean:
 class TestBudgetCategoryTotalSpent:
     """Testes da computed property total_spent."""
 
-    def test_total_spent_with_no_expenses(self, user):
+    def test_total_spent_with_no_expenses(self, user: Any) -> None:
         """Sem despesas, total_spent = 0."""
         wedding = WeddingFactory(user_context=user)
         budget = BudgetFactory(wedding=wedding)
         category = BudgetCategoryFactory(budget=budget, wedding=wedding)
         assert category.total_spent == Decimal("0.00")
 
-    def test_total_spent_sums_expenses(self, user):
+    def test_total_spent_sums_expenses(self, user: Any) -> None:
         """total_spent soma apenas parcelas PAID das despesas."""
         wedding = WeddingFactory(user_context=user)
         budget = BudgetFactory(wedding=wedding)
@@ -147,7 +168,7 @@ class TestBudgetCategoryTotalSpent:
 
         assert category.total_spent == Decimal("5000.00")
 
-    def test_total_spent_only_paid_installments(self, user):
+    def test_total_spent_only_paid_installments(self, user: Any) -> None:
         """total_spent soma apenas parcelas PAID, ignorando PENDING."""
         wedding = WeddingFactory(user_context=user)
         budget = BudgetFactory(wedding=wedding)
@@ -173,7 +194,7 @@ class TestBudgetCategoryTotalSpent:
 
         assert category.total_spent == Decimal("3000.00")
 
-    def test_total_spent_all_pending_returns_zero(self, user):
+    def test_total_spent_all_pending_returns_zero(self, user: Any) -> None:
         """Todas as parcelas PENDING: total_spent = 0."""
         wedding = WeddingFactory(user_context=user)
         budget = BudgetFactory(wedding=wedding)
@@ -193,7 +214,7 @@ class TestBudgetCategoryTotalSpent:
 
         assert category.total_spent == Decimal("0.00")
 
-    def test_total_spent_multiple_expenses_mixed_status(self, user):
+    def test_total_spent_multiple_expenses_mixed_status(self, user: Any) -> None:
         """Soma PAID de múltiplas despesas, ignorando PENDING em todas."""
         wedding = WeddingFactory(user_context=user)
         budget = BudgetFactory(wedding=wedding)

--- a/backend/apps/finances/tests/categories/test_services.py
+++ b/backend/apps/finances/tests/categories/test_services.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from typing import no_type_check
+from typing import Any, cast, no_type_check
 from uuid import uuid4
 
 import pytest
@@ -9,19 +9,45 @@ from apps.core.exceptions import (
     DomainIntegrityError,
     ObjectNotFoundError,
 )
-from apps.finances.models import Budget, BudgetCategory
+from apps.finances.models import Budget, BudgetCategory, Expense
 from apps.finances.schemas import BudgetCategoryIn, BudgetCategoryPatchIn
 from apps.finances.services.budget_category_service import BudgetCategoryService
 from apps.finances.tests.factories import (
-    BudgetCategoryFactory,
-    BudgetFactory,
-    ExpenseFactory,
+    BudgetCategoryFactory as _BudgetCategoryFactory,
 )
-from apps.users.tests.factories import UserFactory
-from apps.weddings.tests.factories import WeddingFactory
+from apps.finances.tests.factories import (
+    BudgetFactory as _BudgetFactory,
+)
+from apps.finances.tests.factories import (
+    ExpenseFactory as _ExpenseFactory,
+)
+from apps.users.models import User
+from apps.users.tests.factories import UserFactory as _UserFactory
+from apps.weddings.models import Wedding
+from apps.weddings.tests.factories import WeddingFactory as _WeddingFactory
 
 
-def _setup_budget(user, **kwargs):
+def BudgetCategoryFactory(*args: Any, **kwargs: Any) -> BudgetCategory:
+    return cast(BudgetCategory, _BudgetCategoryFactory(*args, **kwargs))
+
+
+def BudgetFactory(*args: Any, **kwargs: Any) -> Budget:
+    return cast(Budget, _BudgetFactory(*args, **kwargs))
+
+
+def ExpenseFactory(*args: Any, **kwargs: Any) -> Expense:
+    return cast(Expense, _ExpenseFactory(*args, **kwargs))
+
+
+def UserFactory(*args: Any, **kwargs: Any) -> User:
+    return cast(User, _UserFactory(*args, **kwargs))
+
+
+def WeddingFactory(*args: Any, **kwargs: Any) -> Wedding:
+    return cast(Wedding, _WeddingFactory(*args, **kwargs))
+
+
+def _setup_budget(user: Any, **kwargs: Any) -> tuple[Wedding, Budget]:
     """Helper: cria wedding + budget no contexto do user."""
     wedding = WeddingFactory(user_context=user)
     budget = BudgetFactory(wedding=wedding, **kwargs)
@@ -32,63 +58,67 @@ def _setup_budget(user, **kwargs):
 class TestBudgetCategoryServiceCreate:
     """Testes de criação de categorias via BudgetCategoryService."""
 
-    def test_create_category_success(self, user):
+    def test_create_category_success(self, user: Any) -> None:
         """Criação de categoria vinculada ao budget do casamento."""
         wedding, budget = _setup_budget(user)
 
-        data = {
-            "budget": budget.uuid,
-            "name": "Decoração",
-            "allocated_budget": Decimal("5000.00"),
-        }
-
-        category = BudgetCategoryService.create(user.company, BudgetCategoryIn(**data))
+        category = BudgetCategoryService.create(
+            user.company,
+            BudgetCategoryIn(
+                budget=budget.uuid,
+                name="Decoração",
+                allocated_budget=Decimal("5000.00"),
+            ),
+        )
 
         assert category.budget == budget
         assert category.wedding == wedding
         assert category.name == "Decoração"
         assert category.allocated_budget == Decimal("5000.00")
 
-    def test_create_category_with_budget_instance(self, user):
+    def test_create_category_with_budget_instance(self, user: Any) -> None:
         """create() aceita instância de Budget, não só UUID."""
         _, budget = _setup_budget(user)
 
-        data = {
-            "budget": budget.uuid,
-            "name": "Fotografia",
-            "allocated_budget": Decimal("3000.00"),
-        }
-
-        category = BudgetCategoryService.create(user.company, BudgetCategoryIn(**data))
+        category = BudgetCategoryService.create(
+            user.company,
+            BudgetCategoryIn(
+                budget=budget.uuid,
+                name="Fotografia",
+                allocated_budget=Decimal("3000.00"),
+            ),
+        )
         assert category.budget == budget
 
-    def test_create_category_budget_not_found(self, user):
+    def test_create_category_budget_not_found(self, user: Any) -> None:
         """UUID de orçamento inexistente levanta ObjectNotFoundError."""
-        data = {
-            "budget": uuid4(),
-            "name": "Fantasma",
-            "allocated_budget": Decimal("1000.00"),
-        }
-
         with pytest.raises(ObjectNotFoundError) as exc_info:
-            BudgetCategoryService.create(user.company, BudgetCategoryIn(**data))
+            BudgetCategoryService.create(
+                user.company,
+                BudgetCategoryIn(
+                    budget=uuid4(),
+                    name="Fantasma",
+                    allocated_budget=Decimal("1000.00"),
+                ),
+            )
 
         assert "budget_not_found_or_denied" in str(exc_info.value.code)
 
-    def test_create_category_multitenancy(self):
+    def test_create_category_multitenancy(self) -> None:
         """Usuário A não pode criar categoria com budget do Usuário B."""
         user_a = UserFactory()
         user_b = UserFactory()
         _, budget_b = _setup_budget(user_b)
 
-        data = {
-            "budget": budget_b.uuid,
-            "name": "Invasão",
-            "allocated_budget": Decimal("1000.00"),
-        }
-
         with pytest.raises(ObjectNotFoundError) as exc_info:
-            BudgetCategoryService.create(user_a.company, BudgetCategoryIn(**data))
+            BudgetCategoryService.create(
+                user_a.company,
+                BudgetCategoryIn(
+                    budget=budget_b.uuid,
+                    name="Invasão",
+                    allocated_budget=Decimal("1000.00"),
+                ),
+            )
 
         assert "budget_not_found_or_denied" in str(exc_info.value.code)
 
@@ -110,7 +140,7 @@ class TestBudgetCategoryServiceCreate:
 
         assert exc_info.value.code == "budget_not_found_or_denied"
 
-    def test_create_category_exceeds_budget_cap_raises_error(self, user):
+    def test_create_category_exceeds_budget_cap_raises_error(self, user: Any) -> None:
         """
         TOCTOU: criar categoria que ultrapassa o teto do orçamento
         levanta BusinessRuleViolation.
@@ -122,35 +152,39 @@ class TestBudgetCategoryServiceCreate:
             allocated_budget=Decimal("9000.00"),
         )
 
-        data = {
-            "budget": budget.uuid,
-            "name": "Excedente",
-            "allocated_budget": Decimal("2000.00"),
-        }
-
         with pytest.raises(BusinessRuleViolation) as exc_info:
-            BudgetCategoryService.create(user.company, BudgetCategoryIn(**data))
+            BudgetCategoryService.create(
+                user.company,
+                BudgetCategoryIn(
+                    budget=budget.uuid,
+                    name="Excedente",
+                    allocated_budget=Decimal("2000.00"),
+                ),
+            )
 
         assert "budget_cap_exceeded" in str(exc_info.value.code)
 
-    def test_create_category_uses_select_for_update(self, user, mocker):
+    def test_create_category_uses_select_for_update(
+        self, user: Any, mocker: Any
+    ) -> None:
         """
         TOCTOU: create() deve usar select_for_update() no budget
         para evitar race condition na leitura da soma das categorias.
         """
         _, budget = _setup_budget(user)
-        data = {
-            "budget": budget.uuid,
-            "name": "Teste Lock",
-            "allocated_budget": Decimal("1000.00"),
-        }
-
         mock_qs = mocker.MagicMock()
         mock_qs.select_for_update.return_value = mock_qs
         mock_qs.get.return_value = budget
         mocker.patch.object(Budget.objects, "for_tenant", return_value=mock_qs)
 
-        BudgetCategoryService.create(user.company, BudgetCategoryIn(**data))
+        BudgetCategoryService.create(
+            user.company,
+            BudgetCategoryIn(
+                budget=budget.uuid,
+                name="Teste Lock",
+                allocated_budget=Decimal("1000.00"),
+            ),
+        )
 
         mock_qs.select_for_update.assert_called_once()
 
@@ -159,7 +193,7 @@ class TestBudgetCategoryServiceCreate:
 class TestBudgetCategoryServiceUpdate:
     """Testes de atualização de categorias via BudgetCategoryService."""
 
-    def test_update_category_name(self, user):
+    def test_update_category_name(self, user: Any) -> None:
         """Atualização de campos simples é permitida."""
         wedding, budget = _setup_budget(user)
         category = BudgetCategoryFactory(
@@ -174,7 +208,9 @@ class TestBudgetCategoryServiceUpdate:
 
         assert updated.name == "Nova Categoria"
 
-    def test_update_category_allocated_budget_exceeds_cap_raises_error(self, user):
+    def test_update_category_allocated_budget_exceeds_cap_raises_error(
+        self, user: Any
+    ) -> None:
         """
         TOCTOU: atualizar allocated_budget ultrapassando o teto
         levanta BusinessRuleViolation.
@@ -196,12 +232,16 @@ class TestBudgetCategoryServiceUpdate:
             BudgetCategoryService.update(
                 user.company,
                 category2,
-                BudgetCategoryPatchIn(allocated_budget=Decimal("2000.00")),
+                BudgetCategoryPatchIn(
+                    name="Outra", allocated_budget=Decimal("2000.00")
+                ),
             )
 
         assert "budget_cap_exceeded" in str(exc_info.value.code)
 
-    def test_update_category_uses_select_for_update(self, user, mocker):
+    def test_update_category_uses_select_for_update(
+        self, user: Any, mocker: Any
+    ) -> None:
         """
         TOCTOU: update() deve usar select_for_update() no budget
         para evitar race condition na leitura da soma das categorias.
@@ -222,7 +262,7 @@ class TestBudgetCategoryServiceUpdate:
         )
         mock_qs.select_for_update.assert_called_once()
 
-    def test_update_category_cross_tenant(self, user):
+    def test_update_category_cross_tenant(self, user: Any) -> None:
         """Categoria de outro tenant não pode ser atualizada."""
         from apps.users.tests.factories import UserFactory
 
@@ -243,7 +283,7 @@ class TestBudgetCategoryServiceUpdate:
 class TestBudgetCategoryServiceDelete:
     """Testes de deleção de categorias via BudgetCategoryService."""
 
-    def test_delete_category_success(self, user):
+    def test_delete_category_success(self, user: Any) -> None:
         """Deleção de categoria sem despesas vinculadas é permitida."""
         wedding, budget = _setup_budget(user)
         category = BudgetCategoryFactory(
@@ -255,7 +295,7 @@ class TestBudgetCategoryServiceDelete:
 
         assert BudgetCategory.objects.filter(uuid=category.uuid).count() == 0
 
-    def test_delete_category_with_expenses_fails(self, user):
+    def test_delete_category_with_expenses_fails(self, user: Any) -> None:
         """Categoria com despesas vinculadas não pode ser deletada (PROTECT)."""
         wedding, budget = _setup_budget(user)
         category = BudgetCategoryFactory(
@@ -274,7 +314,7 @@ class TestBudgetCategoryServiceDelete:
         assert "category_protected_error" in str(exc_info.value.code)
         assert BudgetCategory.objects.filter(uuid=category.uuid).count() == 1
 
-    def test_delete_category_cross_tenant(self, user):
+    def test_delete_category_cross_tenant(self, user: Any) -> None:
         """Categoria de outro tenant não pode ser deletada."""
         other_user = UserFactory()
         other_wedding = WeddingFactory(company=other_user.company)
@@ -291,7 +331,7 @@ class TestBudgetCategoryServiceDelete:
 class TestBudgetCategoryServiceListAndGet:
     """Testes de listagem e obtenção de categorias."""
 
-    def test_list_categories_multitenancy(self):
+    def test_list_categories_multitenancy(self) -> None:
         """list() retorna apenas categorias do tenant."""
         user_a = UserFactory()
         user_b = UserFactory()
@@ -303,13 +343,17 @@ class TestBudgetCategoryServiceListAndGet:
 
         qs_a = BudgetCategoryService.list(user_a.company)
         assert qs_a.count() == 1
-        assert qs_a.first().name == "Cat A"
+        category_a = qs_a.first()
+        assert category_a is not None
+        assert category_a.name == "Cat A"
 
         qs_b = BudgetCategoryService.list(user_b.company)
         assert qs_b.count() == 1
-        assert qs_b.first().name == "Cat B"
+        category_b = qs_b.first()
+        assert category_b is not None
+        assert category_b.name == "Cat B"
 
-    def test_list_categories_filter_by_wedding(self, user):
+    def test_list_categories_filter_by_wedding(self, user: Any) -> None:
         """list() com wedding_id filtra por casamento."""
         wedding1, budget1 = _setup_budget(user)
         wedding2, budget2 = _setup_budget(user)
@@ -319,9 +363,11 @@ class TestBudgetCategoryServiceListAndGet:
 
         qs = BudgetCategoryService.list(user.company, wedding_id=wedding1.uuid)
         assert qs.count() == 1
-        assert qs.first().name == "Cat Wedding 1"
+        category = qs.first()
+        assert category is not None
+        assert category.name == "Cat Wedding 1"
 
-    def test_get_category_success(self, user):
+    def test_get_category_success(self, user: Any) -> None:
         """get() retorna categoria por UUID."""
         wedding, budget = _setup_budget(user)
         category = BudgetCategoryFactory(
@@ -334,14 +380,14 @@ class TestBudgetCategoryServiceListAndGet:
         assert result.uuid == category.uuid
         assert result.name == "Buffet"
 
-    def test_get_category_not_found(self, user):
+    def test_get_category_not_found(self, user: Any) -> None:
         """UUID inexistente levanta ObjectNotFoundError."""
         with pytest.raises(ObjectNotFoundError) as exc_info:
             BudgetCategoryService.get(user.company, uuid4())
 
         assert str(exc_info.value.detail) == "Categoria de orçamento não encontrada."
 
-    def test_get_category_multitenancy(self):
+    def test_get_category_multitenancy(self) -> None:
         """Usuário A não pode acessar categoria do Usuário B."""
         user_a = UserFactory()
         user_b = UserFactory()
@@ -361,7 +407,7 @@ class TestBudgetCategoryServiceListAndGet:
 class TestBudgetCategoryServiceSetupDefaults:
     """Testes de criação de categorias padrão via setup_defaults()."""
 
-    def test_setup_defaults_creates_six_categories(self, user):
+    def test_setup_defaults_creates_six_categories(self, user: Any) -> None:
         """setup_defaults() deve criar 6 categorias padrão."""
         wedding, budget = _setup_budget(user)
 
@@ -370,7 +416,7 @@ class TestBudgetCategoryServiceSetupDefaults:
         categories = BudgetCategory.objects.filter(budget=budget)
         assert categories.count() == 6
 
-    def test_setup_defaults_expected_names(self, user):
+    def test_setup_defaults_expected_names(self, user: Any) -> None:
         """Categorias padrão devem ter os nomes esperados."""
         wedding, budget = _setup_budget(user)
 
@@ -389,7 +435,7 @@ class TestBudgetCategoryServiceSetupDefaults:
         }
         assert names == expected
 
-    def test_setup_defaults_allocated_budget_is_zero(self, user):
+    def test_setup_defaults_allocated_budget_is_zero(self, user: Any) -> None:
         """Categorias padrão são criadas com allocated_budget = 0."""
         wedding, budget = _setup_budget(user)
 
@@ -399,7 +445,7 @@ class TestBudgetCategoryServiceSetupDefaults:
         for cat in categories:
             assert cat.allocated_budget == Decimal("0.00")
 
-    def test_setup_defaults_is_idempotent(self, user):
+    def test_setup_defaults_is_idempotent(self, user: Any) -> None:
         """
         TOCTOU: setup_defaults() não duplica categorias quando chamado
         múltiplas vezes.

--- a/backend/apps/finances/tests/expenses/test_models.py
+++ b/backend/apps/finances/tests/expenses/test_models.py
@@ -1,19 +1,42 @@
 from decimal import Decimal
+from typing import Any, cast
 
 import pytest
 from django.core.exceptions import ValidationError
 
-from apps.finances.models import Expense
+from apps.finances.models import Budget, BudgetCategory, Expense, Installment
 from apps.finances.tests.factories import (
-    BudgetCategoryFactory,
-    BudgetFactory,
-    ExpenseFactory,
-    InstallmentFactory,
+    BudgetCategoryFactory as _BudgetCategoryFactory,
 )
-from apps.weddings.tests.factories import WeddingFactory
+from apps.finances.tests.factories import BudgetFactory as _BudgetFactory
+from apps.finances.tests.factories import ExpenseFactory as _ExpenseFactory
+from apps.finances.tests.factories import InstallmentFactory as _InstallmentFactory
+from apps.users.models import User
+from apps.weddings.models import Wedding
+from apps.weddings.tests.factories import WeddingFactory as _WeddingFactory
 
 
-def _setup_expense(user):
+def BudgetCategoryFactory(*args: Any, **kwargs: Any) -> BudgetCategory:
+    return cast(BudgetCategory, _BudgetCategoryFactory(*args, **kwargs))
+
+
+def BudgetFactory(*args: Any, **kwargs: Any) -> Budget:
+    return cast(Budget, _BudgetFactory(*args, **kwargs))
+
+
+def ExpenseFactory(*args: Any, **kwargs: Any) -> Expense:
+    return cast(Expense, _ExpenseFactory(*args, **kwargs))
+
+
+def InstallmentFactory(*args: Any, **kwargs: Any) -> Installment:
+    return cast(Installment, _InstallmentFactory(*args, **kwargs))
+
+
+def WeddingFactory(*args: Any, **kwargs: Any) -> Wedding:
+    return cast(Wedding, _WeddingFactory(*args, **kwargs))
+
+
+def _setup_expense(user: User) -> tuple[Wedding, BudgetCategory]:
     """Helper: cria wedding + budget + category no contexto do user."""
     wedding = WeddingFactory(user_context=user)
     budget = BudgetFactory(wedding=wedding)
@@ -21,7 +44,7 @@ def _setup_expense(user):
     return wedding, category
 
 
-def _make_expense(user, category, **kwargs):
+def _make_expense(user: User, category: BudgetCategory, **kwargs: Any) -> Expense:
     """Helper: cria expense vinculado ao wedding da categoria."""
     return ExpenseFactory(
         wedding=category.wedding, category=category, contract=None, **kwargs
@@ -32,7 +55,7 @@ def _make_expense(user, category, **kwargs):
 class TestExpenseModelMetadata:
     """Testes de representação e metadados do modelo Expense."""
 
-    def test_expense_ordering_by_created_at_descending(self, user):
+    def test_expense_ordering_by_created_at_descending(self, user: Any) -> None:
         """Ordenação padrão deve ser por -created_at (mais recente primeiro)."""
         _, category = _setup_expense(user)
         e1 = _make_expense(user, category, description="Despesa Antiga")
@@ -42,7 +65,7 @@ class TestExpenseModelMetadata:
         assert expenses[0] == e2
         assert expenses[1] == e1
 
-    def test_expense_str_representation(self, user):
+    def test_expense_str_representation(self, user: Any) -> None:
         """__str__ deve conter o nome da despesa."""
         _, category = _setup_expense(user)
         expense = _make_expense(user, category, name="Buffet Premium")
@@ -54,7 +77,7 @@ class TestExpenseModelMetadata:
 class TestExpenseToleranceZero:
     """Testes da regra de Tolerância Zero (ADR-010 / BR-F01)."""
 
-    def test_expense_clean_passes_when_sum_matches(self, user):
+    def test_expense_clean_passes_when_sum_matches(self, user: Any) -> None:
         """Soma das parcelas == actual_amount deve passar na validação."""
         _, category = _setup_expense(user)
         expense = _make_expense(user, category, actual_amount=Decimal("1000.00"))
@@ -71,7 +94,7 @@ class TestExpenseToleranceZero:
 
         expense.full_clean()
 
-    def test_expense_clean_fails_when_sum_mismatch(self, user):
+    def test_expense_clean_fails_when_sum_mismatch(self, user: Any) -> None:
         """Soma das parcelas != actual_amount deve levantar ValidationError."""
         _, category = _setup_expense(user)
         expense = _make_expense(user, category, actual_amount=Decimal("1000.00"))
@@ -88,13 +111,13 @@ class TestExpenseToleranceZero:
 
         assert "não bate" in str(exc_info.value).lower()
 
-    def test_expense_clean_passes_with_zero_actual_amount(self, user):
+    def test_expense_clean_passes_with_zero_actual_amount(self, user: Any) -> None:
         """Despesa com actual_amount = 0 deve passar (sem parcelas)."""
         _, category = _setup_expense(user)
         expense = _make_expense(user, category, actual_amount=Decimal("0.00"))
         expense.full_clean()
 
-    def test_expense_clean_when_no_installments(self, user):
+    def test_expense_clean_when_no_installments(self, user: Any) -> None:
         """Sem parcelas criadas e actual_amount > 0: soma = 0, deve falhar."""
         _, category = _setup_expense(user)
         expense = _make_expense(user, category, actual_amount=Decimal("500.00"))
@@ -104,7 +127,7 @@ class TestExpenseToleranceZero:
 
         assert "não bate" in str(exc_info.value).lower()
 
-    def test_expense_creation_skips_tolerance_validation(self, user):
+    def test_expense_creation_skips_tolerance_validation(self, user: Any) -> None:
         """Criação (primeiro save) não valida Tolerância Zero — gap intencional.
 
         O guard self.pk em Expense.clean() impede a validação durante o

--- a/backend/apps/finances/tests/expenses/test_services.py
+++ b/backend/apps/finances/tests/expenses/test_services.py
@@ -1,7 +1,7 @@
 from datetime import date
 from decimal import Decimal
 from types import SimpleNamespace
-from typing import no_type_check
+from typing import Any, cast, no_type_check
 from uuid import uuid4
 
 import pytest
@@ -11,20 +11,62 @@ from apps.core.exceptions import (
     DomainIntegrityError,
     ObjectNotFoundError,
 )
-from apps.finances.models import Expense, Installment
+from apps.finances.models import (
+    Budget,
+    BudgetCategory,
+    Expense,
+    Installment,
+)
 from apps.finances.schemas import ExpenseIn, ExpensePatchIn
 from apps.finances.services.expense_service import ExpenseService
 from apps.finances.tests.factories import (
-    BudgetCategoryFactory,
-    BudgetFactory,
-    ExpenseFactory,
-    InstallmentFactory,
+    BudgetCategoryFactory as _BudgetCategoryFactory,
 )
-from apps.users.tests.factories import UserFactory
-from apps.weddings.tests.factories import WeddingFactory
+from apps.finances.tests.factories import BudgetFactory as _BudgetFactory
+from apps.finances.tests.factories import ExpenseFactory as _ExpenseFactory
+from apps.finances.tests.factories import InstallmentFactory as _InstallmentFactory
+from apps.logistics.models import Contract, Supplier
+from apps.logistics.tests.factories import ContractFactory as _ContractFactory
+from apps.logistics.tests.factories import SupplierFactory as _SupplierFactory
+from apps.users.models import User
+from apps.users.tests.factories import UserFactory as _UserFactory
+from apps.weddings.models import Wedding
+from apps.weddings.tests.factories import WeddingFactory as _WeddingFactory
 
 
-def _setup_category(user):
+def BudgetCategoryFactory(*args: Any, **kwargs: Any) -> BudgetCategory:
+    return cast(BudgetCategory, _BudgetCategoryFactory(*args, **kwargs))
+
+
+def BudgetFactory(*args: Any, **kwargs: Any) -> Budget:
+    return cast(Budget, _BudgetFactory(*args, **kwargs))
+
+
+def ContractFactory(*args: Any, **kwargs: Any) -> Contract:
+    return cast(Contract, _ContractFactory(*args, **kwargs))
+
+
+def ExpenseFactory(*args: Any, **kwargs: Any) -> Expense:
+    return cast(Expense, _ExpenseFactory(*args, **kwargs))
+
+
+def InstallmentFactory(*args: Any, **kwargs: Any) -> Installment:
+    return cast(Installment, _InstallmentFactory(*args, **kwargs))
+
+
+def SupplierFactory(*args: Any, **kwargs: Any) -> Supplier:
+    return cast(Supplier, _SupplierFactory(*args, **kwargs))
+
+
+def UserFactory(*args: Any, **kwargs: Any) -> User:
+    return cast(User, _UserFactory(*args, **kwargs))
+
+
+def WeddingFactory(*args: Any, **kwargs: Any) -> Wedding:
+    return cast(Wedding, _WeddingFactory(*args, **kwargs))
+
+
+def _setup_category(user: User) -> BudgetCategory:
     """Helper: cria wedding + budget + category no contexto do user."""
     wedding = WeddingFactory(user_context=user)
     budget = BudgetFactory(wedding=wedding)
@@ -36,11 +78,11 @@ def _setup_category(user):
 class TestExpenseServiceCreate:
     """Testes de criação de despesas via ExpenseService."""
 
-    def test_create_expense_success(self, user):
+    def test_create_expense_success(self, user: Any) -> None:
         """Criação de despesa válida com categoria."""
         category = _setup_category(user)
 
-        data = {
+        data: dict[str, Any] = {
             "category": category.uuid,
             "name": "Buffet Premium",
             "description": "Buffet completo",
@@ -55,11 +97,11 @@ class TestExpenseServiceCreate:
         assert expense.name == "Buffet Premium"
         assert expense.actual_amount == Decimal("10000.00")
 
-    def test_create_expense_with_category_instance(self, user):
+    def test_create_expense_with_category_instance(self, user: Any) -> None:
         """create() aceita instância de BudgetCategory, não só UUID."""
         category = _setup_category(user)
 
-        data = {
+        data: dict[str, Any] = {
             "category": category.uuid,
             "name": "Fotografia",
             "estimated_amount": Decimal("5000.00"),
@@ -69,7 +111,7 @@ class TestExpenseServiceCreate:
         expense = ExpenseService.create(user.company, ExpenseIn(**data))
         assert expense.category == category
 
-    def test_create_expense_inherits_wedding_from_category(self, user):
+    def test_create_expense_inherits_wedding_from_category(self, user: Any) -> None:
         """Expense.wedding é injetado a partir da categoria."""
         category = _setup_category(user)
 
@@ -80,14 +122,15 @@ class TestExpenseServiceCreate:
                 name="Decoração",
                 estimated_amount=Decimal("3000.00"),
                 actual_amount=Decimal("3000.00"),
+                num_installments=None,
             ),
         )
 
         assert expense.wedding == category.wedding
 
-    def test_create_expense_category_not_found(self, user):
+    def test_create_expense_category_not_found(self, user: Any) -> None:
         """UUID de categoria inexistente levanta ObjectNotFoundError."""
-        data = {
+        data: dict[str, Any] = {
             "category": uuid4(),
             "name": "Fantasminha",
             "estimated_amount": Decimal("100.00"),
@@ -99,13 +142,13 @@ class TestExpenseServiceCreate:
 
         assert "budget_category_not_found_or_denied" in str(exc_info.value.code)
 
-    def test_create_expense_multitenancy(self):
+    def test_create_expense_multitenancy(self) -> None:
         """Usuário A não pode criar despesa com categoria do Usuário B."""
         user_a = UserFactory()
         user_b = UserFactory()
         category_b = _setup_category(user_b)
 
-        data = {
+        data: dict[str, Any] = {
             "category": category_b.uuid,
             "name": "Invasão",
             "estimated_amount": Decimal("1000.00"),
@@ -117,11 +160,11 @@ class TestExpenseServiceCreate:
 
         assert "budget_category_not_found_or_denied" in str(exc_info.value.code)
 
-    def test_create_expense_validation_error(self, user):
+    def test_create_expense_validation_error(self, user: Any) -> None:
         """Erro de negócio: num_installments < 1."""
         category = _setup_category(user)
 
-        data = {
+        data: dict[str, Any] = {
             "category": category.uuid,
             "name": "Buffet",
             "estimated_amount": Decimal("100.00"),
@@ -134,10 +177,10 @@ class TestExpenseServiceCreate:
 
         assert "invalid_installment_number" in str(exc_info.value.code)
 
-    def test_create_expense_defaults_to_one_installment(self, user):
+    def test_create_expense_defaults_to_one_installment(self, user: Any) -> None:
         """Sem informar parcelamento, gera 1 parcela com vencimento hoje."""
         category = _setup_category(user)
-        data = {
+        data: dict[str, Any] = {
             "category": category.uuid,
             "name": "Buffet",
             "estimated_amount": Decimal("1000.00"),
@@ -146,12 +189,14 @@ class TestExpenseServiceCreate:
 
         expense = ExpenseService.create(user.company, ExpenseIn(**data))
         assert expense.installments.count() == 1
-        assert expense.installments.first().due_date == date.today()
+        first = expense.installments.first()
+        assert first is not None
+        assert first.due_date == date.today()
 
-    def test_create_expense_amount_differs_from_contract_raises_error(self, user):
+    def test_create_expense_amount_differs_from_contract_raises_error(
+        self, user: Any
+    ) -> None:
         """BR-F02: despesa vinculada a contrato deve ter mesmo valor do contrato."""
-        from apps.logistics.tests.factories import ContractFactory, SupplierFactory
-
         category = _setup_category(user)
         supplier = SupplierFactory(company=user.company)
         contract = ContractFactory(
@@ -160,7 +205,7 @@ class TestExpenseServiceCreate:
             total_amount=Decimal("5000.00"),
         )
 
-        data = {
+        data: dict[str, Any] = {
             "category": category.uuid,
             "contract": contract.uuid,
             "name": "Despesa com contrato",
@@ -178,8 +223,6 @@ class TestExpenseServiceCreate:
         self, user
     ) -> None:
         """BR-L02: contrato e categoria devem pertencer ao mesmo casamento."""
-        from apps.logistics.tests.factories import ContractFactory, SupplierFactory
-
         category = _setup_category(user)
         other_category = _setup_category(user)
         supplier = SupplierFactory(company=user.company)
@@ -189,7 +232,7 @@ class TestExpenseServiceCreate:
             total_amount=Decimal("5000.00"),
         )
 
-        data = {
+        data: dict[str, Any] = {
             "category": category.uuid,
             "contract": contract.uuid,
             "name": "Despesa cross-wedding",
@@ -207,8 +250,6 @@ class TestExpenseServiceCreate:
         self,
     ) -> None:
         """Contrato pré-carregado de outro tenant deve ser rejeitado."""
-        from apps.logistics.tests.factories import ContractFactory, SupplierFactory
-
         user_a = UserFactory()
         user_b = UserFactory()
         category_a = _setup_category(user_a)
@@ -231,11 +272,11 @@ class TestExpenseServiceCreate:
 
         assert exc_info.value.code == "contract_not_found_or_denied"
 
-    def test_create_expense_triggers_tolerance_zero(self, user):
+    def test_create_expense_triggers_tolerance_zero(self, user: Any) -> None:
         """BR-F01: expense com actual_amount > 0 deve gerar parcelas que somam
         exatamente o valor total."""
         category = _setup_category(user)
-        data = {
+        data: dict[str, Any] = {
             "category": category.uuid,
             "name": "Tolerância Zero",
             "estimated_amount": Decimal("1000.00"),
@@ -255,7 +296,7 @@ class TestExpenseServiceCreate:
 class TestExpenseServiceUpdate:
     """Testes de atualização de despesas via ExpenseService."""
 
-    def test_update_expense_description(self, user):
+    def test_update_expense_description(self, user: Any) -> None:
         """Atualização de campos simples é permitida."""
         category = _setup_category(user)
         expense = ExpenseFactory(
@@ -272,12 +313,14 @@ class TestExpenseServiceUpdate:
         )
 
         updated = ExpenseService.update(
-            user.company, expense, ExpensePatchIn(description="Nova Descrição")
+            user.company,
+            expense,
+            ExpensePatchIn.model_construct(description="Nova Descrição"),
         )
 
         assert updated.description == "Nova Descrição"
 
-    def test_update_expense_partial_fields_only_name(self, user):
+    def test_update_expense_partial_fields_only_name(self, user: Any) -> None:
         """Atualização apenas do nome não redistribui parcelas nem falha."""
         category = _setup_category(user)
         expense = ExpenseFactory(
@@ -294,14 +337,16 @@ class TestExpenseServiceUpdate:
         )
 
         updated = ExpenseService.update(
-            user.company, expense, ExpensePatchIn(name="Nome Novo")
+            user.company,
+            expense,
+            ExpensePatchIn.model_construct(name="Nome Novo"),
         )
 
         assert updated.name == "Nome Novo"
         assert updated.actual_amount == Decimal("500.00")
         assert updated.installments.count() == 1
 
-    def test_update_expense_cross_tenant(self, user):
+    def test_update_expense_cross_tenant(self, user: Any) -> None:
         """Despesa de outro tenant não pode ser atualizada."""
         other_user = UserFactory()
         other_wedding = WeddingFactory(company=other_user.company)
@@ -318,10 +363,12 @@ class TestExpenseServiceUpdate:
 
         with pytest.raises(ObjectNotFoundError):
             ExpenseService.update(
-                user.company, other_expense, ExpensePatchIn(name="Hack")
+                user.company,
+                other_expense,
+                ExpensePatchIn.model_construct(name="Hack"),
             )
 
-    def test_update_expense_amount_with_installment_count(self, user):
+    def test_update_expense_amount_with_installment_count(self, user: Any) -> None:
         """Alterar actual_amount + especificar num_installments redistribui
         com o número informado."""
         category = _setup_category(user)
@@ -344,7 +391,7 @@ class TestExpenseServiceUpdate:
         updated = ExpenseService.update(
             user.company,
             expense,
-            ExpensePatchIn(
+            ExpensePatchIn.model_construct(
                 actual_amount=Decimal("900.00"),
                 num_installments=3,
                 first_due_date=date.today(),
@@ -356,7 +403,7 @@ class TestExpenseServiceUpdate:
         total = sum(i.amount for i in updated.installments.all())
         assert total == Decimal("900.00")
 
-    def test_update_amount_auto_redistribute(self, user):
+    def test_update_amount_auto_redistribute(self, user: Any) -> None:
         """Alterar actual_amount sem num_installments redistribui parcelas."""
         category = _setup_category(user)
         expense = ExpenseFactory(
@@ -374,14 +421,14 @@ class TestExpenseServiceUpdate:
         updated = ExpenseService.update(
             user.company,
             expense,
-            ExpensePatchIn(actual_amount=Decimal("1000.00")),
+            ExpensePatchIn.model_construct(actual_amount=Decimal("1000.00")),
         )
 
         assert updated.actual_amount == Decimal("1000.00")
         total = sum(i.amount for i in updated.installments.all())
         assert total == Decimal("1000.00")
 
-    def test_update_amount_blocked_by_paid(self, user):
+    def test_update_amount_blocked_by_paid(self, user: Any) -> None:
         """Alterar actual_amount com parcelas PAID levanta erro."""
         category = _setup_category(user)
         expense = ExpenseFactory(
@@ -402,7 +449,7 @@ class TestExpenseServiceUpdate:
             ExpenseService.update(
                 user.company,
                 expense,
-                ExpensePatchIn(actual_amount=Decimal("1000.00")),
+                ExpensePatchIn.model_construct(actual_amount=Decimal("1000.00")),
             )
         assert exc.value.code == "amount_change_blocked_by_paid"
 
@@ -411,8 +458,6 @@ class TestExpenseServiceUpdate:
         self, user
     ) -> None:
         """BR-L02: despesa não pode ser religada a contrato de outro casamento."""
-        from apps.logistics.tests.factories import ContractFactory, SupplierFactory
-
         category = _setup_category(user)
         other_category = _setup_category(user)
         supplier = SupplierFactory(company=user.company)
@@ -447,8 +492,6 @@ class TestExpenseServiceUpdate:
         self, user
     ) -> None:
         """Falha de tenant não deve trocar o contrato em memória."""
-        from apps.logistics.tests.factories import ContractFactory, SupplierFactory
-
         category = _setup_category(user)
         supplier = SupplierFactory(company=user.company)
         current_contract = ContractFactory(wedding=category.wedding, supplier=supplier)
@@ -478,7 +521,7 @@ class TestExpenseServiceUpdate:
 class TestExpenseServiceListAndGet:
     """Testes de listagem e obtenção de despesas."""
 
-    def test_list_expenses_multitenancy(self):
+    def test_list_expenses_multitenancy(self) -> None:
         """list() retorna apenas despesas do tenant."""
         user_a = UserFactory()
         user_b = UserFactory()
@@ -500,13 +543,17 @@ class TestExpenseServiceListAndGet:
 
         qs_a = ExpenseService.list(user_a.company)
         assert qs_a.count() == 1
-        assert qs_a.first().company == user_a.company
+        first_a = qs_a.first()
+        assert first_a is not None
+        assert first_a.company == user_a.company
 
         qs_b = ExpenseService.list(user_b.company)
         assert qs_b.count() == 1
-        assert qs_b.first().company == user_b.company
+        first_b = qs_b.first()
+        assert first_b is not None
+        assert first_b.company == user_b.company
 
-    def test_list_expenses_filter_by_wedding(self, user):
+    def test_list_expenses_filter_by_wedding(self, user: Any) -> None:
         """list() com wedding_id filtra por casamento."""
         cat1 = _setup_category(user)
         cat2 = _setup_category(user)
@@ -517,7 +564,7 @@ class TestExpenseServiceListAndGet:
         qs = ExpenseService.list(user.company, wedding_id=cat1.wedding.uuid)
         assert qs.count() == 1
 
-    def test_get_expense_success(self, user):
+    def test_get_expense_success(self, user: Any) -> None:
         """get() retorna despesa por UUID com select_related."""
         category = _setup_category(user)
         expense = ExpenseFactory(
@@ -531,12 +578,12 @@ class TestExpenseServiceListAndGet:
         assert result.uuid == expense.uuid
         assert result.category == expense.category
 
-    def test_get_expense_not_found(self, user):
+    def test_get_expense_not_found(self, user: Any) -> None:
         """UUID inexistente levanta ObjectNotFoundError."""
         with pytest.raises(ObjectNotFoundError):
             ExpenseService.get(user.company, uuid4())
 
-    def test_get_expense_multitenancy(self):
+    def test_get_expense_multitenancy(self) -> None:
         """Usuário A não pode acessar despesa do Usuário B."""
         user_a = UserFactory()
         user_b = UserFactory()
@@ -550,7 +597,7 @@ class TestExpenseServiceListAndGet:
         with pytest.raises(ObjectNotFoundError):
             ExpenseService.get(user_a.company, expense_b.uuid)
 
-    def test_get_expense_by_installment_uuid_fallback(self, user):
+    def test_get_expense_by_installment_uuid_fallback(self, user: Any) -> None:
         """Passar UUID da parcela retorna a despesa pai correspondente."""
         category = _setup_category(user)
         expense = ExpenseFactory(
@@ -573,7 +620,7 @@ class TestExpenseServiceListAndGet:
 class TestExpenseServiceDelete:
     """Testes de deleção de despesas via ExpenseService."""
 
-    def test_delete_expense_success(self, user, make_expense):
+    def test_delete_expense_success(self, user: Any, make_expense: Any) -> None:
         """Deleção de despesa existente é permitida."""
         expense = make_expense()
 
@@ -582,10 +629,8 @@ class TestExpenseServiceDelete:
         with pytest.raises(ObjectNotFoundError):
             ExpenseService.get(user.company, expense.uuid)
 
-    def test_delete_expense_with_contract_is_allowed(self, user):
+    def test_delete_expense_with_contract_is_allowed(self, user: Any) -> None:
         """Excluir despesa vinculada a contrato é permitido."""
-        from apps.logistics.tests.factories import ContractFactory, SupplierFactory
-
         category = _setup_category(user)
         supplier = SupplierFactory(company=user.company)
         contract = ContractFactory(wedding=category.wedding, supplier=supplier)
@@ -601,7 +646,7 @@ class TestExpenseServiceDelete:
         with pytest.raises(Expense.DoesNotExist):
             Expense.objects.get(uuid=expense.uuid)
 
-    def test_delete_expense_cross_tenant(self, user):
+    def test_delete_expense_cross_tenant(self, user: Any) -> None:
         """Despesa de outro tenant não pode ser deletada."""
 
         other_user = UserFactory()
@@ -626,10 +671,8 @@ class TestExpenseServiceFromDocument:
     """Testes de criação de despesa a partir de contrato
     via ExpenseService.from_document()."""
 
-    def test_from_document_success(self, user):
+    def test_from_document_success(self, user: Any) -> None:
         """from_document() retorna dict com dados do contrato."""
-        from apps.logistics.tests.factories import ContractFactory, SupplierFactory
-
         wedding = WeddingFactory(company=user.company)
         supplier = SupplierFactory(company=user.company)
         contract = ContractFactory(
@@ -648,15 +691,13 @@ class TestExpenseServiceFromDocument:
         assert result["num_installments"] is None
         assert result["first_due_date"] is None
 
-    def test_from_document_contract_not_found(self, user):
+    def test_from_document_contract_not_found(self, user: Any) -> None:
         """UUID de contrato inexistente levanta ObjectNotFoundError."""
         with pytest.raises(ObjectNotFoundError):
             ExpenseService.from_document(user.company, uuid4())
 
-    def test_from_document_multitenancy(self, user):
+    def test_from_document_multitenancy(self, user: Any) -> None:
         """Usuário A não pode acessar contrato do Usuário B."""
-        from apps.logistics.tests.factories import ContractFactory, SupplierFactory
-
         user_b = UserFactory()
         wedding_b = WeddingFactory(company=user_b.company)
         supplier_b = SupplierFactory(company=user_b.company)
@@ -676,10 +717,8 @@ class TestExpenseServiceFromDocument:
 class TestExpenseServiceContractIntegration:
     """Testes de integração com Contract no ExpenseService."""
 
-    def test_create_expense_with_contract_uuid(self, user):
+    def test_create_expense_with_contract_uuid(self, user: Any) -> None:
         """Criação de despesa vinculada a contrato via UUID."""
-        from apps.logistics.tests.factories import ContractFactory, SupplierFactory
-
         category = _setup_category(user)
         supplier = SupplierFactory(company=user.company)
         contract = ContractFactory(
@@ -688,7 +727,7 @@ class TestExpenseServiceContractIntegration:
             total_amount=Decimal("5000.00"),
         )
 
-        data = {
+        data: dict[str, Any] = {
             "category": category.uuid,
             "contract": contract.uuid,
             "name": "Despesa com contrato",
@@ -701,10 +740,8 @@ class TestExpenseServiceContractIntegration:
         assert expense.contract == contract
         assert expense.wedding == category.wedding
 
-    def test_create_expense_with_contract_instance(self, user):
+    def test_create_expense_with_contract_instance(self, user: Any) -> None:
         """Criação de despesa vinculada a contrato via instância."""
-        from apps.logistics.tests.factories import ContractFactory, SupplierFactory
-
         category = _setup_category(user)
         supplier = SupplierFactory(company=user.company)
         contract = ContractFactory(
@@ -712,7 +749,7 @@ class TestExpenseServiceContractIntegration:
             supplier=supplier,
         )
 
-        data = {
+        data: dict[str, Any] = {
             "category": category.uuid,
             "contract": contract.uuid,
             "name": "Despesa com contrato",
@@ -723,10 +760,8 @@ class TestExpenseServiceContractIntegration:
         expense = ExpenseService.create(user.company, ExpenseIn(**data))
         assert expense.contract == contract
 
-    def test_update_expense_swap_contract(self, user):
+    def test_update_expense_swap_contract(self, user: Any) -> None:
         """Troca de contrato vinculado via update."""
-        from apps.logistics.tests.factories import ContractFactory, SupplierFactory
-
         category = _setup_category(user)
         supplier = SupplierFactory(company=user.company)
         contract1 = ContractFactory(wedding=category.wedding, supplier=supplier)
@@ -745,12 +780,14 @@ class TestExpenseServiceContractIntegration:
         )
 
         updated = ExpenseService.update(
-            user.company, expense, ExpensePatchIn(contract=contract2.uuid)
+            user.company,
+            expense,
+            ExpensePatchIn.model_construct(contract=contract2.uuid),
         )
 
         assert updated.contract == contract2
 
-    def test_update_expense_clear_contract(self, user):
+    def test_update_expense_clear_contract(self, user: Any) -> None:
         """Desvinculação de contrato (contract=None) via update."""
         from apps.logistics.tests.factories import ContractFactory, SupplierFactory
 
@@ -771,7 +808,9 @@ class TestExpenseServiceContractIntegration:
         )
 
         updated = ExpenseService.update(
-            user.company, expense, ExpensePatchIn(contract=None)
+            user.company,
+            expense,
+            ExpensePatchIn.model_construct(contract=None),
         )
 
         assert updated.contract is None
@@ -781,10 +820,10 @@ class TestExpenseServiceContractIntegration:
 class TestExpenseServiceInstallmentDistribution:
     """Testes de rateio de parcelas com valores quebrados."""
 
-    def test_create_expense_uneven_installments(self, user):
+    def test_create_expense_uneven_installments(self, user: Any) -> None:
         """R$ 100 / 3 deve criar parcelas que somam exatamente R$ 100."""
         category = _setup_category(user)
-        data = {
+        data: dict[str, Any] = {
             "category": category.uuid,
             "name": "Rateio Quebrado",
             "estimated_amount": Decimal("100.00"),
@@ -797,7 +836,7 @@ class TestExpenseServiceInstallmentDistribution:
         assert total == Decimal("100.00")
         assert expense.installments.count() == 3
 
-    def test_update_redistribute_invalid_number(self, user):
+    def test_update_redistribute_invalid_number(self, user: Any) -> None:
         """Redistribuir com num_installments < 1 levanta BusinessRuleViolation."""
         category = _setup_category(user)
         expense = ExpenseFactory(
@@ -814,7 +853,7 @@ class TestExpenseServiceInstallmentDistribution:
             ExpenseService.update(
                 user.company,
                 expense,
-                ExpensePatchIn(
+                ExpensePatchIn.model_construct(
                     actual_amount=Decimal("500.00"),
                     num_installments=0,
                 ),

--- a/backend/apps/finances/tests/installments/test_models.py
+++ b/backend/apps/finances/tests/installments/test_models.py
@@ -1,20 +1,43 @@
 from datetime import date, timedelta
 from decimal import Decimal
+from typing import Any, cast
 
 import pytest
 from django.core.exceptions import ValidationError
 
-from apps.finances.models import Installment
+from apps.finances.models import Budget, BudgetCategory, Expense, Installment
 from apps.finances.tests.factories import (
-    BudgetCategoryFactory,
-    BudgetFactory,
-    ExpenseFactory,
-    InstallmentFactory,
+    BudgetCategoryFactory as _BudgetCategoryFactory,
 )
-from apps.weddings.tests.factories import WeddingFactory
+from apps.finances.tests.factories import BudgetFactory as _BudgetFactory
+from apps.finances.tests.factories import ExpenseFactory as _ExpenseFactory
+from apps.finances.tests.factories import InstallmentFactory as _InstallmentFactory
+from apps.users.models import User
+from apps.weddings.models import Wedding
+from apps.weddings.tests.factories import WeddingFactory as _WeddingFactory
 
 
-def _setup_expense(user, **kwargs):
+def BudgetCategoryFactory(*args: Any, **kwargs: Any) -> BudgetCategory:
+    return cast(BudgetCategory, _BudgetCategoryFactory(*args, **kwargs))
+
+
+def BudgetFactory(*args: Any, **kwargs: Any) -> Budget:
+    return cast(Budget, _BudgetFactory(*args, **kwargs))
+
+
+def ExpenseFactory(*args: Any, **kwargs: Any) -> Expense:
+    return cast(Expense, _ExpenseFactory(*args, **kwargs))
+
+
+def InstallmentFactory(*args: Any, **kwargs: Any) -> Installment:
+    return cast(Installment, _InstallmentFactory(*args, **kwargs))
+
+
+def WeddingFactory(*args: Any, **kwargs: Any) -> Wedding:
+    return cast(Wedding, _WeddingFactory(*args, **kwargs))
+
+
+def _setup_expense(user: User, **kwargs: Any) -> Expense:
     """Helper: cria wedding + budget + category + expense no contexto do user."""
     wedding = WeddingFactory(user_context=user)
     budget = BudgetFactory(wedding=wedding)
@@ -26,7 +49,7 @@ def _setup_expense(user, **kwargs):
 class TestInstallmentModelMetadata:
     """Testes de representação e metadados do modelo Installment."""
 
-    def test_installment_str_representation(self, user):
+    def test_installment_str_representation(self, user: Any) -> None:
         """__str__ deve conter número da parcela, descrição da despesa e status."""
         expense = _setup_expense(
             user, description="Buffet Premium", actual_amount=Decimal("500.00")
@@ -45,7 +68,7 @@ class TestInstallmentModelMetadata:
         assert "Buffet Premium" in result
         assert "PENDING" in result
 
-    def test_installment_ordering_by_due_date(self, user):
+    def test_installment_ordering_by_due_date(self, user: Any) -> None:
         """Ordenação padrão deve ser por due_date ascendente."""
         expense = _setup_expense(user, actual_amount=Decimal("1500.00"))
 
@@ -71,7 +94,7 @@ class TestInstallmentModelMetadata:
         installments = list(expense.installments.all())
         assert installments == [i2, i1, i3]
 
-    def test_installment_unique_expense_and_number(self, user):
+    def test_installment_unique_expense_and_number(self, user: Any) -> None:
         """Não pode haver duas parcelas com mesmo número para a mesma despesa."""
         expense = _setup_expense(user, actual_amount=Decimal("500.00"))
 
@@ -91,7 +114,7 @@ class TestInstallmentModelMetadata:
 class TestInstallmentStatusConsistency:
     """Testes de consistência paid_date ↔ status (BR-F03)."""
 
-    def _make_installment(self, user, **kwargs):
+    def _make_installment(self, user: User, **kwargs: Any) -> Installment:
         """Helper: cria expense + constrói installment em memória."""
         expense = _setup_expense(
             user,
@@ -108,7 +131,7 @@ class TestInstallmentStatusConsistency:
             status=kwargs.get("status", Installment.StatusChoices.PENDING),
         )
 
-    def test_paid_date_requires_paid_status(self, user):
+    def test_paid_date_requires_paid_status(self, user: Any) -> None:
         """Parcela com paid_date preenchida deve ter status PAID."""
         installment = self._make_installment(
             user,
@@ -121,7 +144,7 @@ class TestInstallmentStatusConsistency:
 
         assert "PAGO" in str(exc_info.value).upper()
 
-    def test_paid_status_requires_paid_date(self, user):
+    def test_paid_status_requires_paid_date(self, user: Any) -> None:
         """Parcela com status PAID deve ter paid_date preenchida."""
         installment = self._make_installment(
             user,
@@ -134,7 +157,7 @@ class TestInstallmentStatusConsistency:
 
         assert "data de pagamento" in str(exc_info.value).lower()
 
-    def test_overdue_with_paid_date_fails(self, user):
+    def test_overdue_with_paid_date_fails(self, user: Any) -> None:
         """Parcela com paid_date preenchida deve ter status PAID, não OVERDUE."""
         installment = self._make_installment(
             user,
@@ -145,7 +168,7 @@ class TestInstallmentStatusConsistency:
         with pytest.raises(ValidationError):
             installment.full_clean()
 
-    def test_pending_without_paid_date_passes(self, user):
+    def test_pending_without_paid_date_passes(self, user: Any) -> None:
         """Parcela PENDING sem paid_date é válida."""
         installment = self._make_installment(
             user,
@@ -155,7 +178,7 @@ class TestInstallmentStatusConsistency:
         )
         installment.full_clean()
 
-    def test_paid_with_paid_date_passes(self, user):
+    def test_paid_with_paid_date_passes(self, user: Any) -> None:
         """Parcela PAID com paid_date é válida."""
         installment = self._make_installment(
             user,
@@ -170,7 +193,7 @@ class TestInstallmentStatusConsistency:
 class TestInstallmentAmountValidator:
     """Testes de validação do valor da parcela."""
 
-    def test_installment_amount_negative_fails(self, user):
+    def test_installment_amount_negative_fails(self, user: Any) -> None:
         """Valor negativo deve levantar ValidationError."""
         expense = _setup_expense(user, actual_amount=Decimal("500.00"))
         installment = Installment(

--- a/backend/apps/finances/tests/installments/test_services.py
+++ b/backend/apps/finances/tests/installments/test_services.py
@@ -1,6 +1,6 @@
 from datetime import date, timedelta
 from decimal import Decimal
-from typing import no_type_check
+from typing import Any, cast
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -11,21 +11,53 @@ from apps.core.exceptions import (
     DomainIntegrityError,
     ObjectNotFoundError,
 )
-from apps.finances.models import Installment
+from apps.finances.models import Budget, BudgetCategory, Expense, Installment
 from apps.finances.schemas import InstallmentAdjustIn, InstallmentIn, InstallmentPatchIn
 from apps.finances.services.installment_service import InstallmentService
 from apps.finances.tests.factories import (
-    BudgetCategoryFactory,
-    BudgetFactory,
-    ExpenseFactory,
-    InstallmentFactory,
+    BudgetCategoryFactory as _BudgetCategoryFactory,
+)
+from apps.finances.tests.factories import (
+    BudgetFactory as _BudgetFactory,
+)
+from apps.finances.tests.factories import (
+    ExpenseFactory as _ExpenseFactory,
+)
+from apps.finances.tests.factories import (
+    InstallmentFactory as _InstallmentFactory,
 )
 from apps.scheduler.models import Event
-from apps.users.tests.factories import UserFactory
-from apps.weddings.tests.factories import WeddingFactory
+from apps.users.models import User
+from apps.users.tests.factories import UserFactory as _UserFactory
+from apps.weddings.models import Wedding
+from apps.weddings.tests.factories import WeddingFactory as _WeddingFactory
 
 
-def _setup_expense(user, **kwargs):
+def BudgetCategoryFactory(*args: Any, **kwargs: Any) -> BudgetCategory:
+    return cast(BudgetCategory, _BudgetCategoryFactory(*args, **kwargs))
+
+
+def BudgetFactory(*args: Any, **kwargs: Any) -> Budget:
+    return cast(Budget, _BudgetFactory(*args, **kwargs))
+
+
+def ExpenseFactory(*args: Any, **kwargs: Any) -> Expense:
+    return cast(Expense, _ExpenseFactory(*args, **kwargs))
+
+
+def InstallmentFactory(*args: Any, **kwargs: Any) -> Installment:
+    return cast(Installment, _InstallmentFactory(*args, **kwargs))
+
+
+def UserFactory(*args: Any, **kwargs: Any) -> User:
+    return cast(User, _UserFactory(*args, **kwargs))
+
+
+def WeddingFactory(*args: Any, **kwargs: Any) -> Wedding:
+    return cast(Wedding, _WeddingFactory(*args, **kwargs))
+
+
+def _setup_expense(user: User, **kwargs: Any) -> Expense:
     """Helper: cria wedding + budget + category + expense no contexto do user."""
     wedding = WeddingFactory(user_context=user)
     budget = BudgetFactory(wedding=wedding)
@@ -40,11 +72,11 @@ def _setup_expense(user, **kwargs):
 class TestInstallmentServiceCreate:
     """Testes de criação de parcelas via InstallmentService."""
 
-    def test_create_installment_success(self, user):
+    def test_create_installment_success(self, user: User) -> None:
         """Criação de parcela com valor compatível com a despesa."""
         expense = _setup_expense(user, actual_amount=Decimal("1000.00"))
 
-        data = {
+        data: dict[str, Any] = {
             "expense": expense.uuid,
             "installment_number": 1,
             "amount": Decimal("1000.00"),
@@ -58,11 +90,11 @@ class TestInstallmentServiceCreate:
         assert installment.amount == Decimal("1000.00")
         assert installment.status == Installment.StatusChoices.PENDING
 
-    def test_create_installment_with_expense_instance(self, user):
+    def test_create_installment_with_expense_instance(self, user: User) -> None:
         """create() aceita instância de Expense, não só UUID."""
         expense = _setup_expense(user, actual_amount=Decimal("500.00"))
 
-        data = {
+        data: dict[str, Any] = {
             "expense": expense.uuid,
             "installment_number": 1,
             "amount": Decimal("500.00"),
@@ -72,11 +104,11 @@ class TestInstallmentServiceCreate:
         installment = InstallmentService.create(user.company, InstallmentIn(**data))
         assert installment.expense == expense
 
-    def test_create_installment_tolerance_zero_violation(self, user):
+    def test_create_installment_tolerance_zero_violation(self, user: User) -> None:
         """Tolerância Zero: soma != actual_amount levanta BusinessRuleViolation."""
         expense = _setup_expense(user, actual_amount=Decimal("1000.00"))
 
-        data = {
+        data: dict[str, Any] = {
             "expense": expense.uuid,
             "installment_number": 1,
             "amount": Decimal("999.99"),
@@ -88,7 +120,7 @@ class TestInstallmentServiceCreate:
 
         assert "expense_math_violation" in str(exc_info.value.code)
 
-    def test_create_installment_exact_sum_passes(self, user):
+    def test_create_installment_exact_sum_passes(self, user: User) -> None:
         """Duas parcelas que somam exatamente o actual_amount = Tolerância Zero ok.
         O service valida a soma ao final de cada criação. Para evitar violação
         no estado intermediário, criamos via factory."""
@@ -115,9 +147,9 @@ class TestInstallmentServiceCreate:
         total = sum(i.amount for i in expense.installments.all())
         assert total == Decimal("1000.00")
 
-    def test_create_installment_expense_not_found(self, user):
+    def test_create_installment_expense_not_found(self, user: User) -> None:
         """UUID de despesa inexistente deve levantar ObjectNotFoundError."""
-        data = {
+        data: dict[str, Any] = {
             "expense": uuid4(),
             "installment_number": 1,
             "amount": Decimal("100.00"),
@@ -129,13 +161,13 @@ class TestInstallmentServiceCreate:
 
         assert "expense_not_found_or_denied" in str(exc_info.value.code)
 
-    def test_create_installment_multitenancy_isolation(self):
+    def test_create_installment_multitenancy_isolation(self) -> None:
         """Usuário A não pode criar parcela em despesa do Usuário B."""
         user_a = UserFactory()
         user_b = UserFactory()
         expense_b = _setup_expense(user_b, actual_amount=Decimal("500.00"))
 
-        data = {
+        data: dict[str, Any] = {
             "expense": expense_b.uuid,
             "installment_number": 1,
             "amount": Decimal("500.00"),
@@ -152,13 +184,16 @@ class TestInstallmentServiceCreate:
 class TestInstallmentServiceAutoGeneration:
     """Testes de geração automática de parcelas."""
 
-    def test_auto_generate_installments_success(self, user):
+    def test_auto_generate_installments_success(self, user: User) -> None:
         """Sucesso: gera parcelas que somam exatamente o total da despesa."""
         expense = _setup_expense(user, actual_amount=Decimal("1000.00"))
         first_date = date.today() + timedelta(days=30)
 
-        installments = InstallmentService.auto_generate_installments(
-            user.company, expense, 3, first_date
+        installments = cast(
+            list[Installment],
+            InstallmentService.auto_generate_installments(
+                user.company, expense, 3, first_date
+            ),
         )
 
         assert len(installments) == 3
@@ -176,7 +211,7 @@ class TestInstallmentServiceAutoGeneration:
         total_sum = sum(i.amount for i in Installment.objects.filter(expense=expense))
         assert total_sum == Decimal("1000.00")
 
-    def test_auto_generate_installments_already_exists(self, user):
+    def test_auto_generate_installments_already_exists(self, user: User) -> None:
         """Bloqueia geração se despesa já possui parcelas."""
         expense = _setup_expense(user, actual_amount=Decimal("100.00"))
         InstallmentFactory(expense=expense, amount=Decimal("100.00"))
@@ -187,7 +222,7 @@ class TestInstallmentServiceAutoGeneration:
             )
         assert exc.value.code == "installments_already_exist"
 
-    def test_auto_generate_invalid_num_installments(self, user):
+    def test_auto_generate_invalid_num_installments(self, user: User) -> None:
         expense = _setup_expense(user, actual_amount=Decimal("100.00"))
         with pytest.raises(BusinessRuleViolation) as exc:
             InstallmentService.auto_generate_installments(
@@ -195,7 +230,7 @@ class TestInstallmentServiceAutoGeneration:
             )
         assert exc.value.code == "invalid_installment_number"
 
-    def test_auto_generate_invalid_expense_amount(self, user):
+    def test_auto_generate_invalid_expense_amount(self, user: User) -> None:
         expense = _setup_expense(user, actual_amount=Decimal("100.00"))
         # Burlar validação do model para forçar o erro no service
         expense.actual_amount = Decimal("0.00")
@@ -205,7 +240,7 @@ class TestInstallmentServiceAutoGeneration:
             )
         assert exc.value.code == "invalid_expense_amount"
 
-    def test_auto_generate_creates_payment_events(self, user):
+    def test_auto_generate_creates_payment_events(self, user: User) -> None:
         """BR-S01: auto_generate_installments cria eventos PAYMENT no scheduler."""
         expense = _setup_expense(
             user, actual_amount=Decimal("1500.00"), name="Buffet Infantil"
@@ -228,7 +263,7 @@ class TestInstallmentServiceAutoGeneration:
             assert event.company == user.company
             assert event.wedding == expense.wedding
 
-    def test_auto_generate_payment_event_values(self, user):
+    def test_auto_generate_payment_event_values(self, user: User) -> None:
         """Eventos PAYMENT contêm valor da parcela e nome da despesa."""
         expense = _setup_expense(user, actual_amount=Decimal("250.00"), name="Flores")
         first_date = date.today() + timedelta(days=15)
@@ -243,13 +278,16 @@ class TestInstallmentServiceAutoGeneration:
         assert "125.00" in events[0].description
         assert "Flores" in events[0].description
 
-    def test_auto_generate_single_installment(self, user):
+    def test_auto_generate_single_installment(self, user: User) -> None:
         """num_installments=1 cria uma unica parcela com o valor total."""
         expense = _setup_expense(user, actual_amount=Decimal("500.00"))
         first_date = date.today() + timedelta(days=30)
 
-        installments = InstallmentService.auto_generate_installments(
-            user.company, expense, 1, first_date
+        installments = cast(
+            list[Installment],
+            InstallmentService.auto_generate_installments(
+                user.company, expense, 1, first_date
+            ),
         )
 
         assert len(installments) == 1
@@ -263,7 +301,7 @@ class TestInstallmentServiceAutoGeneration:
 class TestInstallmentServiceUpdate:
     """Testes de atualização de parcelas via InstallmentService."""
 
-    def test_update_installment_amount(self, user):
+    def test_update_installment_amount(self, user: User) -> None:
         """Atualização de valor é permitida quando Tolerância Zero se mantém.
         Neste cenário: uma única parcela cobre 100% do valor, atualizar para
         o mesmo valor que a despesa mantém a integridade."""
@@ -284,7 +322,7 @@ class TestInstallmentServiceUpdate:
         )
         assert updated.amount == Decimal("1000.00")
 
-    def test_update_installment_tolerance_zero_violation(self, user):
+    def test_update_installment_tolerance_zero_violation(self, user: User) -> None:
         """Atualização que quebra Tolerância Zero levanta BusinessRuleViolation."""
         expense = _setup_expense(user, actual_amount=Decimal("1000.00"))
         i1 = InstallmentFactory(
@@ -298,7 +336,7 @@ class TestInstallmentServiceUpdate:
 
         assert "expense_math_violation" in str(exc_info.value.code)
 
-    def test_update_installment_due_date(self, user):
+    def test_update_installment_due_date(self, user: User) -> None:
         """Atualização de due_date é permitida para parcelas futuras."""
         expense = _setup_expense(user, actual_amount=Decimal("500.00"))
         installment = InstallmentFactory(
@@ -321,9 +359,8 @@ class TestInstallmentServiceUpdate:
             ("installment_number", 2),
         ],
     )
-    @no_type_check
     def test_update_paid_installment_protected_fields_blocked(
-        self, user, field, value
+        self, user: User, field: str, value: Any
     ) -> None:
         """BR-F06: parcela paga não permite alterar valor, vencimento ou número."""
         expense = _setup_expense(user, actual_amount=Decimal("500.00"))
@@ -339,13 +376,12 @@ class TestInstallmentServiceUpdate:
             InstallmentService.update(
                 user.company,
                 installment,
-                InstallmentPatchIn(**{field: value}),
+                InstallmentPatchIn.model_construct(**{field: value}),
             )
 
         assert exc_info.value.code == "paid_installment_immutable"
 
-    @no_type_check
-    def test_update_paid_installment_notes_allowed(self, user) -> None:
+    def test_update_paid_installment_notes_allowed(self, user: User) -> None:
         """BR-F06 protege campos contábeis, mas permite anotação operacional."""
         expense = _setup_expense(user, actual_amount=Decimal("500.00"))
         installment = InstallmentFactory(
@@ -364,7 +400,7 @@ class TestInstallmentServiceUpdate:
 
         assert updated.notes == "Comprovante conferido."
 
-    def test_update_installment_cross_tenant(self, user):
+    def test_update_installment_cross_tenant(self, user: User) -> None:
         """Parcela de outro tenant não pode ser atualizada."""
         other_user = UserFactory()
         other_wedding = WeddingFactory(company=other_user.company)
@@ -395,7 +431,7 @@ class TestInstallmentServiceUpdate:
 class TestInstallmentServiceDelete:
     """Testes de deleção de parcelas via InstallmentService."""
 
-    def test_delete_installment_tolerance_zero_violation(self, user):
+    def test_delete_installment_tolerance_zero_violation(self, user: User) -> None:
         """Deleção que quebra Tolerância Zero levanta DomainIntegrityError."""
         expense = _setup_expense(user, actual_amount=Decimal("1000.00"))
         installment = InstallmentFactory(
@@ -407,7 +443,7 @@ class TestInstallmentServiceDelete:
 
         assert "installment_deletion_math_error" in str(exc_info.value.code)
 
-    def test_delete_installment_when_sum_still_matches_passes(self, user):
+    def test_delete_installment_when_sum_still_matches_passes(self, user: User) -> None:
         """Deleção permitida se soma das restantes ainda fecha."""
         expense = _setup_expense(user, actual_amount=Decimal("1000.00"))
         InstallmentFactory(
@@ -421,14 +457,16 @@ class TestInstallmentServiceDelete:
 
         expense.refresh_from_db()
         assert expense.installments.count() == 1
-        assert expense.installments.first().amount == Decimal("1000.00")
+        remaining = expense.installments.first()
+        assert remaining is not None
+        assert remaining.amount == Decimal("1000.00")
 
 
 @pytest.mark.django_db
 class TestInstallmentServiceMarkAsPaid:
     """Testes de mark_as_paid e unmark_as_paid."""
 
-    def test_mark_as_paid_success(self, user):
+    def test_mark_as_paid_success(self, user: User) -> None:
         """Parcela PENDING é marcada como PAID com paid_date=today."""
         expense = _setup_expense(user, actual_amount=Decimal("500.00"))
         installment = InstallmentFactory(
@@ -441,7 +479,7 @@ class TestInstallmentServiceMarkAsPaid:
         assert result.status == Installment.StatusChoices.PAID
         assert result.paid_date == date.today()
 
-    def test_mark_as_paid_already_paid(self, user):
+    def test_mark_as_paid_already_paid(self, user: User) -> None:
         """Parcela já PAID levanta BusinessRuleViolation."""
         expense = _setup_expense(user, actual_amount=Decimal("500.00"))
         installment = InstallmentFactory(
@@ -455,7 +493,7 @@ class TestInstallmentServiceMarkAsPaid:
             InstallmentService.mark_as_paid(user.company, installment)
         assert exc.value.code == "installment_already_paid"
 
-    def test_mark_as_paid_tolerance_zero_intact(self, user):
+    def test_mark_as_paid_tolerance_zero_intact(self, user: User) -> None:
         """Tolerância Zero permanece válida após marcar como paga."""
         expense = _setup_expense(user, actual_amount=Decimal("500.00"))
         installment = InstallmentFactory(
@@ -467,7 +505,7 @@ class TestInstallmentServiceMarkAsPaid:
         expense.refresh_from_db()
         expense.full_clean()  # não deve lançar exceção
 
-    def test_unmark_as_paid_success(self, user):
+    def test_unmark_as_paid_success(self, user: User) -> None:
         """Parcela PAID é desmarcada voltando para PENDING."""
         expense = _setup_expense(user, actual_amount=Decimal("500.00"))
         installment = InstallmentFactory(
@@ -482,7 +520,7 @@ class TestInstallmentServiceMarkAsPaid:
         assert result.status == Installment.StatusChoices.PENDING
         assert result.paid_date is None
 
-    def test_unmark_as_paid_overdue(self, user):
+    def test_unmark_as_paid_overdue(self, user: User) -> None:
         """Parcela PAID vencida volta para OVERDUE."""
         from datetime import timedelta
 
@@ -500,7 +538,7 @@ class TestInstallmentServiceMarkAsPaid:
         assert result.status == Installment.StatusChoices.OVERDUE
         assert result.paid_date is None
 
-    def test_unmark_as_paid_not_paid(self, user):
+    def test_unmark_as_paid_not_paid(self, user: User) -> None:
         """Parcela não PAID levanta BusinessRuleViolation ao desmarcar."""
         expense = _setup_expense(user, actual_amount=Decimal("500.00"))
         installment = InstallmentFactory(
@@ -512,8 +550,7 @@ class TestInstallmentServiceMarkAsPaid:
             InstallmentService.unmark_as_paid(user.company, installment)
         assert exc.value.code == "installment_not_paid"
 
-    @no_type_check
-    def test_unmark_as_paid_math_violation(self, user):
+    def test_unmark_as_paid_math_violation(self, user: User) -> None:
         """Erro de validação ao desmarcar levanta BusinessRuleViolation."""
         from django.core.exceptions import ValidationError as DjangoValidationError
 
@@ -534,7 +571,7 @@ class TestInstallmentServiceMarkAsPaid:
 
         assert exc.value.code == "expense_math_violation"
 
-    def test_mark_as_paid_cross_tenant(self, user):
+    def test_mark_as_paid_cross_tenant(self, user: User) -> None:
         """Parcela de outro tenant não pode ser marcada como paga."""
         other_user = UserFactory()
         other_wedding = WeddingFactory(company=other_user.company)
@@ -556,8 +593,9 @@ class TestInstallmentServiceMarkAsPaid:
         with pytest.raises(ObjectNotFoundError):
             InstallmentService.mark_as_paid(user.company, other_installment)
 
-    @no_type_check
-    def test_mark_as_paid_tolerance_zero_violation(self, user, mocker):
+    def test_mark_as_paid_tolerance_zero_violation(
+        self, user: User, mocker: Any
+    ) -> None:
         """Marcação de parcela como paga que quebra Tolerância Zero levanta erro.
         Para forçar isso, simulamos um erro de validação (DjangoValidationError)
         durante o `full_clean()` da despesa na hora do mark_as_paid."""
@@ -579,8 +617,9 @@ class TestInstallmentServiceMarkAsPaid:
 
         assert exc.value.code == "expense_math_violation"
 
-    @no_type_check
-    def test_unmark_as_paid_tolerance_zero_violation(self, user, mocker):
+    def test_unmark_as_paid_tolerance_zero_violation(
+        self, user: User, mocker: Any
+    ) -> None:
         """Desmarcação de parcela que quebra Tolerância Zero levanta erro.
         Simulamos um erro de validação (DjangoValidationError) durante
         o `full_clean()` da despesa na hora do unmark_as_paid."""
@@ -604,7 +643,7 @@ class TestInstallmentServiceMarkAsPaid:
 
         assert exc.value.code == "expense_math_violation"
 
-    def test_unmark_as_paid_cross_tenant(self, user):
+    def test_unmark_as_paid_cross_tenant(self, user: User) -> None:
         """Parcela de outro tenant não pode ser desmarcada como paga."""
         other_user = UserFactory()
         other_wedding = WeddingFactory(company=other_user.company)
@@ -634,7 +673,7 @@ class TestInstallmentServiceMarkAsPaid:
 class TestInstallmentServiceRedistribute:
     """Testes de redistribuição de parcelas."""
 
-    def test_redistribute_success(self, user):
+    def test_redistribute_success(self, user: User) -> None:
         """Redistribui 3 parcelas para 5 com novo valor total."""
         expense = _setup_expense(user, actual_amount=Decimal("1500.00"))
         InstallmentService.auto_generate_installments(
@@ -644,18 +683,21 @@ class TestInstallmentServiceRedistribute:
             date.today(),
         )
 
-        result = InstallmentService.redistribute(
-            user.company,
-            expense,
-            5,
-            date.today(),
+        result = cast(
+            list[Installment],
+            InstallmentService.redistribute(
+                user.company,
+                expense,
+                5,
+                date.today(),
+            ),
         )
 
         assert len(result) == 5
         total = sum(r.amount for r in result)
         assert total == Decimal("1500.00")
 
-    def test_redistribute_reduce_installments(self, user):
+    def test_redistribute_reduce_installments(self, user: User) -> None:
         """Redistribui 5 parcelas para 2."""
         expense = _setup_expense(user, actual_amount=Decimal("1000.00"))
         InstallmentService.auto_generate_installments(
@@ -665,11 +707,14 @@ class TestInstallmentServiceRedistribute:
             date.today(),
         )
 
-        result = InstallmentService.redistribute(
-            user.company,
-            expense,
-            2,
-            date.today(),
+        result = cast(
+            list[Installment],
+            InstallmentService.redistribute(
+                user.company,
+                expense,
+                2,
+                date.today(),
+            ),
         )
 
         assert len(result) == 2
@@ -677,7 +722,7 @@ class TestInstallmentServiceRedistribute:
         assert total == Decimal("1000.00")
         assert expense.installments.count() == 2
 
-    def test_redistribute_blocked_by_paid(self, user):
+    def test_redistribute_blocked_by_paid(self, user: User) -> None:
         """Redistribuição bloqueada se há parcelas PAID."""
         expense = _setup_expense(user, actual_amount=Decimal("1000.00"))
         InstallmentService.auto_generate_installments(
@@ -687,6 +732,7 @@ class TestInstallmentServiceRedistribute:
             date.today(),
         )
         first = expense.installments.first()
+        assert first is not None
         first.status = Installment.StatusChoices.PAID
         first.paid_date = date.today()
         first.save()
@@ -700,7 +746,7 @@ class TestInstallmentServiceRedistribute:
             )
         assert exc.value.code == "redistribute_blocked_by_paid"
 
-    def test_redistribute_cleans_up_payment_events(self, user):
+    def test_redistribute_cleans_up_payment_events(self, user: User) -> None:
         """Redistribuir parcelas remove eventos PAYMENT antigos e cria novos."""
         from datetime import date as date_type
 
@@ -709,8 +755,11 @@ class TestInstallmentServiceRedistribute:
         expense = _setup_expense(
             user, actual_amount=Decimal("1000.00"), name="Buffet Teste"
         )
-        installments = InstallmentService.auto_generate_installments(
-            user.company, expense, 3, date_type.today()
+        installments = cast(
+            list[Installment],
+            InstallmentService.auto_generate_installments(
+                user.company, expense, 3, date_type.today()
+            ),
         )
 
         # Verify FK is set on created events
@@ -744,7 +793,7 @@ class TestInstallmentServiceRedistribute:
         assert old_events.count() == 2
         assert all("Parcela" in e.title for e in old_events)
 
-    def test_delete_installment_cleans_up_payment_event(self, user):
+    def test_delete_installment_cleans_up_payment_event(self, user: User) -> None:
         """Deletar parcela individual remove seu evento PAYMENT."""
         from datetime import date as date_type
 
@@ -753,8 +802,11 @@ class TestInstallmentServiceRedistribute:
         expense = _setup_expense(
             user, actual_amount=Decimal("500.00"), name="Flores Teste"
         )
-        installments = InstallmentService.auto_generate_installments(
-            user.company, expense, 2, date_type.today()
+        installments = cast(
+            list[Installment],
+            InstallmentService.auto_generate_installments(
+                user.company, expense, 2, date_type.today()
+            ),
         )
 
         # Verify FK is set
@@ -783,7 +835,7 @@ class TestInstallmentServiceRedistribute:
 
         assert not SchedulerEvent.objects.filter(uuid=deleted_event_uuid).exists()
 
-    def test_delete_installment_cross_tenant(self, user):
+    def test_delete_installment_cross_tenant(self, user: User) -> None:
         """Parcela de outro tenant não pode ser deletada."""
         other_user = UserFactory()
         other_wedding = WeddingFactory(company=other_user.company)
@@ -810,7 +862,7 @@ class TestInstallmentServiceRedistribute:
 class TestInstallmentServiceAdjust:
     """Testes de ajuste de parcelas via InstallmentService.adjust()."""
 
-    def test_adjust_amount_success(self, user):
+    def test_adjust_amount_success(self, user: User) -> None:
         """Ajuste de valor de parcela pendente é permitido (soma mantida)."""
         expense = _setup_expense(user, actual_amount=Decimal("900.00"))
         InstallmentFactory(
@@ -832,7 +884,7 @@ class TestInstallmentServiceAdjust:
 
         assert result.amount == Decimal("400.00")
 
-    def test_adjust_due_date_success(self, user):
+    def test_adjust_due_date_success(self, user: User) -> None:
         """Ajuste de data de parcela pendente é permitido."""
         expense = _setup_expense(user, actual_amount=Decimal("500.00"))
         inst = InstallmentFactory(
@@ -849,7 +901,7 @@ class TestInstallmentServiceAdjust:
 
         assert result.due_date == new_date
 
-    def test_adjust_blocked_by_paid(self, user):
+    def test_adjust_blocked_by_paid(self, user: User) -> None:
         """Parcela PAID não pode ser ajustada."""
         expense = _setup_expense(user, actual_amount=Decimal("500.00"))
         inst = InstallmentFactory(
@@ -866,7 +918,7 @@ class TestInstallmentServiceAdjust:
             )
         assert exc.value.code == "adjustment_on_paid_installment"
 
-    def test_adjust_due_date_before_previous(self, user):
+    def test_adjust_due_date_before_previous(self, user: User) -> None:
         """Data anterior à parcela anterior é rejeitada."""
         expense = _setup_expense(user, actual_amount=Decimal("1000.00"))
         first_date = date.today() + timedelta(days=30)
@@ -891,7 +943,7 @@ class TestInstallmentServiceAdjust:
             )
         assert exc.value.code == "due_date_before_previous_installment"
 
-    def test_adjust_due_date_after_next(self, user):
+    def test_adjust_due_date_after_next(self, user: User) -> None:
         """Data posterior à parcela seguinte é rejeitada."""
         expense = _setup_expense(user, actual_amount=Decimal("1500.00"))
         first_date = date.today() + timedelta(days=30)
@@ -917,7 +969,7 @@ class TestInstallmentServiceAdjust:
             )
         assert exc.value.code == "due_date_after_next_installment"
 
-    def test_adjust_tolerance_zero_intact(self, user):
+    def test_adjust_tolerance_zero_intact(self, user: User) -> None:
         """Ajuste que quebra Tolerância Zero levanta BusinessRuleViolation."""
         expense = _setup_expense(user, actual_amount=Decimal("1000.00"))
         inst = InstallmentFactory(
@@ -937,7 +989,7 @@ class TestInstallmentServiceAdjust:
             )
         assert exc.value.code == "expense_math_violation"
 
-    def test_adjust_cross_tenant(self, user):
+    def test_adjust_cross_tenant(self, user: User) -> None:
         """Parcela de outro tenant não pode ser ajustada."""
         other_user = UserFactory()
         other_wedding = WeddingFactory(company=other_user.company)
@@ -968,7 +1020,7 @@ class TestInstallmentServiceAdjust:
 class TestInstallmentServiceListAndGet:
     """Testes de listagem e obtenção de parcelas."""
 
-    def test_list_installments_multitenancy(self):
+    def test_list_installments_multitenancy(self) -> None:
         """list() retorna apenas parcelas do tenant."""
         user_a = UserFactory()
         user_b = UserFactory()
@@ -980,14 +1032,19 @@ class TestInstallmentServiceListAndGet:
 
         qs_a = InstallmentService.list(user_a.company)
         assert qs_a.count() == 1
-        assert qs_a.first().expense.company == user_a.company
+        installment_a = qs_a.first()
+        assert installment_a is not None
+        assert installment_a.expense.company == user_a.company
 
         qs_b = InstallmentService.list(user_b.company)
         assert qs_b.count() == 1
-        assert qs_b.first().expense.company == user_b.company
+        installment_b = qs_b.first()
+        assert installment_b is not None
+        assert installment_b.expense.company == user_b.company
 
-    @no_type_check
-    def test_list_installments_filter_by_wedding_and_expense_id(self, user):
+    def test_list_installments_filter_by_wedding_and_expense_id(
+        self, user: User
+    ) -> None:
         """list() filtra por wedding_id e expense_id."""
         wedding1 = WeddingFactory(user_context=user)
         wedding2 = WeddingFactory(user_context=user)
@@ -1007,21 +1064,27 @@ class TestInstallmentServiceListAndGet:
         # Filtro por wedding_id
         qs_wedding = InstallmentService.list(user.company, wedding_id=wedding1.uuid)
         assert qs_wedding.count() == 1
-        assert qs_wedding.first().expense == expense1
+        installment_wedding = qs_wedding.first()
+        assert installment_wedding is not None
+        assert installment_wedding.expense == expense1
 
         # Filtro por expense_id
         qs_expense = InstallmentService.list(user.company, expense_id=expense2.uuid)
         assert qs_expense.count() == 1
-        assert qs_expense.first().expense == expense2
+        installment_expense = qs_expense.first()
+        assert installment_expense is not None
+        assert installment_expense.expense == expense2
 
         # Filtro por wedding_id e expense_id combinados
         qs_both = InstallmentService.list(
             user.company, wedding_id=wedding1.uuid, expense_id=expense1.uuid
         )
         assert qs_both.count() == 1
-        assert qs_both.first().expense == expense1
+        installment_both = qs_both.first()
+        assert installment_both is not None
+        assert installment_both.expense == expense1
 
-    def test_list_installments_filter_by_status(self, user):
+    def test_list_installments_filter_by_status(self, user: User) -> None:
         """list() com status filtra corretamente."""
         expense = _setup_expense(user, actual_amount=Decimal("1000.00"))
         InstallmentFactory(expense=expense, amount=Decimal("500.00"), status="PENDING")
@@ -1034,9 +1097,11 @@ class TestInstallmentServiceListAndGet:
 
         qs = InstallmentService.list(user.company, status="PAID")
         assert qs.count() == 1
-        assert qs.first().status == "PAID"
+        installment = qs.first()
+        assert installment is not None
+        assert installment.status == "PAID"
 
-    def test_list_installments_filter_by_due_date_gte(self, user):
+    def test_list_installments_filter_by_due_date_gte(self, user: User) -> None:
         """list() com due_date_gte filtra corretamente."""
         expense = _setup_expense(user, actual_amount=Decimal("1000.00"))
         InstallmentFactory(expense=expense, due_date=date(2026, 1, 1))
@@ -1044,9 +1109,11 @@ class TestInstallmentServiceListAndGet:
 
         qs = InstallmentService.list(user.company, due_date_gte=date(2026, 3, 1))
         assert qs.count() == 1
-        assert qs.first().due_date == date(2026, 6, 1)
+        installment = qs.first()
+        assert installment is not None
+        assert installment.due_date == date(2026, 6, 1)
 
-    def test_list_installments_filter_by_due_date_lte(self, user):
+    def test_list_installments_filter_by_due_date_lte(self, user: User) -> None:
         """list() com due_date_lte filtra corretamente."""
         expense = _setup_expense(user, actual_amount=Decimal("1000.00"))
         InstallmentFactory(expense=expense, due_date=date(2026, 1, 1))
@@ -1054,9 +1121,13 @@ class TestInstallmentServiceListAndGet:
 
         qs = InstallmentService.list(user.company, due_date_lte=date(2026, 3, 1))
         assert qs.count() == 1
-        assert qs.first().due_date == date(2026, 1, 1)
+        installment = qs.first()
+        assert installment is not None
+        assert installment.due_date == date(2026, 1, 1)
 
-    def test_list_installments_filter_by_status_and_date_range(self, user):
+    def test_list_installments_filter_by_status_and_date_range(
+        self, user: User
+    ) -> None:
         """list() combina status + date range."""
         expense = _setup_expense(user, actual_amount=Decimal("2000.00"))
         InstallmentFactory(expense=expense, due_date=date(2026, 1, 1), status="PENDING")
@@ -1075,9 +1146,11 @@ class TestInstallmentServiceListAndGet:
             due_date_lte=date(2026, 7, 1),
         )
         assert qs.count() == 1
-        assert qs.first().due_date == date(2026, 6, 1)
+        installment = qs.first()
+        assert installment is not None
+        assert installment.due_date == date(2026, 6, 1)
 
-    def test_get_installment_success(self, user):
+    def test_get_installment_success(self, user: User) -> None:
         """get() retorna parcela por UUID com select_related."""
         expense = _setup_expense(user, actual_amount=Decimal("500.00"))
         installment = InstallmentFactory(expense=expense, amount=Decimal("500.00"))
@@ -1086,14 +1159,14 @@ class TestInstallmentServiceListAndGet:
         assert result.uuid == installment.uuid
         assert result.expense == expense
 
-    def test_get_installment_not_found(self, user):
+    def test_get_installment_not_found(self, user: User) -> None:
         """UUID inexistente levanta ObjectNotFoundError."""
         with pytest.raises(ObjectNotFoundError) as exc_info:
             InstallmentService.get(user.company, uuid4())
 
         assert str(exc_info.value.detail) == "Parcela não encontrada."
 
-    def test_get_installment_multitenancy(self):
+    def test_get_installment_multitenancy(self) -> None:
         """Usuário A não pode acessar parcela do Usuário B."""
         user_a = UserFactory()
         user_b = UserFactory()

--- a/backend/apps/finances/tests/test_apis.py
+++ b/backend/apps/finances/tests/test_apis.py
@@ -1,5 +1,6 @@
 from datetime import date
 from decimal import Decimal
+from typing import Any, cast
 from uuid import uuid4
 
 import pytest
@@ -7,22 +8,43 @@ import pytest
 from apps.finances.schemas import ExpenseIn
 from apps.finances.services.budget_service import BudgetService
 from apps.finances.services.expense_service import ExpenseService
-from apps.logistics.tests.factories import ContractFactory, SupplierFactory
+from apps.logistics.models import Contract, Supplier
+from apps.logistics.tests.factories import ContractFactory as _ContractFactory
+from apps.logistics.tests.factories import SupplierFactory as _SupplierFactory
+from apps.users.models import User
+from apps.users.tests.factories import UserFactory as _UserFactory
 from apps.weddings.schemas import WeddingIn
 from apps.weddings.services import WeddingService
 
 
+def ContractFactory(*args: Any, **kwargs: Any) -> Contract:
+    return cast(Contract, _ContractFactory(*args, **kwargs))
+
+
+def SupplierFactory(*args: Any, **kwargs: Any) -> Supplier:
+    return cast(Supplier, _SupplierFactory(*args, **kwargs))
+
+
+def UserFactory(*args: Any, **kwargs: Any) -> User:
+    return cast(User, _UserFactory(*args, **kwargs))
+
+
 @pytest.fixture
-def seed_data(user, django_user_model):
+def seed_data(user: Any, django_user_model: Any) -> dict[str, Any]:
     # Planner alvo
     my_wedding = WeddingService.create(
         user.company,
         WeddingIn(
-            bride_name="Minha", groom_name="Noz", location="A", date=date(2026, 10, 11)
+            bride_name="Minha",
+            groom_name="Noz",
+            location="A",
+            date=date(2026, 10, 11),
+            template="civil_buffet_3m",
         ),
     )
     my_budget = BudgetService.get_or_create_for_wedding(user.company, my_wedding.uuid)
     my_category = my_budget.categories.first()
+    assert my_category is not None
     my_expense = ExpenseService.create(
         user.company,
         ExpenseIn(
@@ -30,12 +52,11 @@ def seed_data(user, django_user_model):
             name="Despesa A",
             estimated_amount=Decimal("100.00"),
             actual_amount=Decimal("100.00"),
+            num_installments=None,
         ),
     )
 
     # Planner alheio
-    from apps.users.tests.factories import UserFactory
-
     other_user = UserFactory(email="b@b.com")
     other_user.set_password("123")
     other_user.save()
@@ -47,12 +68,14 @@ def seed_data(user, django_user_model):
             groom_name="Alheio",
             location="B",
             date=date(2026, 10, 11),
+            template="civil_buffet_3m",
         ),
     )
     other_budget = BudgetService.get_or_create_for_wedding(
         other_user.company, other_wedding.uuid
     )
     other_category = other_budget.categories.first()
+    assert other_category is not None
     ExpenseService.create(
         other_user.company,
         ExpenseIn(
@@ -60,6 +83,7 @@ def seed_data(user, django_user_model):
             name="Despesa B",
             estimated_amount=Decimal("200.00"),
             actual_amount=Decimal("200.00"),
+            num_installments=None,
         ),
     )
 
@@ -72,7 +96,7 @@ def seed_data(user, django_user_model):
 
 @pytest.mark.django_db
 class TestFinancesNinjaAPI:
-    def test_list_budgets_isolation(self, auth_client, seed_data):
+    def test_list_budgets_isolation(self, auth_client: Any, seed_data: Any) -> None:
         response = auth_client.get("/api/v1/finances/budgets/")
         assert response.status_code == 200
         data = response.json()
@@ -80,28 +104,30 @@ class TestFinancesNinjaAPI:
         assert data["items"][0]["uuid"] == str(seed_data["my_budget"].uuid)
         assert data["items"][0]["total_estimated"] == "0.00"
 
-    def test_list_categories_isolation(self, auth_client, seed_data):
+    def test_list_categories_isolation(self, auth_client: Any, seed_data: Any) -> None:
         response = auth_client.get("/api/v1/finances/categories/")
         assert response.status_code == 200
         data = response.json()
         assert len(data["items"]) == 6
 
-    def test_list_expenses_isolation(self, auth_client, seed_data):
+    def test_list_expenses_isolation(self, auth_client: Any, seed_data: Any) -> None:
         response = auth_client.get("/api/v1/finances/expenses/")
         assert response.status_code == 200
         data = response.json()
         assert len(data["items"]) == 1
         assert data["items"][0]["name"] == "Despesa A"
 
-    def test_list_installments_isolation(self, auth_client, seed_data):
+    def test_list_installments_isolation(
+        self, auth_client: Any, seed_data: Any
+    ) -> None:
         response = auth_client.get("/api/v1/finances/installments/")
         assert response.status_code == 200
         data = response.json()
         assert len(data["items"]) == 1  # 1 parcela auto-gerada (min 1)
 
     def test_update_expense_returns_422_on_business_rule_violation(
-        self, auth_client, seed_data
-    ):
+        self, auth_client: Any, seed_data: Any
+    ) -> None:
         expense_uuid = seed_data["my_expense"].uuid
 
         response = auth_client.patch(
@@ -112,7 +138,7 @@ class TestFinancesNinjaAPI:
 
         assert response.status_code == 422
 
-    def test_update_budget_success(self, auth_client, seed_data):
+    def test_update_budget_success(self, auth_client: Any, seed_data: Any) -> None:
         """PATCH orçamento — altera total_estimated com sucesso."""
         response = auth_client.patch(
             f"/api/v1/finances/budgets/{seed_data['my_budget'].uuid}/",
@@ -122,7 +148,7 @@ class TestFinancesNinjaAPI:
         assert response.status_code == 200
         assert response.json()["total_estimated"] == "50000.00"
 
-    def test_create_category_success(self, auth_client, seed_data):
+    def test_create_category_success(self, auth_client: Any, seed_data: Any) -> None:
         """POST categoria — cria nova categoria no orçamento."""
         # Aumenta teto do orçamento primeiro (está em 0.00)
         auth_client.patch(
@@ -144,7 +170,7 @@ class TestFinancesNinjaAPI:
         assert response.status_code == 201, response.json()
         assert response.json()["name"] == "Buffet Extra"
 
-    def test_update_category_success(self, auth_client, seed_data):
+    def test_update_category_success(self, auth_client: Any, seed_data: Any) -> None:
         """PATCH categoria — altera nome com sucesso."""
         response = auth_client.patch(
             f"/api/v1/finances/categories/{seed_data['my_category'].uuid}/",
@@ -154,7 +180,7 @@ class TestFinancesNinjaAPI:
         assert response.status_code == 200
         assert response.json()["name"] == "Buffet Premium"
 
-    def test_delete_category_success(self, auth_client, seed_data):
+    def test_delete_category_success(self, auth_client: Any, seed_data: Any) -> None:
         """DELETE categoria — remove categoria recém-criada (sem despesas)."""
         # Aumenta teto do orçamento primeiro
         auth_client.patch(
@@ -178,7 +204,7 @@ class TestFinancesNinjaAPI:
         response = auth_client.delete(f"/api/v1/finances/categories/{new_uuid}/")
         assert response.status_code == 204
 
-    def test_update_expense_success(self, auth_client, seed_data):
+    def test_update_expense_success(self, auth_client: Any, seed_data: Any) -> None:
         """PATCH despesa — altera nome com sucesso."""
         response = auth_client.patch(
             f"/api/v1/finances/expenses/{seed_data['my_expense'].uuid}/",
@@ -188,7 +214,7 @@ class TestFinancesNinjaAPI:
         assert response.status_code == 200
         assert response.json()["name"] == "Despesa Atualizada"
 
-    def test_create_expense_success(self, auth_client, seed_data):
+    def test_create_expense_success(self, auth_client: Any, seed_data: Any) -> None:
         """POST despesa — cria com sucesso."""
         response = auth_client.patch(
             f"/api/v1/finances/budgets/{seed_data['my_budget'].uuid}/",
@@ -211,14 +237,16 @@ class TestFinancesNinjaAPI:
         assert response.status_code == 201
         assert response.json()["name"] == "Nova Despesa"
 
-    def test_delete_expense_success(self, auth_client, seed_data):
+    def test_delete_expense_success(self, auth_client: Any, seed_data: Any) -> None:
         """DELETE despesa — remove com sucesso."""
         response = auth_client.delete(
             f"/api/v1/finances/expenses/{seed_data['my_expense'].uuid}/",
         )
         assert response.status_code == 204
 
-    def test_mark_installment_as_paid_success(self, auth_client, seed_data):
+    def test_mark_installment_as_paid_success(
+        self, auth_client: Any, seed_data: Any
+    ) -> None:
         """POST marcar parcela como paga — status PAID."""
         installment = seed_data["my_expense"].installments.first()
         response = auth_client.post(
@@ -227,7 +255,9 @@ class TestFinancesNinjaAPI:
         assert response.status_code == 200
         assert response.json()["status"] == "PAID"
 
-    def test_unmark_installment_as_paid_success(self, auth_client, seed_data):
+    def test_unmark_installment_as_paid_success(
+        self, auth_client: Any, seed_data: Any
+    ) -> None:
         """POST desmarcar parcela como paga — status PENDING."""
         installment = seed_data["my_expense"].installments.first()
 
@@ -242,7 +272,7 @@ class TestFinancesNinjaAPI:
         )
         assert response.status_code == 200
 
-    def test_adjust_installment_success(self, auth_client, seed_data):
+    def test_adjust_installment_success(self, auth_client: Any, seed_data: Any) -> None:
         """PATCH ajustar parcela — altera valor com sucesso."""
         # Atualiza expense para 200 primeiro (Tolerância Zero exige soma = valor)
         auth_client.patch(
@@ -259,7 +289,7 @@ class TestFinancesNinjaAPI:
         assert response.status_code == 200
         assert response.json()["amount"] == "200.00"
 
-    def test_get_budget_for_wedding(self, auth_client, seed_data):
+    def test_get_budget_for_wedding(self, auth_client: Any, seed_data: Any) -> None:
         """GET orçamento por wedding_uuid — lazy-create."""
         wedding_uuid = seed_data["my_budget"].wedding.uuid
         response = auth_client.get(
@@ -268,7 +298,7 @@ class TestFinancesNinjaAPI:
         assert response.status_code == 200
         assert "total_estimated" in response.json()
 
-    def test_get_expense(self, auth_client, seed_data):
+    def test_get_expense(self, auth_client: Any, seed_data: Any) -> None:
         """GET despesa por UUID."""
         response = auth_client.get(
             f"/api/v1/finances/expenses/{seed_data['my_expense'].uuid}/"
@@ -276,14 +306,14 @@ class TestFinancesNinjaAPI:
         assert response.status_code == 200
         assert response.json()["name"] == "Despesa A"
 
-    def test_get_installment(self, auth_client, seed_data):
+    def test_get_installment(self, auth_client: Any, seed_data: Any) -> None:
         """GET parcela por UUID."""
         installment = seed_data["my_expense"].installments.first()
         response = auth_client.get(f"/api/v1/finances/installments/{installment.uuid}/")
         assert response.status_code == 200
         assert "amount" in response.json()
 
-    def test_from_document(self, auth_client, seed_data):
+    def test_from_document(self, auth_client: Any, seed_data: Any) -> None:
         """POST from-document — sugere payload de despesa a partir de contrato."""
         wedding = seed_data["my_budget"].wedding
         supplier = SupplierFactory(company=wedding.company)
@@ -296,7 +326,9 @@ class TestFinancesNinjaAPI:
         data = response.json()
         assert "description" in data
 
-    def test_mark_as_paid_already_paid_returns_422(self, auth_client, seed_data):
+    def test_mark_as_paid_already_paid_returns_422(
+        self, auth_client: Any, seed_data: Any
+    ) -> None:
         """Marcar parcela já paga deve retornar 422."""
         installment = seed_data["my_expense"].installments.first()
         auth_client.post(
@@ -307,7 +339,9 @@ class TestFinancesNinjaAPI:
         )
         assert response.status_code == 422
 
-    def test_unmark_as_paid_not_paid_returns_422(self, auth_client, seed_data):
+    def test_unmark_as_paid_not_paid_returns_422(
+        self, auth_client: Any, seed_data: Any
+    ) -> None:
         """Desmarcar parcela não paga deve retornar 422."""
         installment = seed_data["my_expense"].installments.first()
         response = auth_client.post(
@@ -315,7 +349,9 @@ class TestFinancesNinjaAPI:
         )
         assert response.status_code == 422
 
-    def test_adjust_paid_installment_returns_422(self, auth_client, seed_data):
+    def test_adjust_paid_installment_returns_422(
+        self, auth_client: Any, seed_data: Any
+    ) -> None:
         """Ajustar parcela já paga deve retornar 422 (BR-F06)."""
         installment = seed_data["my_expense"].installments.first()
         auth_client.post(
@@ -328,7 +364,9 @@ class TestFinancesNinjaAPI:
         )
         assert response.status_code == 422
 
-    def test_delete_category_with_expenses_returns_409(self, auth_client, seed_data):
+    def test_delete_category_with_expenses_returns_409(
+        self, auth_client: Any, seed_data: Any
+    ) -> None:
         """Deletar categoria com despesas ativas deve retornar 409."""
         response = auth_client.delete(
             f"/api/v1/finances/categories/{seed_data['my_category'].uuid}/",
@@ -338,14 +376,14 @@ class TestFinancesNinjaAPI:
 
 @pytest.mark.django_db
 class TestFinancesAPIErrorHandling:
-    def test_get_budget_not_found(self, auth_client):
+    def test_get_budget_not_found(self, auth_client: Any) -> None:
         response = auth_client.get(f"/api/v1/finances/budgets/{uuid4()}/")
         assert response.status_code == 404
 
-    def test_get_category_not_found(self, auth_client):
+    def test_get_category_not_found(self, auth_client: Any) -> None:
         response = auth_client.get(f"/api/v1/finances/categories/{uuid4()}/")
         assert response.status_code == 404
 
-    def test_get_expense_not_found(self, auth_client):
+    def test_get_expense_not_found(self, auth_client: Any) -> None:
         response = auth_client.get(f"/api/v1/finances/expenses/{uuid4()}/")
         assert response.status_code == 404

--- a/backend/apps/finances/tests/test_managers.py
+++ b/backend/apps/finances/tests/test_managers.py
@@ -1,5 +1,6 @@
 from datetime import date
 from decimal import Decimal
+from typing import Any, Protocol, cast
 
 import pytest
 
@@ -14,19 +15,29 @@ from apps.finances.tests.factories import (
 from apps.weddings.tests.factories import WeddingFactory
 
 
-def _setup_expense(user):
+class _ExpenseDetails(Protocol):
+    installments_count: int
+    paid_installments_count: int
+    total_paid: Decimal
+    total_pending: Decimal
+
+
+def _setup_expense(user: Any) -> tuple[Any, Expense]:
     wedding = WeddingFactory(user_context=user)
     budget = BudgetFactory(wedding=wedding)
     category = BudgetCategoryFactory(budget=budget, wedding=wedding)
-    expense = ExpenseFactory(
-        wedding=wedding, category=category, actual_amount=Decimal("1500.00")
+    expense = cast(
+        Expense,
+        ExpenseFactory(
+            wedding=wedding, category=category, actual_amount=Decimal("1500.00")
+        ),
     )
     return wedding, expense
 
 
 @pytest.mark.django_db
 class TestExpenseQuerySet:
-    def test_with_details_returns_expense_queryset(self, user):
+    def test_with_details_returns_expense_queryset(self, user: Any) -> None:
         _setup_expense(user)
 
         qs = Expense.objects.for_tenant(user.company).with_details()
@@ -34,7 +45,7 @@ class TestExpenseQuerySet:
         assert isinstance(qs, ExpenseQuerySet)
         assert qs.count() == 1
 
-    def test_with_details_counts_mixed_installment_statuses(self, user):
+    def test_with_details_counts_mixed_installment_statuses(self, user: Any) -> None:
         wedding, expense = _setup_expense(user)
         InstallmentFactory(
             expense=expense,
@@ -59,10 +70,13 @@ class TestExpenseQuerySet:
             status=Installment.StatusChoices.OVERDUE,
         )
 
-        result = (
-            Expense.objects.for_tenant(user.company)
-            .with_details()
-            .get(uuid=expense.uuid)
+        result = cast(
+            _ExpenseDetails,
+            (
+                Expense.objects.for_tenant(user.company)
+                .with_details()
+                .get(uuid=expense.uuid)
+            ),
         )
 
         assert result.installments_count == 3
@@ -70,7 +84,7 @@ class TestExpenseQuerySet:
         assert result.total_paid == Decimal("500.00")
         assert result.total_pending == Decimal("1000.00")
 
-    def test_with_details_all_paid(self, user):
+    def test_with_details_all_paid(self, user: Any) -> None:
         wedding, expense = _setup_expense(user)
         InstallmentFactory(
             expense=expense,
@@ -81,10 +95,13 @@ class TestExpenseQuerySet:
             paid_date=date.today(),
         )
 
-        result = (
-            Expense.objects.for_tenant(user.company)
-            .with_details()
-            .get(uuid=expense.uuid)
+        result = cast(
+            _ExpenseDetails,
+            (
+                Expense.objects.for_tenant(user.company)
+                .with_details()
+                .get(uuid=expense.uuid)
+            ),
         )
 
         assert result.installments_count == 1
@@ -92,7 +109,7 @@ class TestExpenseQuerySet:
         assert result.total_paid == Decimal("1000.00")
         assert result.total_pending == Decimal("0.00")
 
-    def test_with_details_all_pending(self, user):
+    def test_with_details_all_pending(self, user: Any) -> None:
         wedding, expense = _setup_expense(user)
         InstallmentFactory(
             expense=expense,
@@ -102,22 +119,28 @@ class TestExpenseQuerySet:
             status=Installment.StatusChoices.PENDING,
         )
 
-        result = (
-            Expense.objects.for_tenant(user.company)
-            .with_details()
-            .get(uuid=expense.uuid)
+        result = cast(
+            _ExpenseDetails,
+            (
+                Expense.objects.for_tenant(user.company)
+                .with_details()
+                .get(uuid=expense.uuid)
+            ),
         )
 
         assert result.total_paid == Decimal("0.00")
         assert result.total_pending == Decimal("1000.00")
 
-    def test_with_details_no_installments(self, user):
+    def test_with_details_no_installments(self, user: Any) -> None:
         _, expense = _setup_expense(user)
 
-        result = (
-            Expense.objects.for_tenant(user.company)
-            .with_details()
-            .get(uuid=expense.uuid)
+        result = cast(
+            _ExpenseDetails,
+            (
+                Expense.objects.for_tenant(user.company)
+                .with_details()
+                .get(uuid=expense.uuid)
+            ),
         )
 
         assert result.installments_count == 0

--- a/backend/apps/logistics/admin.py
+++ b/backend/apps/logistics/admin.py
@@ -4,7 +4,7 @@ from django.contrib import admin
 from .models import Contract, Item, Supplier
 
 
-class ItemInline(admin.TabularInline):
+class ItemInline(admin.TabularInline):  # type: ignore[type-arg]
     model = Item
     extra = 0
     fields = ["name", "quantity", "acquisition_status"]
@@ -12,7 +12,7 @@ class ItemInline(admin.TabularInline):
 
 
 @admin.register(Supplier)
-class SupplierAdmin(admin.ModelAdmin):
+class SupplierAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
     list_display = ["name", "phone", "email", "is_active"]
     list_filter = ["is_active", "created_at"]
     search_fields = ["name", "email"]
@@ -20,7 +20,7 @@ class SupplierAdmin(admin.ModelAdmin):
 
 
 @admin.register(Item)
-class ItemAdmin(admin.ModelAdmin):
+class ItemAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
     list_display = [
         "name",
         "wedding",
@@ -39,7 +39,7 @@ class ItemAdmin(admin.ModelAdmin):
 
 
 @admin.register(Contract)
-class ContractAdmin(admin.ModelAdmin):
+class ContractAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
     list_display = [
         "wedding",
         "supplier",

--- a/backend/apps/logistics/services/item_service.py
+++ b/backend/apps/logistics/services/item_service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from uuid import UUID
 
 from django.core.exceptions import ValidationError
@@ -118,14 +118,17 @@ class ItemService:
 
         from django.apps import apps
 
-        Wedding = apps.get_model("weddings", "Wedding")
+        wedding_model = apps.get_model("weddings", "Wedding")
 
-        return resolve_tenant_resource(
-            Wedding,
-            company,
-            wedding_input,
-            detail="Casamento não encontrado ou acesso negado.",
-            code="wedding_not_found_or_denied",
+        return cast(
+            "Wedding | None",
+            resolve_tenant_resource(
+                wedding_model,
+                company,
+                wedding_input,
+                detail="Casamento não encontrado ou acesso negado.",
+                code="wedding_not_found_or_denied",
+            ),
         )
 
     @staticmethod

--- a/backend/apps/logistics/tests/contracts/test_models.py
+++ b/backend/apps/logistics/tests/contracts/test_models.py
@@ -1,21 +1,36 @@
 from datetime import date
 from decimal import Decimal
+from typing import Any, cast
 
 import pytest
 from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
 
 from apps.core.validators import MaxFileSizeValidator
-from apps.logistics.models import Contract
-from apps.logistics.tests.factories import ContractFactory, SupplierFactory
-from apps.weddings.tests.factories import WeddingFactory
+from apps.logistics.models import Contract, Supplier
+from apps.logistics.tests.factories import ContractFactory as _ContractFactory
+from apps.logistics.tests.factories import SupplierFactory as _SupplierFactory
+from apps.weddings.models import Wedding
+from apps.weddings.tests.factories import WeddingFactory as _WeddingFactory
+
+
+def ContractFactory(*args: Any, **kwargs: Any) -> Contract:
+    return cast(Contract, _ContractFactory(*args, **kwargs))
+
+
+def SupplierFactory(*args: Any, **kwargs: Any) -> Supplier:
+    return cast(Supplier, _SupplierFactory(*args, **kwargs))
+
+
+def WeddingFactory(*args: Any, **kwargs: Any) -> Wedding:
+    return cast(Wedding, _WeddingFactory(*args, **kwargs))
 
 
 @pytest.mark.django_db
 class TestContractModelMetadata:
     """Testes de representação e metadados do modelo Contract."""
 
-    def test_contract_str_contains_supplier_and_wedding(self, user):
+    def test_contract_str_contains_supplier_and_wedding(self, user: Any) -> None:
         """__str__ deve conter supplier, wedding e total_amount."""
         wedding = WeddingFactory(user_context=user, bride_name="Ana", groom_name="João")
         supplier = SupplierFactory(company=user.company, name="Buffet Premium")
@@ -31,7 +46,7 @@ class TestContractModelMetadata:
         assert "João" in result
         assert "15000.00" in result
 
-    def test_contract_ordering_by_created_at_descending(self, user):
+    def test_contract_ordering_by_created_at_descending(self, user: Any) -> None:
         """Ordenação padrão deve ser por -created_at."""
         wedding = WeddingFactory(user_context=user)
         c1 = ContractFactory(wedding=wedding, description="Contrato Antigo")
@@ -41,7 +56,7 @@ class TestContractModelMetadata:
         assert contracts[0] == c2
         assert contracts[1] == c1
 
-    def test_contract_status_default_is_draft(self, user):
+    def test_contract_status_default_is_draft(self, user: Any) -> None:
         """Status padrão deve ser DRAFT."""
         wedding = WeddingFactory(user_context=user)
         contract = ContractFactory(wedding=wedding)
@@ -52,7 +67,7 @@ class TestContractModelMetadata:
 class TestContractSignedValidation:
     """Testes da regra BR-L01: contrato ASSINADO exige PDF, valor positivo e data."""
 
-    def test_signed_without_pdf_fails(self, user):
+    def test_signed_without_pdf_fails(self, user: Any) -> None:
         """Contrato ASSINADO sem PDF deve falhar validação."""
         wedding = WeddingFactory(user_context=user)
         supplier = SupplierFactory(company=user.company)
@@ -71,7 +86,7 @@ class TestContractSignedValidation:
 
         assert "PDF" in str(exc_info.value).upper()
 
-    def test_signed_without_positive_amount_fails(self, user):
+    def test_signed_without_positive_amount_fails(self, user: Any) -> None:
         """Contrato ASSINADO com valor zero ou negativo deve falhar.
         As validações acumulam — PDF também será exigido, mas valor pega também."""
         wedding = WeddingFactory(user_context=user)
@@ -89,7 +104,7 @@ class TestContractSignedValidation:
         with pytest.raises(ValidationError):
             contract.full_clean()
 
-    def test_signed_without_signed_date_fails(self, user):
+    def test_signed_without_signed_date_fails(self, user: Any) -> None:
         """Contrato ASSINADO sem signed_date deve falhar."""
         wedding = WeddingFactory(user_context=user)
         supplier = SupplierFactory(company=user.company)
@@ -106,13 +121,13 @@ class TestContractSignedValidation:
         with pytest.raises(ValidationError):
             contract.full_clean()
 
-    def test_draft_passes_without_requirements(self, user):
+    def test_draft_passes_without_requirements(self, user: Any) -> None:
         """Contrato DRAFT não exige PDF, valor ou assinatura."""
         wedding = WeddingFactory(user_context=user)
         contract = ContractFactory(wedding=wedding, status=Contract.StatusChoices.DRAFT)
         contract.full_clean()
 
-    def test_pending_passes_without_requirements(self, user):
+    def test_pending_passes_without_requirements(self, user: Any) -> None:
         """Contrato PENDING não exige PDF, valor ou assinatura."""
         wedding = WeddingFactory(user_context=user)
         contract = ContractFactory(
@@ -126,7 +141,7 @@ class TestContractSignedValidation:
 class TestContractFileValidation:
     """Testes de validação de tipo e tamanho do arquivo pdf_file."""
 
-    def test_pdf_file_invalid_extension_fails(self, user):
+    def test_pdf_file_invalid_extension_fails(self, user: Any) -> None:
         """Extensão inválida (exe) deve falhar validação."""
         wedding = WeddingFactory(user_context=user)
         supplier = SupplierFactory(company=user.company)
@@ -152,7 +167,7 @@ class TestContractFileValidation:
             or "extensão" in str(exc_info.value).lower()
         )
 
-    def test_pdf_file_exceeds_max_size_fails(self, user):
+    def test_pdf_file_exceeds_max_size_fails(self, user: Any) -> None:
         """Arquivo > 10MB deve falhar validação."""
         wedding = WeddingFactory(user_context=user)
         supplier = SupplierFactory(company=user.company)
@@ -175,7 +190,7 @@ class TestContractFileValidation:
 
         assert "10mb" in str(exc_info.value).lower()
 
-    def test_pdf_file_valid_extension_passes(self, user):
+    def test_pdf_file_valid_extension_passes(self, user: Any) -> None:
         """Extensão válida (pdf) deve passar sem erro."""
         wedding = WeddingFactory(user_context=user)
         supplier = SupplierFactory(company=user.company)
@@ -194,7 +209,7 @@ class TestContractFileValidation:
         )
         contract.full_clean()
 
-    def test_pdf_file_valid_png_passes(self, user):
+    def test_pdf_file_valid_png_passes(self, user: Any) -> None:
         """Extensão válida (png) deve passar sem erro."""
         wedding = WeddingFactory(user_context=user)
         supplier = SupplierFactory(company=user.company)
@@ -213,7 +228,7 @@ class TestContractFileValidation:
         )
         contract.full_clean()
 
-    def test_pdf_file_valid_jpeg_passes(self, user):
+    def test_pdf_file_valid_jpeg_passes(self, user: Any) -> None:
         """Extensão válida (jpeg) deve passar sem erro."""
         wedding = WeddingFactory(user_context=user)
         supplier = SupplierFactory(company=user.company)
@@ -232,7 +247,7 @@ class TestContractFileValidation:
         )
         contract.full_clean()
 
-    def test_pdf_file_null_passes(self, user):
+    def test_pdf_file_null_passes(self, user: Any) -> None:
         """pdf_file nulo deve passar sem erro (campo opcional)."""
         wedding = WeddingFactory(user_context=user)
         supplier = SupplierFactory(company=user.company)
@@ -246,7 +261,7 @@ class TestContractFileValidation:
         )
         contract.full_clean()
 
-    def test_max_file_size_validator_is_wired_on_field(self, user):
+    def test_max_file_size_validator_is_wired_on_field(self, user: Any) -> None:
         """MaxFileSizeValidator deve estar configurado no campo pdf_file."""
         field = Contract._meta.get_field("pdf_file")
 
@@ -267,7 +282,7 @@ class TestContractStatusTransitionValidation:
         "total_amount": Decimal("5000.00"),
     }
 
-    _VALID: list[tuple[str, str, dict]] = [
+    _VALID: list[tuple[str, str, dict[str, object]]] = [
         ("DRAFT", "PENDING", {}),
         ("DRAFT", "CANCELED", {}),
         ("PENDING", "SIGNED", {}),
@@ -277,7 +292,7 @@ class TestContractStatusTransitionValidation:
         ("CANCELED", "DRAFT", {}),
     ]
 
-    _INVALID: list[tuple[str, str, dict]] = [
+    _INVALID: list[tuple[str, str, dict[str, object]]] = [
         ("DRAFT", "SIGNED", {}),
         ("SIGNED", "DRAFT", _SIGNED_KWARGS),
         ("CANCELED", "SIGNED", {}),
@@ -285,7 +300,9 @@ class TestContractStatusTransitionValidation:
     ]
 
     @pytest.mark.parametrize("from_status, to_status, kwargs", _VALID)
-    def test_valid_transitions(self, make_contract, from_status, to_status, kwargs):
+    def test_valid_transitions(
+        self, make_contract: Any, from_status: Any, to_status: Any, kwargs: Any
+    ) -> None:
         contract = make_contract(from_status, **kwargs)
         if to_status == "SIGNED":
             contract.pdf_file = "contracts/test.pdf"
@@ -295,13 +312,15 @@ class TestContractStatusTransitionValidation:
         contract.full_clean()
 
     @pytest.mark.parametrize("from_status, to_status, kwargs", _INVALID)
-    def test_invalid_transitions(self, make_contract, from_status, to_status, kwargs):
+    def test_invalid_transitions(
+        self, make_contract: Any, from_status: Any, to_status: Any, kwargs: Any
+    ) -> None:
         contract = make_contract(from_status, **kwargs)
         contract.status = to_status
         with pytest.raises(ValidationError):
             contract.full_clean()
 
-    def test_new_instance_not_validated_as_transition(self):
+    def test_new_instance_not_validated_as_transition(self) -> None:
         """Criação direta de contrato ASSINADO não deve falhar por transição,
         apenas pelas regras de SIGNED (PDF, valor, data)."""
         with pytest.raises(ValidationError) as exc_info:

--- a/backend/apps/logistics/tests/contracts/test_performance.py
+++ b/backend/apps/logistics/tests/contracts/test_performance.py
@@ -1,23 +1,28 @@
+from typing import Any, cast
+
 import pytest
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
 
+from apps.logistics.models import Contract, Supplier
 from apps.logistics.schemas import ContractOut
 from apps.logistics.services.contract_service import ContractService
 from apps.logistics.tests.factories import ContractFactory, SupplierFactory
+from apps.tenants.models import Company
 from apps.tenants.tests.factories import CompanyFactory
+from apps.weddings.models import Wedding
 from apps.weddings.tests.factories import WeddingFactory
 
 
 @pytest.mark.django_db
-def test_contract_out_resolvers_no_extra_queries():
+def test_contract_out_resolvers_no_extra_queries() -> None:
     """
     Verifies that ContractOut resolvers do NOT trigger extra queries when
     annotated data is available.
     """
-    company = CompanyFactory()
-    wedding = WeddingFactory(company=company)
-    supplier = SupplierFactory(company=company)
+    company = cast(Company, CompanyFactory())
+    wedding = cast(Wedding, WeddingFactory(company=company))
+    supplier = cast(Supplier, SupplierFactory(company=company))
 
     # Create 5 contracts
     ContractFactory.create_batch(5, wedding=wedding, company=company, supplier=supplier)
@@ -39,35 +44,37 @@ def test_contract_out_resolvers_no_extra_queries():
 
 
 @pytest.mark.django_db
-def test_contract_service_list_annotations():
+def test_contract_service_list_annotations() -> None:
     """
     Verifies that addendums_count is correctly calculated using Subquery.
     """
-    company = CompanyFactory()
-    wedding = WeddingFactory(company=company)
+    company = cast(Company, CompanyFactory())
+    wedding = cast(Wedding, WeddingFactory(company=company))
 
-    parent = ContractFactory(wedding=wedding, company=company)
+    parent = cast(Contract, ContractFactory(wedding=wedding, company=company))
     ContractFactory.create_batch(3, wedding=wedding, company=company, parent=parent)
 
     qs = ContractService.list(company, wedding_id=wedding.uuid)
     parent_contract = next(c for c in qs if c.uuid == parent.uuid)
 
-    assert parent_contract.addendums_count == 3
-    print(f"\nAddendums count verified: {parent_contract.addendums_count}")
+    assert cast(Any, parent_contract).addendums_count == 3
+    print(f"\nAddendums count verified: {cast(Any, parent_contract).addendums_count}")
 
 
 @pytest.mark.django_db
-def test_single_contract_serialization_queries():
+def test_single_contract_serialization_queries() -> None:
     """
     Verifies that ContractService.get() annotates data so that serializing
     a single detailed contract executes ZERO extra queries.
     """
-    company = CompanyFactory()
-    wedding = WeddingFactory(company=company)
-    supplier = SupplierFactory(company=company)
+    company = cast(Company, CompanyFactory())
+    wedding = cast(Wedding, WeddingFactory(company=company))
+    supplier = cast(Supplier, SupplierFactory(company=company))
 
     # Create 1 contract to test with
-    contract = ContractFactory(wedding=wedding, company=company, supplier=supplier)
+    contract = cast(
+        Contract, ContractFactory(wedding=wedding, company=company, supplier=supplier)
+    )
 
     # Get contract via service which annotates fields
     db_contract = ContractService.get(company, uuid=contract.uuid)

--- a/backend/apps/logistics/tests/contracts/test_services.py
+++ b/backend/apps/logistics/tests/contracts/test_services.py
@@ -1,6 +1,6 @@
 from datetime import date
 from decimal import Decimal
-from typing import no_type_check
+from typing import Any, cast
 from uuid import uuid4
 
 import pytest
@@ -9,14 +9,21 @@ from django.db import connection
 from django.test.utils import CaptureQueriesContext
 
 from apps.core.exceptions import BusinessRuleViolation, ObjectNotFoundError
+from apps.finances.models import Budget, BudgetCategory, Expense, Installment
 from apps.finances.schemas import ExpenseIn
 from apps.finances.tests.factories import (
-    BudgetCategoryFactory,
-    BudgetFactory,
-    ExpenseFactory,
-    InstallmentFactory,
+    BudgetCategoryFactory as _BudgetCategoryFactory,
 )
-from apps.logistics.models import Contract
+from apps.finances.tests.factories import (
+    BudgetFactory as _BudgetFactory,
+)
+from apps.finances.tests.factories import (
+    ExpenseFactory as _ExpenseFactory,
+)
+from apps.finances.tests.factories import (
+    InstallmentFactory as _InstallmentFactory,
+)
+from apps.logistics.models import Contract, Item, Supplier
 from apps.logistics.schemas import (
     ContractFullCreateIn,
     ContractIn,
@@ -25,12 +32,58 @@ from apps.logistics.schemas import (
     ItemIn,
 )
 from apps.logistics.services.contract_service import ContractService
-from apps.logistics.tests.factories import ContractFactory, ItemFactory, SupplierFactory
-from apps.users.tests.factories import UserFactory
-from apps.weddings.tests.factories import WeddingFactory
+from apps.logistics.tests.factories import (
+    ContractFactory as _ContractFactory,
+)
+from apps.logistics.tests.factories import (
+    ItemFactory as _ItemFactory,
+)
+from apps.logistics.tests.factories import (
+    SupplierFactory as _SupplierFactory,
+)
+from apps.users.models import User
+from apps.users.tests.factories import UserFactory as _UserFactory
+from apps.weddings.models import Wedding
+from apps.weddings.tests.factories import WeddingFactory as _WeddingFactory
 
 
-def _setup_contract_context(user):
+def ContractFactory(*args: Any, **kwargs: Any) -> Contract:
+    return cast(Contract, _ContractFactory(*args, **kwargs))
+
+
+def ItemFactory(*args: Any, **kwargs: Any) -> Item:
+    return cast(Item, _ItemFactory(*args, **kwargs))
+
+
+def SupplierFactory(*args: Any, **kwargs: Any) -> Supplier:
+    return cast(Supplier, _SupplierFactory(*args, **kwargs))
+
+
+def UserFactory(*args: Any, **kwargs: Any) -> User:
+    return cast(User, _UserFactory(*args, **kwargs))
+
+
+def WeddingFactory(*args: Any, **kwargs: Any) -> Wedding:
+    return cast(Wedding, _WeddingFactory(*args, **kwargs))
+
+
+def BudgetFactory(*args: Any, **kwargs: Any) -> Budget:
+    return cast(Budget, _BudgetFactory(*args, **kwargs))
+
+
+def BudgetCategoryFactory(*args: Any, **kwargs: Any) -> BudgetCategory:
+    return cast(BudgetCategory, _BudgetCategoryFactory(*args, **kwargs))
+
+
+def ExpenseFactory(*args: Any, **kwargs: Any) -> Expense:
+    return cast(Expense, _ExpenseFactory(*args, **kwargs))
+
+
+def InstallmentFactory(*args: Any, **kwargs: Any) -> Installment:
+    return cast(Installment, _InstallmentFactory(*args, **kwargs))
+
+
+def _setup_contract_context(user: User) -> tuple[Wedding, Supplier]:
     """Helper: cria wedding + supplier no contexto do user."""
     wedding = WeddingFactory(user_context=user)
     supplier = SupplierFactory(company=user.company)
@@ -41,11 +94,11 @@ def _setup_contract_context(user):
 class TestContractServiceCreate:
     """Testes de criação de contratos via ContractService."""
 
-    def test_create_contract_success(self, user):
+    def test_create_contract_success(self, user: Any) -> None:
         """Criação de contrato com wedding e supplier."""
         wedding, supplier = _setup_contract_context(user)
 
-        data = {
+        data: dict[str, Any] = {
             "wedding": wedding.uuid,
             "supplier": supplier.uuid,
             "name": "Buffet Completo",
@@ -60,11 +113,11 @@ class TestContractServiceCreate:
         assert contract.total_amount == Decimal("10000.00")
         assert contract.status == Contract.StatusChoices.DRAFT
 
-    def test_create_contract_with_instances(self, user):
+    def test_create_contract_with_instances(self, user: Any) -> None:
         """create() aceita instâncias de Wedding e Supplier."""
         wedding, supplier = _setup_contract_context(user)
 
-        data = {
+        data: dict[str, Any] = {
             "wedding": wedding.uuid,
             "supplier": supplier.uuid,
             "name": "Buffet Teste",
@@ -75,11 +128,11 @@ class TestContractServiceCreate:
         assert contract.wedding == wedding
         assert contract.supplier == supplier
 
-    def test_create_contract_wedding_not_found(self, user):
+    def test_create_contract_wedding_not_found(self, user: Any) -> None:
         """UUID de wedding inexistente levanta ObjectNotFoundError."""
         _, supplier = _setup_contract_context(user)
 
-        data = {
+        data: dict[str, Any] = {
             "wedding": uuid4(),
             "supplier": supplier.uuid,
             "total_amount": Decimal("1000.00"),
@@ -91,11 +144,11 @@ class TestContractServiceCreate:
 
         assert "wedding_not_found_or_denied" in str(exc_info.value.code)
 
-    def test_create_contract_supplier_not_found(self, user):
+    def test_create_contract_supplier_not_found(self, user: Any) -> None:
         """UUID de supplier inexistente levanta ObjectNotFoundError."""
         wedding, _ = _setup_contract_context(user)
 
-        data = {
+        data: dict[str, Any] = {
             "wedding": wedding.uuid,
             "supplier": uuid4(),
             "total_amount": Decimal("1000.00"),
@@ -107,14 +160,14 @@ class TestContractServiceCreate:
 
         assert "supplier_not_found_or_denied" in str(exc_info.value.code)
 
-    def test_create_contract_multitenancy_wedding(self):
+    def test_create_contract_multitenancy_wedding(self) -> None:
         """Usuário A não pode criar contrato com wedding do Usuário B."""
         user_a = UserFactory()
         user_b = UserFactory()
         wedding_b = WeddingFactory(user_context=user_b)
         supplier_a = SupplierFactory(company=user_a.company)
 
-        data = {
+        data: dict[str, Any] = {
             "wedding": wedding_b.uuid,
             "supplier": supplier_a.uuid,
             "total_amount": Decimal("1000.00"),
@@ -126,7 +179,6 @@ class TestContractServiceCreate:
 
         assert "wedding_not_found_or_denied" in str(exc_info.value.code)
 
-    @no_type_check
     def test_create_contract_rejects_supplier_instance_from_other_tenant(self) -> None:
         """Instâncias pré-carregadas também precisam respeitar o tenant."""
         user_a = UserFactory()
@@ -153,13 +205,13 @@ class TestContractServiceCreate:
     # O status is_active do supplier é um controle interno, não uma validação
     # de integridade referencial. O contrato pode referenciar um supplier que
     # foi desativado após a criação.
-    def test_create_contract_with_inactive_supplier(self, user):
+    def test_create_contract_with_inactive_supplier(self, user: Any) -> None:
         """Criação de contrato com fornecedor inativo deve funcionar."""
         wedding, supplier = _setup_contract_context(user)
         supplier.is_active = False
         supplier.save()
 
-        data = {
+        data: dict[str, Any] = {
             "wedding": wedding.uuid,
             "supplier": supplier.uuid,
             "name": "Contrato Fornecedor Inativo",
@@ -175,7 +227,7 @@ class TestContractServiceCreate:
 class TestContractServiceUpdate:
     """Testes de atualização de contratos via ContractService."""
 
-    def test_update_contract_description(self, user):
+    def test_update_contract_description(self, user: Any) -> None:
         """Atualização de campos simples é permitida."""
         wedding, supplier = _setup_contract_context(user)
         contract = ContractFactory(
@@ -188,7 +240,7 @@ class TestContractServiceUpdate:
 
         assert updated.description == "Nova descrição"
 
-    def test_update_contract_change_supplier(self, user):
+    def test_update_contract_change_supplier(self, user: Any) -> None:
         """Troca de supplier é permitida com validação multitenant."""
         wedding, supplier1 = _setup_contract_context(user)
         supplier2 = SupplierFactory(company=user.company)
@@ -200,7 +252,9 @@ class TestContractServiceUpdate:
 
         assert updated.supplier == supplier2
 
-    def test_update_expiration_date_with_alert_days_before(self, make_contract):
+    def test_update_expiration_date_with_alert_days_before(
+        self, make_contract: Any
+    ) -> None:
         """Atualizar expiration_date e alert_days_before juntos."""
         contract = make_contract("DRAFT")
         future_date = date(2027, 12, 31)
@@ -213,7 +267,7 @@ class TestContractServiceUpdate:
         assert updated.expiration_date == future_date
         assert updated.alert_days_before == 30
 
-    def test_update_with_valid_status_transition(self, make_contract):
+    def test_update_with_valid_status_transition(self, make_contract: Any) -> None:
         """update() com status válido chama transition_status internamente."""
         contract = make_contract("DRAFT")
 
@@ -223,7 +277,9 @@ class TestContractServiceUpdate:
 
         assert updated.status == "PENDING"
 
-    def test_update_with_invalid_status_transition_raises_error(self, make_contract):
+    def test_update_with_invalid_status_transition_raises_error(
+        self, make_contract: Any
+    ) -> None:
         """update() com transição inválida propaga BusinessRuleViolation."""
         contract = make_contract("DRAFT")
 
@@ -234,7 +290,7 @@ class TestContractServiceUpdate:
 
         assert "Não é permitido transitar" in str(exc_info.value)
 
-    def test_update_contract_cross_tenant(self, user):
+    def test_update_contract_cross_tenant(self, user: Any) -> None:
         """Contrato de outro tenant não pode ser atualizado."""
         other_user = UserFactory()
         other_wedding = WeddingFactory(company=other_user.company)
@@ -246,9 +302,8 @@ class TestContractServiceUpdate:
                 user.company, other_contract, ContractPatchIn(description="Hack")
             )
 
-    @no_type_check
     def test_update_contract_rejects_supplier_instance_from_other_tenant(
-        self, user
+        self, user: Any
     ) -> None:
         """Update não pode receber Supplier pré-carregado de outro tenant."""
         wedding, supplier = _setup_contract_context(user)
@@ -267,7 +322,7 @@ class TestContractServiceUpdate:
 class TestContractServiceDelete:
     """Testes de deleção de contratos via ContractService."""
 
-    def test_delete_contract_orphans_items(self, user):
+    def test_delete_contract_orphans_items(self, user: Any) -> None:
         """Deleção de contrato desvincula itens (contract=None) antes de deletar."""
         wedding, supplier = _setup_contract_context(user)
         contract = ContractFactory(wedding=wedding, supplier=supplier)
@@ -281,7 +336,7 @@ class TestContractServiceDelete:
         item.refresh_from_db()
         assert item.contract is None
 
-    def test_delete_contract_with_expenses_succeeds(self, user):
+    def test_delete_contract_with_expenses_succeeds(self, user: Any) -> None:
         """Contrato com Expense vinculada pode ser deletado (SET_NULL).
         Diferente de amarras de integridade pesada, o vínculo Contrato-Despesa
         é flexível: deletar o contrato apenas deixa a despesa sem referência,
@@ -301,7 +356,7 @@ class TestContractServiceDelete:
 
         assert Contract.objects.filter(uuid=contract.uuid).count() == 0
 
-    def test_delete_contract_with_file_removes_physical_file(self, user):
+    def test_delete_contract_with_file_removes_physical_file(self, user: Any) -> None:
         wedding, supplier = _setup_contract_context(user)
         contract = ContractFactory(
             wedding=wedding, supplier=supplier, pdf_file="contracts/dummy.pdf"
@@ -310,7 +365,7 @@ class TestContractServiceDelete:
         ContractService.delete(user.company, contract)
         assert Contract.objects.filter(uuid=contract.uuid).count() == 0
 
-    def test_delete_contract_cross_tenant(self, user):
+    def test_delete_contract_cross_tenant(self, user: Any) -> None:
         """Contrato de outro tenant não pode ser deletado."""
         other_user = UserFactory()
         other_wedding = WeddingFactory(company=other_user.company)
@@ -325,7 +380,7 @@ class TestContractServiceDelete:
 class TestContractServiceListAndGet:
     """Testes de listagem e obtenção de contratos."""
 
-    def test_list_contracts_multitenancy(self):
+    def test_list_contracts_multitenancy(self) -> None:
         """list() retorna apenas contratos do tenant."""
         user_a = UserFactory()
         user_b = UserFactory()
@@ -343,13 +398,17 @@ class TestContractServiceListAndGet:
 
         qs_a = ContractService.list(user_a.company)
         assert qs_a.count() == 1
-        assert qs_a.first().description == "Contrato A"
+        first_a = qs_a.first()
+        assert first_a is not None
+        assert first_a.description == "Contrato A"
 
         qs_b = ContractService.list(user_b.company)
         assert qs_b.count() == 1
-        assert qs_b.first().description == "Contrato B"
+        first_b = qs_b.first()
+        assert first_b is not None
+        assert first_b.description == "Contrato B"
 
-    def test_list_contracts_filter_by_wedding(self, user):
+    def test_list_contracts_filter_by_wedding(self, user: Any) -> None:
         """list() com wedding_id filtra por casamento."""
         wedding1, supplier = _setup_contract_context(user)
         wedding2 = WeddingFactory(user_context=user)
@@ -359,9 +418,11 @@ class TestContractServiceListAndGet:
 
         qs = ContractService.list(user.company, wedding_id=wedding1.uuid)
         assert qs.count() == 1
-        assert qs.first().description == "C1"
+        first = qs.first()
+        assert first is not None
+        assert first.description == "C1"
 
-    def test_get_contract_success(self, user):
+    def test_get_contract_success(self, user: Any) -> None:
         """get() retorna contrato com select_related."""
         wedding, supplier = _setup_contract_context(user)
         contract = ContractFactory(wedding=wedding, supplier=supplier)
@@ -371,7 +432,7 @@ class TestContractServiceListAndGet:
         assert result.supplier == supplier
         assert result.wedding == wedding
 
-    def test_get_contract_with_expense(self, user):
+    def test_get_contract_with_expense(self, user: Any) -> None:
         wedding, supplier = _setup_contract_context(user)
         contract = ContractFactory(wedding=wedding, supplier=supplier)
         budget = BudgetFactory(wedding=wedding)
@@ -385,9 +446,9 @@ class TestContractServiceListAndGet:
 
         result = ContractService.get(user.company, contract.uuid)
         assert result.uuid == contract.uuid
-        assert result.expense_id == expense.uuid
+        assert cast(Any, result).expense_id == expense.uuid
 
-    def test_list_contracts_filter_by_parent(self, user):
+    def test_list_contracts_filter_by_parent(self, user: Any) -> None:
         """list() com parent_id filtra apenas aditivos do contrato pai."""
         wedding, supplier = _setup_contract_context(user)
         parent = ContractFactory(
@@ -405,14 +466,16 @@ class TestContractServiceListAndGet:
 
         qs = ContractService.list(user.company, parent_id=parent.uuid)
         assert qs.count() == 1
-        assert qs.first().description == "Aditivo 1"
+        first = qs.first()
+        assert first is not None
+        assert first.description == "Aditivo 1"
 
-    def test_get_contract_not_found(self, user):
+    def test_get_contract_not_found(self, user: Any) -> None:
         """UUID inexistente levanta ObjectNotFoundError."""
         with pytest.raises(ObjectNotFoundError):
             ContractService.get(user.company, uuid4())
 
-    def test_get_contract_multitenancy(self):
+    def test_get_contract_multitenancy(self) -> None:
         """Usuário A não pode acessar contrato do Usuário B."""
         user_a = UserFactory()
         user_b = UserFactory()
@@ -423,7 +486,6 @@ class TestContractServiceListAndGet:
         with pytest.raises(ObjectNotFoundError):
             ContractService.get(user_a.company, contract_b.uuid)
 
-    @no_type_check
     def test_list_annotations_ignore_cross_tenant_related_records(self) -> None:
         """Subqueries de list() não consideram vínculos corrompidos de outro tenant."""
         user_a = UserFactory()
@@ -444,7 +506,7 @@ class TestContractServiceListAndGet:
         )
         other_addendum = ContractFactory(wedding=wedding_b, supplier=supplier_b)
 
-        ExpenseFactory._meta.model.objects.filter(pk=other_expense.pk).update(
+        Expense.objects.filter(pk=other_expense.pk).update(
             contract=contract,
             company=user_b.company,
         )
@@ -458,11 +520,11 @@ class TestContractServiceListAndGet:
 
         result = ContractService.list(user_a.company).get(uuid=contract.uuid)
 
-        assert result.expense_id is None
-        assert result.total_paid == Decimal("0.00")
-        assert result.addendums_count == 0
+        annotated = cast(Any, result)
+        assert annotated.expense_id is None
+        assert annotated.total_paid == Decimal("0.00")
+        assert annotated.addendums_count == 0
 
-    @no_type_check
     def test_get_annotations_ignore_cross_tenant_related_records(self) -> None:
         """Subqueries de get() não consideram vínculos corrompidos de outro tenant."""
         user_a = UserFactory()
@@ -483,7 +545,7 @@ class TestContractServiceListAndGet:
         )
         other_addendum = ContractFactory(wedding=wedding_b, supplier=supplier_b)
 
-        ExpenseFactory._meta.model.objects.filter(pk=other_expense.pk).update(
+        Expense.objects.filter(pk=other_expense.pk).update(
             contract=contract,
             company=user_b.company,
         )
@@ -497,16 +559,17 @@ class TestContractServiceListAndGet:
 
         result = ContractService.get(user_a.company, contract.uuid)
 
-        assert result.expense_id is None
-        assert result.total_paid == Decimal("0.00")
-        assert result.addendums_count == 0
+        annotated = cast(Any, result)
+        assert annotated.expense_id is None
+        assert annotated.total_paid == Decimal("0.00")
+        assert annotated.addendums_count == 0
 
 
 @pytest.mark.django_db
 class TestContractServiceUploadFile:
     """Testes de upload de arquivo para contrato via ContractService."""
 
-    def test_upload_file_invalid_extension_fails(self, user):
+    def test_upload_file_invalid_extension_fails(self, user: Any) -> None:
         """upload_file com extensão inválida deve falhar na validação do model."""
         wedding, supplier = _setup_contract_context(user)
         contract = ContractFactory(wedding=wedding, supplier=supplier)
@@ -518,7 +581,7 @@ class TestContractServiceUploadFile:
 
         assert "não suportado" in str(exc_info.value).lower()
 
-    def test_upload_file_valid_key_succeeds(self, user):
+    def test_upload_file_valid_key_succeeds(self, user: Any) -> None:
         """upload_file com key válida deve salvar com sucesso."""
         wedding, supplier = _setup_contract_context(user)
         contract = ContractFactory(wedding=wedding, supplier=supplier)
@@ -535,21 +598,21 @@ class TestContractServiceUploadFile:
 class TestContractServiceTransitionStatus:
     """Testes da máquina de estados de contratos."""
 
-    def test_draft_to_pending(self, make_contract):
+    def test_draft_to_pending(self, make_contract: Any) -> None:
         contract = make_contract("DRAFT")
         result = ContractService.transition_status(
             contract.company, contract, "PENDING"
         )
         assert result.status == "PENDING"
 
-    def test_draft_to_canceled(self, make_contract):
+    def test_draft_to_canceled(self, make_contract: Any) -> None:
         contract = make_contract("DRAFT")
         result = ContractService.transition_status(
             contract.company, contract, "CANCELED"
         )
         assert result.status == "CANCELED"
 
-    def test_pending_to_signed(self, make_contract):
+    def test_pending_to_signed(self, make_contract: Any) -> None:
         contract = make_contract("PENDING")
         contract.pdf_file = "contracts/test.pdf"
         contract.signed_date = date.today()
@@ -558,19 +621,19 @@ class TestContractServiceTransitionStatus:
         result = ContractService.transition_status(contract.company, contract, "SIGNED")
         assert result.status == "SIGNED"
 
-    def test_pending_to_draft(self, make_contract):
+    def test_pending_to_draft(self, make_contract: Any) -> None:
         contract = make_contract("PENDING")
         result = ContractService.transition_status(contract.company, contract, "DRAFT")
         assert result.status == "DRAFT"
 
-    def test_pending_to_canceled(self, make_contract):
+    def test_pending_to_canceled(self, make_contract: Any) -> None:
         contract = make_contract("PENDING")
         result = ContractService.transition_status(
             contract.company, contract, "CANCELED"
         )
         assert result.status == "CANCELED"
 
-    def test_signed_to_canceled(self, user):
+    def test_signed_to_canceled(self, user: Any) -> None:
         wedding = WeddingFactory(company=user.company)
         supplier = SupplierFactory(company=user.company)
         contract = ContractFactory(
@@ -586,18 +649,18 @@ class TestContractServiceTransitionStatus:
         )
         assert result.status == "CANCELED"
 
-    def test_canceled_to_draft(self, make_contract):
+    def test_canceled_to_draft(self, make_contract: Any) -> None:
         contract = make_contract("CANCELED")
         result = ContractService.transition_status(contract.company, contract, "DRAFT")
         assert result.status == "DRAFT"
 
-    def test_invalid_transition_raises_error(self, make_contract):
+    def test_invalid_transition_raises_error(self, make_contract: Any) -> None:
         contract = make_contract("DRAFT")
         with pytest.raises(BusinessRuleViolation) as exc_info:
             ContractService.transition_status(contract.company, contract, "SIGNED")
         assert "Não é permitido transitar" in str(exc_info.value)
 
-    def test_signed_to_draft_invalid(self, user):
+    def test_signed_to_draft_invalid(self, user: Any) -> None:
         wedding = WeddingFactory(company=user.company)
         supplier = SupplierFactory(company=user.company)
         contract = ContractFactory(
@@ -611,12 +674,12 @@ class TestContractServiceTransitionStatus:
         with pytest.raises(BusinessRuleViolation):
             ContractService.transition_status(contract.company, contract, "DRAFT")
 
-    def test_canceled_to_signed_invalid(self, make_contract):
+    def test_canceled_to_signed_invalid(self, make_contract: Any) -> None:
         contract = make_contract("CANCELED")
         with pytest.raises(BusinessRuleViolation):
             ContractService.transition_status(contract.company, contract, "SIGNED")
 
-    def test_transition_status_multitenancy(self, make_contract):
+    def test_transition_status_multitenancy(self, make_contract: Any) -> None:
         """Transição com company diferente deve falhar — ou o service
         deve validar que instance pertence à company passada."""
         contract = make_contract("DRAFT")
@@ -625,7 +688,9 @@ class TestContractServiceTransitionStatus:
         with pytest.raises(ObjectNotFoundError):
             ContractService.transition_status(other_user.company, contract, "PENDING")
 
-    def test_transition_to_signed_without_pdf_raises_error(self, make_contract):
+    def test_transition_to_signed_without_pdf_raises_error(
+        self, make_contract: Any
+    ) -> None:
         """Transição para SIGNED sem PDF vinculado deve falhar."""
         contract = make_contract("PENDING", pdf_file=None)
 
@@ -633,7 +698,9 @@ class TestContractServiceTransitionStatus:
             ContractService.transition_status(contract.company, contract, "SIGNED")
         assert "PDF" in str(exc_info.value.detail)
 
-    def test_transition_to_signed_without_signed_date_raises_error(self, make_contract):
+    def test_transition_to_signed_without_signed_date_raises_error(
+        self, make_contract: Any
+    ) -> None:
         """Transição para SIGNED sem signed_date deve falhar."""
         contract = make_contract(
             "PENDING",
@@ -645,7 +712,9 @@ class TestContractServiceTransitionStatus:
             ContractService.transition_status(contract.company, contract, "SIGNED")
         assert "data" in str(exc_info.value.detail).lower()
 
-    def test_cancel_contract_with_pending_installments(self, make_contract, user):
+    def test_cancel_contract_with_pending_installments(
+        self, make_contract: Any, user: Any
+    ) -> None:
         """Cancelar contrato com parcelas pendentes deve ser permitido."""
         from apps.finances.tests.factories import (
             BudgetCategoryFactory,
@@ -684,7 +753,7 @@ class TestContractServiceTransitionStatus:
 class TestContractServiceDeleteFile:
     """Testes de remoção de arquivo de contrato."""
 
-    def test_delete_file_success(self, contract_with_file):
+    def test_delete_file_success(self, contract_with_file: Any) -> None:
         assert contract_with_file.pdf_file.name
 
         ContractService.delete_file(contract_with_file.company, contract_with_file.uuid)
@@ -692,11 +761,11 @@ class TestContractServiceDeleteFile:
         contract_with_file.refresh_from_db()
         assert contract_with_file.pdf_file.name == ""
 
-    def test_delete_file_contract_not_found(self, user):
+    def test_delete_file_contract_not_found(self, user: Any) -> None:
         with pytest.raises(ObjectNotFoundError):
             ContractService.delete_file(user.company, uuid4())
 
-    def test_delete_file_multitenancy(self, contract_with_file, user):
+    def test_delete_file_multitenancy(self, contract_with_file: Any, user: Any) -> None:
         other_user = UserFactory()
         with pytest.raises(ObjectNotFoundError):
             ContractService.delete_file(other_user.company, contract_with_file.uuid)
@@ -706,7 +775,7 @@ class TestContractServiceDeleteFile:
 class TestContractServiceResolveParent:
     """Testes de vinculação de contrato pai via update()."""
 
-    def test_update_parent_success(self, user):
+    def test_update_parent_success(self, user: Any) -> None:
         wedding = WeddingFactory(company=user.company)
         supplier = SupplierFactory(company=user.company)
         parent = ContractFactory(
@@ -719,13 +788,13 @@ class TestContractServiceResolveParent:
         )
         child = ContractFactory(wedding=wedding, supplier=supplier, status="DRAFT")
         ContractService.update(
-            child.company, child, ContractPatchIn(parent=str(parent.uuid))
+            child.company, child, ContractPatchIn(parent=parent.uuid)
         )
 
         child.refresh_from_db()
         assert child.parent == parent
 
-    def test_update_parent_self_raises_error(self, make_contract):
+    def test_update_parent_self_raises_error(self, make_contract: Any) -> None:
         contract = make_contract("DRAFT")
         with pytest.raises(BusinessRuleViolation) as exc_info:
             ContractService.update(
@@ -733,7 +802,7 @@ class TestContractServiceResolveParent:
             )
         assert "não pode ser pai de si mesmo" in str(exc_info.value)
 
-    def test_update_parent_cross_wedding_raises_error(self, user):
+    def test_update_parent_cross_wedding_raises_error(self, user: Any) -> None:
         parent = ContractFactory(
             wedding__company=user.company,
             status="SIGNED",
@@ -749,11 +818,11 @@ class TestContractServiceResolveParent:
 
         with pytest.raises(BusinessRuleViolation) as exc_info:
             ContractService.update(
-                child.company, child, ContractPatchIn(parent=str(parent.uuid))
+                child.company, child, ContractPatchIn(parent=parent.uuid)
             )
         assert "deve pertencer ao mesmo casamento" in str(exc_info.value)
 
-    def test_update_parent_circular_raises_error(self, user):
+    def test_update_parent_circular_raises_error(self, user: Any) -> None:
         wedding = WeddingFactory(company=user.company)
         supplier = SupplierFactory(company=user.company)
         ancestor = ContractFactory(
@@ -782,11 +851,11 @@ class TestContractServiceResolveParent:
             )
         assert "descendente" in str(exc_info.value)
 
-    def test_update_parent_not_found_raises_error(self, make_contract):
+    def test_update_parent_not_found_raises_error(self, make_contract: Any) -> None:
         contract = make_contract("DRAFT")
         with pytest.raises(ObjectNotFoundError):
             ContractService.update(
-                contract.company, contract, ContractPatchIn(parent=str(uuid4()))
+                contract.company, contract, ContractPatchIn(parent=uuid4())
             )
 
 
@@ -794,7 +863,7 @@ class TestContractServiceResolveParent:
 class TestContractServiceCreateFull:
     """Testes de criação completa de contrato via ContractService.create_full()."""
 
-    def _setup(self, user):
+    def _setup(self, user: Any) -> tuple[Wedding, Supplier, BudgetCategory]:
         """
         Cria o contexto mínimo para criação completa de contratos.
 
@@ -808,7 +877,7 @@ class TestContractServiceCreateFull:
         category = BudgetCategoryFactory(budget=budget)
         return wedding, supplier, category
 
-    def test_create_full_contract_only(self, user):
+    def test_create_full_contract_only(self, user: Any) -> None:
         """Cria contrato sem file, items ou expense."""
         wedding, supplier, _ = self._setup(user)
         contract_data = ContractIn(
@@ -825,7 +894,7 @@ class TestContractServiceCreateFull:
         assert contract.total_amount == Decimal("10000.00")
         assert not contract.pdf_file
 
-    def test_create_full_with_file(self, user):
+    def test_create_full_with_file(self, user: Any) -> None:
         """Cria contrato com upload de arquivo."""
         wedding, supplier, _ = self._setup(user)
         contract_data = ContractIn(
@@ -841,7 +910,7 @@ class TestContractServiceCreateFull:
         )
         assert contract.pdf_file.name == "contracts/contrato.pdf"
 
-    def test_create_full_with_items(self, user):
+    def test_create_full_with_items(self, user: Any) -> None:
         """Cria contrato com itens via items_data."""
         wedding, supplier, _ = self._setup(user)
         contract_data = ContractIn(
@@ -861,7 +930,7 @@ class TestContractServiceCreateFull:
         )
         assert contract.items.count() == 2
 
-    def test_create_full_with_expense(self, user):
+    def test_create_full_with_expense(self, user: Any) -> None:
         """Cria contrato com despesa vinculada."""
         wedding, supplier, category = self._setup(user)
         contract_data = ContractIn(
@@ -896,7 +965,7 @@ class TestContractServiceCreateFull:
             "finances_expense" in query["sql"] for query in ctx.captured_queries
         )
 
-    def test_create_full_with_all(self, user):
+    def test_create_full_with_all(self, user: Any) -> None:
         """Cria contrato completo: file + items + expense."""
         wedding, supplier, category = self._setup(user)
         contract_data = ContractIn(
@@ -928,8 +997,7 @@ class TestContractServiceCreateFull:
         assert contract.expense is not None
         assert contract.expense.installments.count() == 3
 
-    @no_type_check
-    def test_create_full_from_payload_with_all(self, user) -> None:
+    def test_create_full_from_payload_with_all(self, user: Any) -> None:
         """Cria contrato completo a partir do schema usado pela API."""
         wedding, supplier, category = self._setup(user)
         payload = ContractFullCreateIn(
@@ -959,8 +1027,9 @@ class TestContractServiceCreateFull:
         assert contract.expense is not None
         assert contract.expense.installments.count() == 2
 
-    @no_type_check
-    def test_create_full_from_payload_rejects_non_list_items_data(self, user) -> None:
+    def test_create_full_from_payload_rejects_non_list_items_data(
+        self, user: Any
+    ) -> None:
         """items_data precisa ser uma lista JSON de objetos."""
         wedding, supplier, _ = self._setup(user)
         payload = ContractFullCreateIn(
@@ -979,8 +1048,7 @@ class TestContractServiceCreateFull:
 
         assert exc_info.value.code == "invalid_items_data"
 
-    @no_type_check
-    def test_create_full_from_payload_rejects_non_object_items(self, user) -> None:
+    def test_create_full_from_payload_rejects_non_object_items(self, user: Any) -> None:
         """Cada item de items_data precisa ser um objeto JSON."""
         wedding, supplier, _ = self._setup(user)
         payload = ContractFullCreateIn(
@@ -999,7 +1067,6 @@ class TestContractServiceCreateFull:
 
         assert exc_info.value.code == "invalid_items_data"
 
-    @no_type_check
     def test_create_full_from_payload_cross_tenant_wedding_raises_error(self) -> None:
         """Payload da API preserva isolamento ao delegar a criação completa."""
         user_a = UserFactory()
@@ -1019,7 +1086,7 @@ class TestContractServiceCreateFull:
                 payload=payload,
             )
 
-    def test_create_full_invalid_file_type(self, user):
+    def test_create_full_invalid_file_type(self, user: Any) -> None:
         """Arquivo com tipo inválido deve falhar."""
         wedding, supplier, _ = self._setup(user)
         contract_data = ContractIn(
@@ -1036,7 +1103,7 @@ class TestContractServiceCreateFull:
             )
         assert "não suportado" in str(exc_info.value)
 
-    def test_create_full_invalid_file_size(self, user):
+    def test_create_full_invalid_file_size(self, user: Any) -> None:
         """Arquivo com tamanho acima de 10MB deve falhar via model."""
         from django.core.files.uploadedfile import SimpleUploadedFile
 
@@ -1061,7 +1128,7 @@ class TestContractServiceCreateFull:
             contract.full_clean()
         assert "excede o limite" in str(exc_info.value).lower()
 
-    def test_create_full_with_parent(self, user):
+    def test_create_full_with_parent(self, user: Any) -> None:
         """Cria contrato como aditivo de outro contrato."""
         wedding, supplier, _ = self._setup(user)
         parent = ContractFactory(
@@ -1088,7 +1155,7 @@ class TestContractServiceCreateFull:
     # Regra intencional: contratos cancelados podem receber aditivos.
     # O cancelamento não é um estado terminal absoluto — um contrato
     # cancelado pode ser regularizado via aditivo.
-    def test_create_full_addendum_with_canceled_parent(self, user):
+    def test_create_full_addendum_with_canceled_parent(self, user: Any) -> None:
         """Criar aditivo de contrato cancelado — documenta comportamento."""
         wedding, supplier, _ = self._setup(user)
         parent = ContractFactory(
@@ -1110,7 +1177,7 @@ class TestContractServiceCreateFull:
         )
         assert contract.parent == parent
 
-    def test_create_full_multitenancy_isolation(self):
+    def test_create_full_multitenancy_isolation(self) -> None:
         """Usuário B não pode criar contrato com wedding do Usuário A."""
         user_a = UserFactory()
         user_b = UserFactory()
@@ -1128,7 +1195,7 @@ class TestContractServiceCreateFull:
                 contract_data=contract_data,
             )
 
-    def test_create_full_expense_category_not_found(self, user):
+    def test_create_full_expense_category_not_found(self, user: Any) -> None:
         """Expense com categoria inexistente deve falhar."""
         wedding, supplier, _ = self._setup(user)
         contract_data = ContractIn(
@@ -1142,6 +1209,8 @@ class TestContractServiceCreateFull:
             name="Despesa Inválida",
             estimated_amount=Decimal("5000.00"),
             actual_amount=Decimal("5000.00"),
+            num_installments=1,
+            first_due_date=date.today(),
         )
         with pytest.raises(ObjectNotFoundError) as exc_info:
             ContractService.create_full(
@@ -1151,7 +1220,7 @@ class TestContractServiceCreateFull:
             )
         assert exc_info.value.code == "budget_category_not_found_or_denied"
 
-    def test_create_full_expense_amount_mismatch_contract(self, user):
+    def test_create_full_expense_amount_mismatch_contract(self, user: Any) -> None:
         """Expense com valor divergente do contrato deve falhar (BR-F02)."""
         wedding, supplier, category = self._setup(user)
         contract_data = ContractIn(
@@ -1165,6 +1234,8 @@ class TestContractServiceCreateFull:
             name="Despesa Divergente",
             estimated_amount=Decimal("3000.00"),
             actual_amount=Decimal("3000.00"),
+            num_installments=1,
+            first_due_date=date.today(),
         )
         with pytest.raises(BusinessRuleViolation) as exc_info:
             ContractService.create_full(
@@ -1186,7 +1257,9 @@ class DummyStorageService:
 class TestContractServiceGenerateUploadUrl:
     """Testes de geração de upload URL pré-assinada."""
 
-    def test_generate_upload_url_success_with_injection(self, user, settings):
+    def test_generate_upload_url_success_with_injection(
+        self, user: Any, settings: Any
+    ) -> None:
         settings.AWS_STORAGE_BUCKET_NAME = "test-bucket"
         wedding, _ = _setup_contract_context(user)
         dummy_storage = DummyStorageService()
@@ -1206,7 +1279,9 @@ class TestContractServiceGenerateUploadUrl:
         assert result["object_key"].startswith(f"contracts/{wedding.uuid}/")
         assert result["object_key"].endswith("/contrato.pdf")
 
-    def test_generate_upload_url_success_with_class_setter(self, user, settings):
+    def test_generate_upload_url_success_with_class_setter(
+        self, user: Any, settings: Any
+    ) -> None:
         settings.AWS_STORAGE_BUCKET_NAME = "test-bucket"
         wedding, _ = _setup_contract_context(user)
 
@@ -1225,9 +1300,11 @@ class TestContractServiceGenerateUploadUrl:
                 == f"https://r2.com/test-bucket/{result['object_key']}"
             )
         finally:
-            ContractService.set_storage_service(original_storage)
+            ContractService.set_storage_service(cast(Any, original_storage))
 
-    def test_generate_upload_url_wedding_not_found(self, user, settings):
+    def test_generate_upload_url_wedding_not_found(
+        self, user: Any, settings: Any
+    ) -> None:
         settings.AWS_STORAGE_BUCKET_NAME = "test-bucket"
 
         with pytest.raises(ObjectNotFoundError):
@@ -1238,7 +1315,7 @@ class TestContractServiceGenerateUploadUrl:
                 storage_service=DummyStorageService(),
             )
 
-    def test_generate_upload_url_multitenancy(self, user, settings):
+    def test_generate_upload_url_multitenancy(self, user: Any, settings: Any) -> None:
         settings.AWS_STORAGE_BUCKET_NAME = "test-bucket"
 
         other_user = UserFactory()
@@ -1251,7 +1328,9 @@ class TestContractServiceGenerateUploadUrl:
                 storage_service=DummyStorageService(),
             )
 
-    def test_generate_upload_url_configuration_incomplete(self, user, settings):
+    def test_generate_upload_url_configuration_incomplete(
+        self, user: Any, settings: Any
+    ) -> None:
         settings.AWS_STORAGE_BUCKET_NAME = ""
         settings.R2_BUCKET = ""
 
@@ -1265,7 +1344,7 @@ class TestContractServiceGenerateUploadUrl:
             )
         assert exc_info.value.code == "storage_configuration_incomplete"
 
-    def test_contract_service_get_storage_client_lazy_load(self):
+    def test_contract_service_get_storage_client_lazy_load(self) -> None:
         # Salva o estado original
         original_storage = ContractService._storage_service
 

--- a/backend/apps/logistics/tests/items/test_models.py
+++ b/backend/apps/logistics/tests/items/test_models.py
@@ -1,16 +1,33 @@
+from typing import Any, cast
+
 import pytest
 from django.core.exceptions import ValidationError
 
-from apps.logistics.models import Item
-from apps.logistics.tests.factories import ContractFactory, ItemFactory
-from apps.weddings.tests.factories import WeddingFactory
+from apps.logistics.models import Contract, Item
+from apps.logistics.tests.factories import ContractFactory as _ContractFactory
+from apps.logistics.tests.factories import ItemFactory as _ItemFactory
+from apps.users.models import User
+from apps.weddings.models import Wedding
+from apps.weddings.tests.factories import WeddingFactory as _WeddingFactory
+
+
+def ContractFactory(*args: Any, **kwargs: Any) -> Contract:
+    return cast(Contract, _ContractFactory(*args, **kwargs))
+
+
+def ItemFactory(*args: Any, **kwargs: Any) -> Item:
+    return cast(Item, _ItemFactory(*args, **kwargs))
+
+
+def WeddingFactory(*args: Any, **kwargs: Any) -> Wedding:
+    return cast(Wedding, _WeddingFactory(*args, **kwargs))
 
 
 @pytest.mark.django_db
 class TestItemModelMetadata:
     """Testes de representação e metadados do modelo Item."""
 
-    def test_item_str_contains_name_and_quantity(self, user):
+    def test_item_str_contains_name_and_quantity(self, user: Any) -> None:
         """__str__ deve conter nome e quantidade."""
         wedding = WeddingFactory(user_context=user)
         contract = ContractFactory(wedding=wedding)
@@ -22,7 +39,7 @@ class TestItemModelMetadata:
         assert "Buquê de Rosas" in result
         assert "5x" in result
 
-    def test_item_ordering_by_created_at_descending(self, user):
+    def test_item_ordering_by_created_at_descending(self, user: Any) -> None:
         """Ordenação padrão deve ser por -created_at."""
         wedding = WeddingFactory(user_context=user)
         contract = ContractFactory(wedding=wedding)
@@ -33,13 +50,13 @@ class TestItemModelMetadata:
         assert items[0] == i2
         assert items[1] == i1
 
-    def test_item_acquisition_status_default_pending(self, user):
+    def test_item_acquisition_status_default_pending(self, user: Any) -> None:
         """Status de aquisição padrão deve ser PENDING."""
         wedding = WeddingFactory(user_context=user)
         item = ItemFactory(wedding=wedding)
         assert item.acquisition_status == Item.AcquisitionStatus.PENDING
 
-    def test_item_quantity_default_one(self, user):
+    def test_item_quantity_default_one(self, user: Any) -> None:
         """Quantidade padrão do modelo deve ser 1 (usando build para isolar factory)."""
         wedding = WeddingFactory(user_context=user)
         item = Item(wedding=wedding, name="Teste")
@@ -50,7 +67,7 @@ class TestItemModelMetadata:
 class TestItemSupplierProperty:
     """Testes da computed property supplier."""
 
-    def test_item_supplier_comes_from_contract(self, user):
+    def test_item_supplier_comes_from_contract(self, user: Any) -> None:
         """Fornecedor do item é derivado do contrato associado."""
         wedding = WeddingFactory(user_context=user)
         contract = ContractFactory(wedding=wedding, supplier__name="Decorações Ltda")
@@ -59,7 +76,7 @@ class TestItemSupplierProperty:
         assert item.supplier is not None
         assert item.supplier.name == "Decorações Ltda"
 
-    def test_item_supplier_none_when_no_contract(self, user):
+    def test_item_supplier_none_when_no_contract(self, user: Any) -> None:
         """Item sem contrato retorna supplier=None."""
         wedding = WeddingFactory(user_context=user)
         item = ItemFactory(wedding=wedding, contract=None)
@@ -73,7 +90,7 @@ class TestItemAcquisitionStatus:
     (BR-L04: independente de pagamento).
     """
 
-    def test_item_can_be_pending(self, user):
+    def test_item_can_be_pending(self, user: Any) -> None:
         """Item criado como PENDING é válido."""
         wedding = WeddingFactory(user_context=user)
         item = ItemFactory(
@@ -81,7 +98,7 @@ class TestItemAcquisitionStatus:
         )
         item.full_clean()
 
-    def test_item_can_be_in_progress(self, user):
+    def test_item_can_be_in_progress(self, user: Any) -> None:
         """Item pode transitar para IN_PROGRESS."""
         wedding = WeddingFactory(user_context=user)
         item = ItemFactory(
@@ -89,7 +106,7 @@ class TestItemAcquisitionStatus:
         )
         item.full_clean()
 
-    def test_item_can_be_done(self, user):
+    def test_item_can_be_done(self, user: Any) -> None:
         """Item pode transitar para DONE."""
         wedding = WeddingFactory(user_context=user)
         item = ItemFactory(
@@ -115,24 +132,28 @@ class TestItemStatusTransitionValidation:
     ]
 
     @pytest.fixture
-    def item_for_transition(self, user):
+    def item_for_transition(self, user: User) -> Any:
         wedding = WeddingFactory(user_context=user)
         return lambda status: ItemFactory(wedding=wedding, acquisition_status=status)
 
     @pytest.mark.parametrize("from_status, to_status", _VALID)
-    def test_valid_transitions(self, item_for_transition, from_status, to_status):
+    def test_valid_transitions(
+        self, item_for_transition: Any, from_status: str, to_status: str
+    ) -> None:
         item = item_for_transition(from_status)
         item.acquisition_status = to_status
         item.full_clean()
 
     @pytest.mark.parametrize("from_status, to_status", _INVALID)
-    def test_invalid_transitions(self, item_for_transition, from_status, to_status):
+    def test_invalid_transitions(
+        self, item_for_transition: Any, from_status: str, to_status: str
+    ) -> None:
         item = item_for_transition(from_status)
         item.acquisition_status = to_status
         with pytest.raises(ValidationError):
             item.full_clean()
 
-    def test_no_change_does_not_validate(self, item_for_transition):
+    def test_no_change_does_not_validate(self, item_for_transition: Any) -> None:
         item = item_for_transition("PENDING")
         item.acquisition_status = "PENDING"
         item.full_clean()

--- a/backend/apps/logistics/tests/items/test_services.py
+++ b/backend/apps/logistics/tests/items/test_services.py
@@ -1,4 +1,4 @@
-from typing import no_type_check
+from typing import Any, cast, no_type_check
 from uuid import uuid4
 
 import pytest
@@ -8,15 +8,39 @@ from apps.core.exceptions import (
     DomainIntegrityError,
     ObjectNotFoundError,
 )
-from apps.logistics.models import Item
+from apps.logistics.models import Contract, Item, Supplier
 from apps.logistics.schemas import ItemIn, ItemPatchIn
 from apps.logistics.services.item_service import ItemService
-from apps.logistics.tests.factories import ContractFactory, ItemFactory, SupplierFactory
-from apps.users.tests.factories import UserFactory
-from apps.weddings.tests.factories import WeddingFactory
+from apps.logistics.tests.factories import ContractFactory as _ContractFactory
+from apps.logistics.tests.factories import ItemFactory as _ItemFactory
+from apps.logistics.tests.factories import SupplierFactory as _SupplierFactory
+from apps.users.models import User
+from apps.users.tests.factories import UserFactory as _UserFactory
+from apps.weddings.models import Wedding
+from apps.weddings.tests.factories import WeddingFactory as _WeddingFactory
 
 
-def _setup_item_context(user):
+def ContractFactory(*args: Any, **kwargs: Any) -> Contract:
+    return cast(Contract, _ContractFactory(*args, **kwargs))
+
+
+def ItemFactory(*args: Any, **kwargs: Any) -> Item:
+    return cast(Item, _ItemFactory(*args, **kwargs))
+
+
+def SupplierFactory(*args: Any, **kwargs: Any) -> Supplier:
+    return cast(Supplier, _SupplierFactory(*args, **kwargs))
+
+
+def UserFactory(*args: Any, **kwargs: Any) -> User:
+    return cast(User, _UserFactory(*args, **kwargs))
+
+
+def WeddingFactory(*args: Any, **kwargs: Any) -> Wedding:
+    return cast(Wedding, _WeddingFactory(*args, **kwargs))
+
+
+def _setup_item_context(user: User) -> tuple[Wedding, Contract]:
     """Helper: cria wedding + contract no contexto do user."""
     wedding = WeddingFactory(user_context=user)
     supplier = SupplierFactory(company=user.company)
@@ -28,11 +52,11 @@ def _setup_item_context(user):
 class TestItemServiceCreate:
     """Testes de criação de itens via ItemService."""
 
-    def test_create_item_with_contract(self, user):
+    def test_create_item_with_contract(self, user: Any) -> None:
         """Criação de item vinculado a contrato — wedding deriva do contrato."""
         wedding, contract = _setup_item_context(user)
 
-        data = {
+        data: dict[str, Any] = {
             "contract": contract.uuid,
             "name": "Buquê de Rosas",
             "quantity": 5,
@@ -46,11 +70,11 @@ class TestItemServiceCreate:
         assert item.quantity == 5
         assert item.acquisition_status == Item.AcquisitionStatus.PENDING
 
-    def test_create_item_with_explicit_wedding_no_contract(self, user):
+    def test_create_item_with_explicit_wedding_no_contract(self, user: Any) -> None:
         """Item pode ser criado sem contrato, com wedding explícito."""
         wedding, _ = _setup_item_context(user)
 
-        data = {
+        data: dict[str, Any] = {
             "wedding": wedding.uuid,
             "name": "Item avulso",
             "quantity": 1,
@@ -61,11 +85,11 @@ class TestItemServiceCreate:
         assert item.wedding == wedding
         assert item.contract is None
 
-    def test_create_item_with_contract_instance(self, user):
+    def test_create_item_with_contract_instance(self, user: Any) -> None:
         """create() aceita instância de Contract."""
         _, contract = _setup_item_context(user)
 
-        data = {
+        data: dict[str, Any] = {
             "contract": contract.uuid,
             "name": "Cadeiras",
             "quantity": 100,
@@ -74,9 +98,9 @@ class TestItemServiceCreate:
         item = ItemService.create(user.company, ItemIn(**data))
         assert item.contract == contract
 
-    def test_create_item_contract_not_found(self, user):
+    def test_create_item_contract_not_found(self, user: Any) -> None:
         """UUID de contrato inexistente levanta ObjectNotFoundError."""
-        data = {
+        data: dict[str, Any] = {
             "contract": uuid4(),
             "name": "Fantasma",
             "quantity": 1,
@@ -87,13 +111,13 @@ class TestItemServiceCreate:
 
         assert "contract_not_found_or_denied" in str(exc_info.value.code)
 
-    def test_create_item_multitenancy_contract(self):
+    def test_create_item_multitenancy_contract(self) -> None:
         """Usuário A não pode criar item com contrato do Usuário B."""
         user_a = UserFactory()
         user_b = UserFactory()
         _, contract_b = _setup_item_context(user_b)
 
-        data = {
+        data: dict[str, Any] = {
             "contract": contract_b.uuid,
             "name": "Invasão",
             "quantity": 1,
@@ -124,12 +148,14 @@ class TestItemServiceCreate:
 
         assert exc_info.value.code == "contract_not_found_or_denied"
 
-    def test_create_item_without_contract_and_wedding_raises_error(self, user):
+    def test_create_item_without_contract_and_wedding_raises_error(
+        self, user: Any
+    ) -> None:
         """
         Sem contrato E sem wedding, create() levanta BusinessRuleViolation
         em vez de IntegrityError obscuro do banco.
         """
-        data = {
+        data: dict[str, Any] = {
             "name": "Item solto no vácuo",
             "quantity": 1,
         }
@@ -139,7 +165,7 @@ class TestItemServiceCreate:
 
         assert "item_missing_wedding" in str(exc_info.value.code)
 
-    def test_create_item_mismatched_wedding_and_contract(self, user):
+    def test_create_item_mismatched_wedding_and_contract(self, user: Any) -> None:
         """
         Se contract e wedding são fornecidos e divergem,
         levanta DomainIntegrityError.
@@ -147,7 +173,7 @@ class TestItemServiceCreate:
         _, contract_a = _setup_item_context(user)
         wedding_b = WeddingFactory(user_context=user)
 
-        data = {
+        data: dict[str, Any] = {
             "contract": contract_a.uuid,
             "wedding": wedding_b.uuid,
             "name": "Item conflitante",
@@ -159,14 +185,14 @@ class TestItemServiceCreate:
 
         assert "item_contract_wedding_mismatch" in str(exc_info.value.code)
 
-    def test_create_item_matching_wedding_and_contract(self, user):
+    def test_create_item_matching_wedding_and_contract(self, user: Any) -> None:
         """
         Se contract e wedding são fornecidos e coincidem,
         cria o item com sucesso.
         """
         wedding, contract = _setup_item_context(user)
 
-        data = {
+        data: dict[str, Any] = {
             "contract": contract.uuid,
             "wedding": wedding.uuid,
             "name": "Item consistente",
@@ -177,11 +203,11 @@ class TestItemServiceCreate:
         assert item.contract == contract
         assert item.wedding == wedding
 
-    def test_create_item_with_wedding_instance(self, user):
+    def test_create_item_with_wedding_instance(self, user: Any) -> None:
         """Criação de item passando uma instância de Wedding diretamente."""
         wedding, _ = _setup_item_context(user)
 
-        data = {
+        data: dict[str, Any] = {
             "wedding": wedding.uuid,
             "name": "Item com instância",
             "quantity": 1,
@@ -190,12 +216,14 @@ class TestItemServiceCreate:
         item = ItemService.create(user.company, ItemIn(**data))
         assert item.wedding == wedding
 
-    def test_create_item_with_nonexistent_wedding_uuid_raises_error(self, user):
+    def test_create_item_with_nonexistent_wedding_uuid_raises_error(
+        self, user: Any
+    ) -> None:
         """
         Criação de item com UUID de casamento inexistente
         levanta ObjectNotFoundError.
         """
-        data = {
+        data: dict[str, Any] = {
             "wedding": uuid4(),
             "name": "Item fantasma",
             "quantity": 1,
@@ -211,16 +239,18 @@ class TestItemServiceCreate:
 class TestItemServiceUpdate:
     """Testes de atualização de itens via ItemService."""
 
-    def test_update_item_name(self, user):
+    def test_update_item_name(self, user: Any) -> None:
         """Atualização de campos simples é permitida."""
         wedding, contract = _setup_item_context(user)
         item = ItemFactory(contract=contract, wedding=wedding, name="Velho")
 
-        updated = ItemService.update(user.company, item, ItemPatchIn(name="Novo Nome"))
+        updated = ItemService.update(
+            user.company, item, ItemPatchIn.model_construct(name="Novo Nome")
+        )
 
         assert updated.name == "Novo Nome"
 
-    def test_update_item_acquisition_status(self, user):
+    def test_update_item_acquisition_status(self, user: Any) -> None:
         """Troca de status de aquisição é permitida (BR-L04)."""
         wedding, contract = _setup_item_context(user)
         item = ItemFactory(contract=contract, wedding=wedding)
@@ -228,24 +258,26 @@ class TestItemServiceUpdate:
         updated = ItemService.update(
             user.company,
             item,
-            ItemPatchIn(acquisition_status=Item.AcquisitionStatus.IN_PROGRESS),
+            ItemPatchIn.model_construct(
+                acquisition_status=Item.AcquisitionStatus.IN_PROGRESS
+            ),
         )
 
         assert updated.acquisition_status == Item.AcquisitionStatus.IN_PROGRESS
 
-    def test_update_item_cannot_change_wedding(self, user):
+    def test_update_item_cannot_change_wedding(self, user: Any) -> None:
         """Wedding é bloqueado no update."""
         wedding1, contract = _setup_item_context(user)
         wedding2 = WeddingFactory(user_context=user)
         item = ItemFactory(contract=contract, wedding=wedding1)
 
         updated = ItemService.update(
-            user.company, item, ItemPatchIn(wedding=wedding2.uuid)
+            user.company, item, ItemPatchIn.model_construct(wedding=wedding2.uuid)
         )
 
         assert updated.wedding == wedding1
 
-    def test_update_item_cross_tenant(self, user):
+    def test_update_item_cross_tenant(self, user: Any) -> None:
         """Item de outro tenant não pode ser atualizado."""
         other_user = UserFactory()
         other_wedding = WeddingFactory(company=other_user.company)
@@ -254,18 +286,24 @@ class TestItemServiceUpdate:
         other_item = ItemFactory(contract=other_contract, wedding=other_wedding)
 
         with pytest.raises(ObjectNotFoundError):
-            ItemService.update(user.company, other_item, ItemPatchIn(name="Hack"))
+            ItemService.update(
+                user.company,
+                other_item,
+                ItemPatchIn.model_construct(name="Hack"),
+            )
 
-    def test_update_item_clear_contract(self, user):
+    def test_update_item_clear_contract(self, user: Any) -> None:
         """Item pode ser desvinculado do contrato (contract=None)."""
         wedding, contract = _setup_item_context(user)
         item = ItemFactory(contract=contract, wedding=wedding)
 
-        updated = ItemService.update(user.company, item, ItemPatchIn(contract=None))
+        updated = ItemService.update(
+            user.company, item, ItemPatchIn.model_construct(contract=None)
+        )
 
         assert updated.contract is None
 
-    def test_update_item_contract_matching_wedding(self, user):
+    def test_update_item_contract_matching_wedding(self, user: Any) -> None:
         """Atualização do contrato para um contrato com casamento correspondente."""
         wedding, contract1 = _setup_item_context(user)
         supplier = SupplierFactory(company=user.company)
@@ -273,12 +311,16 @@ class TestItemServiceUpdate:
         item = ItemFactory(contract=contract1, wedding=wedding)
 
         updated = ItemService.update(
-            user.company, item, ItemPatchIn(contract=contract2.uuid)
+            user.company,
+            item,
+            ItemPatchIn.model_construct(contract=contract2.uuid),
         )
 
         assert updated.contract == contract2
 
-    def test_update_item_contract_mismatched_wedding_raises_error(self, user):
+    def test_update_item_contract_mismatched_wedding_raises_error(
+        self, user: Any
+    ) -> None:
         """Atualização do contrato para um com casamento diferente levanta erro."""
         wedding1, contract1 = _setup_item_context(user)
         wedding2 = WeddingFactory(user_context=user)
@@ -287,7 +329,11 @@ class TestItemServiceUpdate:
         item = ItemFactory(contract=contract1, wedding=wedding1)
 
         with pytest.raises(DomainIntegrityError) as exc_info:
-            ItemService.update(user.company, item, ItemPatchIn(contract=contract2.uuid))
+            ItemService.update(
+                user.company,
+                item,
+                ItemPatchIn.model_construct(contract=contract2.uuid),
+            )
 
         assert "item_contract_wedding_mismatch" in str(exc_info.value.code)
 
@@ -296,7 +342,7 @@ class TestItemServiceUpdate:
 class TestItemServiceDelete:
     """Testes de deleção de itens via ItemService."""
 
-    def test_delete_item_success(self, user):
+    def test_delete_item_success(self, user: Any) -> None:
         """Deleção de item sem dependências é permitida."""
         wedding, contract = _setup_item_context(user)
         item = ItemFactory(contract=contract, wedding=wedding)
@@ -305,7 +351,7 @@ class TestItemServiceDelete:
 
         assert Item.objects.filter(uuid=item.uuid).count() == 0
 
-    def test_delete_item_cross_tenant(self, user):
+    def test_delete_item_cross_tenant(self, user: Any) -> None:
         """Item de outro tenant não pode ser deletado."""
         other_user = UserFactory()
         other_wedding = WeddingFactory(company=other_user.company)
@@ -321,7 +367,7 @@ class TestItemServiceDelete:
 class TestItemServiceListAndGet:
     """Testes de listagem e obtenção de itens."""
 
-    def test_list_items_multitenancy(self):
+    def test_list_items_multitenancy(self) -> None:
         """list() retorna apenas itens do tenant."""
         user_a = UserFactory()
         user_b = UserFactory()
@@ -333,13 +379,17 @@ class TestItemServiceListAndGet:
 
         qs_a = ItemService.list(user_a.company)
         assert qs_a.count() == 1
-        assert qs_a.first().name == "Item A"
+        first_a = qs_a.first()
+        assert first_a is not None
+        assert first_a.name == "Item A"
 
         qs_b = ItemService.list(user_b.company)
         assert qs_b.count() == 1
-        assert qs_b.first().name == "Item B"
+        first_b = qs_b.first()
+        assert first_b is not None
+        assert first_b.name == "Item B"
 
-    def test_list_items_filter_by_wedding(self, user):
+    def test_list_items_filter_by_wedding(self, user: Any) -> None:
         """list() com wedding_id filtra por casamento."""
         wedding1, contract = _setup_item_context(user)
         wedding2 = WeddingFactory(user_context=user)
@@ -349,9 +399,11 @@ class TestItemServiceListAndGet:
 
         qs = ItemService.list(user.company, wedding_id=wedding1.uuid)
         assert qs.count() == 1
-        assert qs.first().name == "Item W1"
+        first = qs.first()
+        assert first is not None
+        assert first.name == "Item W1"
 
-    def test_get_item_success(self, user):
+    def test_get_item_success(self, user: Any) -> None:
         """get() retorna item com select_related."""
         wedding, contract = _setup_item_context(user)
         item = ItemFactory(contract=contract, wedding=wedding, name="Toalhas")
@@ -360,12 +412,12 @@ class TestItemServiceListAndGet:
         assert result.uuid == item.uuid
         assert result.name == "Toalhas"
 
-    def test_get_item_not_found(self, user):
+    def test_get_item_not_found(self, user: Any) -> None:
         """UUID inexistente levanta ObjectNotFoundError."""
         with pytest.raises(ObjectNotFoundError):
             ItemService.get(user.company, uuid4())
 
-    def test_get_item_multitenancy(self):
+    def test_get_item_multitenancy(self) -> None:
         """Usuário A não pode acessar item do Usuário B."""
         user_a = UserFactory()
         user_b = UserFactory()
@@ -380,7 +432,7 @@ class TestItemServiceListAndGet:
 class TestItemServiceTransitionStatus:
     """Testes da máquina de estados de itens."""
 
-    def test_pending_to_in_progress(self, user):
+    def test_pending_to_in_progress(self, user: Any) -> None:
         wedding, contract = _setup_item_context(user)
         item = ItemFactory(
             contract=contract, wedding=wedding, acquisition_status="PENDING"
@@ -388,7 +440,7 @@ class TestItemServiceTransitionStatus:
         result = ItemService.transition_status(user.company, item, "IN_PROGRESS")
         assert result.acquisition_status == "IN_PROGRESS"
 
-    def test_in_progress_to_done(self, user):
+    def test_in_progress_to_done(self, user: Any) -> None:
         wedding, contract = _setup_item_context(user)
         item = ItemFactory(
             contract=contract, wedding=wedding, acquisition_status="IN_PROGRESS"
@@ -396,7 +448,7 @@ class TestItemServiceTransitionStatus:
         result = ItemService.transition_status(user.company, item, "DONE")
         assert result.acquisition_status == "DONE"
 
-    def test_in_progress_to_pending(self, user):
+    def test_in_progress_to_pending(self, user: Any) -> None:
         wedding, contract = _setup_item_context(user)
         item = ItemFactory(
             contract=contract, wedding=wedding, acquisition_status="IN_PROGRESS"
@@ -404,7 +456,7 @@ class TestItemServiceTransitionStatus:
         result = ItemService.transition_status(user.company, item, "PENDING")
         assert result.acquisition_status == "PENDING"
 
-    def test_done_to_in_progress(self, user):
+    def test_done_to_in_progress(self, user: Any) -> None:
         wedding, contract = _setup_item_context(user)
         item = ItemFactory(
             contract=contract, wedding=wedding, acquisition_status="DONE"
@@ -412,7 +464,7 @@ class TestItemServiceTransitionStatus:
         result = ItemService.transition_status(user.company, item, "IN_PROGRESS")
         assert result.acquisition_status == "IN_PROGRESS"
 
-    def test_pending_to_done_invalid(self, user):
+    def test_pending_to_done_invalid(self, user: Any) -> None:
         wedding, contract = _setup_item_context(user)
         item = ItemFactory(
             contract=contract, wedding=wedding, acquisition_status="PENDING"
@@ -420,7 +472,7 @@ class TestItemServiceTransitionStatus:
         with pytest.raises(BusinessRuleViolation):
             ItemService.transition_status(user.company, item, "DONE")
 
-    def test_done_to_pending_invalid(self, user):
+    def test_done_to_pending_invalid(self, user: Any) -> None:
         wedding, contract = _setup_item_context(user)
         item = ItemFactory(
             contract=contract, wedding=wedding, acquisition_status="DONE"
@@ -428,7 +480,7 @@ class TestItemServiceTransitionStatus:
         with pytest.raises(BusinessRuleViolation):
             ItemService.transition_status(user.company, item, "PENDING")
 
-    def test_transition_status_multitenancy(self, user):
+    def test_transition_status_multitenancy(self, user: Any) -> None:
         """Transição com company diferente deve falhar."""
         wedding, contract = _setup_item_context(user)
         item = ItemFactory(

--- a/backend/apps/logistics/tests/suppliers/test_models.py
+++ b/backend/apps/logistics/tests/suppliers/test_models.py
@@ -9,12 +9,12 @@ from apps.logistics.tests.factories import SupplierFactory
 class TestSupplierModelMetadata:
     """Testes de representação e metadados do modelo Supplier."""
 
-    def test_supplier_str_is_name(self):
+    def test_supplier_str_is_name(self) -> None:
         """__str__ deve retornar o nome do fornecedor."""
         supplier = SupplierFactory.build(name="Buffet Master")
         assert str(supplier) == "Buffet Master"
 
-    def test_supplier_ordering_by_name(self):
+    def test_supplier_ordering_by_name(self) -> None:
         """Ordenação padrão deve ser alfabética por name."""
         SupplierFactory.create(name="Zeta")
         SupplierFactory.create(name="Alfa")
@@ -25,7 +25,7 @@ class TestSupplierModelMetadata:
         assert suppliers[1].name == "Beta"
         assert suppliers[2].name == "Zeta"
 
-    def test_supplier_is_active_default(self):
+    def test_supplier_is_active_default(self) -> None:
         """is_active deve ser True por padrão."""
         supplier = SupplierFactory.build()
         assert supplier.is_active is True
@@ -35,7 +35,7 @@ class TestSupplierModelMetadata:
 class TestSupplierFullAddress:
     """Testes da computed property full_address."""
 
-    def test_full_address_with_all_fields(self):
+    def test_full_address_with_all_fields(self) -> None:
         """full_address deve concatenar address, city e state."""
         supplier = SupplierFactory.build(
             address="Rua das Flores, 123",
@@ -48,7 +48,7 @@ class TestSupplierFullAddress:
         assert "São Paulo" in result
         assert "SP" in result
 
-    def test_full_address_without_state(self):
+    def test_full_address_without_state(self) -> None:
         """full_address sem state não deve incluir campo vazio."""
         supplier = SupplierFactory.build(
             address="Av. Paulista, 1000",
@@ -59,7 +59,7 @@ class TestSupplierFullAddress:
         result = supplier.full_address
         assert result == "Av. Paulista, 1000, São Paulo"
 
-    def test_full_address_minimal(self):
+    def test_full_address_minimal(self) -> None:
         """full_address com campos vazios deve retornar string enxuta."""
         supplier = SupplierFactory.build(
             address="",
@@ -76,7 +76,7 @@ class TestSupplierFullAddress:
 class TestSupplierCnpjValidation:
     """Testes de validação do campo CNPJ via full_clean()."""
 
-    def test_full_clean_rejects_invalid_cnpj(self):
+    def test_full_clean_rejects_invalid_cnpj(self) -> None:
         """full_clean() deve disparar ValidationError para CNPJ inválido."""
         supplier = SupplierFactory.build(cnpj="123")
 
@@ -84,7 +84,7 @@ class TestSupplierCnpjValidation:
             supplier.full_clean()
         assert "cnpj" in exc_info.value.message_dict
 
-    def test_full_clean_accepts_valid_cnpj(self):
+    def test_full_clean_accepts_valid_cnpj(self) -> None:
         """full_clean() deve aceitar CNPJ no formato correto."""
         supplier = SupplierFactory.create(
             cnpj="00.000.000/0001-00",
@@ -92,7 +92,7 @@ class TestSupplierCnpjValidation:
 
         supplier.full_clean()
 
-    def test_full_clean_accepts_empty_cnpj(self):
+    def test_full_clean_accepts_empty_cnpj(self) -> None:
         """full_clean() deve aceitar CNPJ vazio (blank=True)."""
         supplier = SupplierFactory.create(
             cnpj="",

--- a/backend/apps/logistics/tests/suppliers/test_services.py
+++ b/backend/apps/logistics/tests/suppliers/test_services.py
@@ -1,3 +1,4 @@
+from typing import Any, cast
 from uuid import uuid4
 
 import pytest
@@ -7,18 +8,41 @@ from apps.core.exceptions import ObjectNotFoundError
 from apps.logistics.models import Contract, Supplier
 from apps.logistics.schemas import SupplierIn, SupplierPatchIn
 from apps.logistics.services.supplier_service import SupplierService
-from apps.logistics.tests.factories import ContractFactory, SupplierFactory
-from apps.users.tests.factories import UserFactory
-from apps.weddings.tests.factories import WeddingFactory
+from apps.logistics.tests.factories import (
+    ContractFactory as _ContractFactory,
+)
+from apps.logistics.tests.factories import (
+    SupplierFactory as _SupplierFactory,
+)
+from apps.users.models import User
+from apps.users.tests.factories import UserFactory as _UserFactory
+from apps.weddings.models import Wedding
+from apps.weddings.tests.factories import WeddingFactory as _WeddingFactory
+
+
+def ContractFactory(*args: Any, **kwargs: Any) -> Contract:
+    return cast(Contract, _ContractFactory(*args, **kwargs))
+
+
+def SupplierFactory(*args: Any, **kwargs: Any) -> Supplier:
+    return cast(Supplier, _SupplierFactory(*args, **kwargs))
+
+
+def UserFactory(*args: Any, **kwargs: Any) -> User:
+    return cast(User, _UserFactory(*args, **kwargs))
+
+
+def WeddingFactory(*args: Any, **kwargs: Any) -> Wedding:
+    return cast(Wedding, _WeddingFactory(*args, **kwargs))
 
 
 @pytest.mark.django_db
 class TestSupplierServiceCreate:
     """Testes de criação de fornecedores via SupplierService."""
 
-    def test_create_supplier_success(self, user):
+    def test_create_supplier_success(self, user: Any) -> None:
         """Criação de fornecedor vinculado à empresa do planner."""
-        data = {
+        data: dict[str, Any] = {
             "name": "Buffet Master",
             "cnpj": "00.000.000/0001-00",
             "phone": "11999999999",
@@ -41,9 +65,11 @@ class TestSupplierServiceCreate:
         assert supplier.website == "https://buffetmaster.com.br"
         assert supplier.notes == "Fornecedor premium"
 
-    def test_create_supplier_with_invalid_cnpj_raises_validation_error(self, user):
+    def test_create_supplier_with_invalid_cnpj_raises_validation_error(
+        self, user: Any
+    ) -> None:
         """CNPJ com formato inválido deve disparar ValidationError."""
-        data = {
+        data: dict[str, Any] = {
             "name": "Fornecedor Inválido",
             "cnpj": "123",
             "phone": "11999999999",
@@ -58,44 +84,50 @@ class TestSupplierServiceCreate:
 class TestSupplierServiceUpdate:
     """Testes de atualização de fornecedores via SupplierService."""
 
-    def test_update_supplier_name(self, user):
+    def test_update_supplier_name(self, user: Any) -> None:
         """Atualização de nome é permitida."""
         supplier = SupplierFactory(company=user.company, name="Nome Antigo")
 
         updated = SupplierService.update(
-            user.company, supplier, SupplierPatchIn(name="Nome Novo")
+            user.company,
+            supplier,
+            SupplierPatchIn.model_construct(name="Nome Novo"),
         )
 
         assert updated.name == "Nome Novo"
 
-    def test_update_supplier_cross_tenant(self, user):
+    def test_update_supplier_cross_tenant(self, user: Any) -> None:
         """Fornecedor de outro tenant não pode ser atualizado."""
         other_user = UserFactory()
         other_supplier = SupplierFactory(company=other_user.company)
 
         with pytest.raises(ObjectNotFoundError):
             SupplierService.update(
-                user.company, other_supplier, SupplierPatchIn(name="Hack")
+                user.company,
+                other_supplier,
+                SupplierPatchIn.model_construct(name="Hack"),
             )
 
-    def test_update_supplier_toggle_active(self, user):
+    def test_update_supplier_toggle_active(self, user: Any) -> None:
         """Desativar/ativar fornecedor via is_active."""
         supplier = SupplierFactory(company=user.company, is_active=True)
 
         updated = SupplierService.update(
-            user.company, supplier, SupplierPatchIn(is_active=False)
+            user.company,
+            supplier,
+            SupplierPatchIn.model_construct(is_active=False),
         )
 
         assert updated.is_active is False
 
-    def test_update_supplier_new_fields(self, user):
+    def test_update_supplier_new_fields(self, user: Any) -> None:
         """Atualização dos campos address, city, state, website, notes."""
         supplier = SupplierFactory(company=user.company)
 
         updated = SupplierService.update(
             user.company,
             supplier,
-            SupplierPatchIn(
+            SupplierPatchIn.model_construct(
                 address="Av. Paulista, 1000",
                 city="São Paulo",
                 state="SP",
@@ -115,7 +147,7 @@ class TestSupplierServiceUpdate:
 class TestSupplierServiceDelete:
     """Testes de deleção de fornecedores via SupplierService."""
 
-    def test_delete_supplier_success(self, user):
+    def test_delete_supplier_success(self, user: Any) -> None:
         """Deleção de fornecedor sem contratos é permitida."""
         supplier = SupplierFactory(company=user.company)
 
@@ -123,7 +155,7 @@ class TestSupplierServiceDelete:
 
         assert Supplier.objects.filter(uuid=supplier.uuid).count() == 0
 
-    def test_delete_supplier_cascades_to_contracts(self, user):
+    def test_delete_supplier_cascades_to_contracts(self, user: Any) -> None:
         """Fornecedor com contratos: CASCADE deleta contratos junto.
         (Contract.supplier é on_delete=CASCADE, sem proteção de integridade via FK.)"""
         wedding = WeddingFactory(user_context=user)
@@ -136,7 +168,7 @@ class TestSupplierServiceDelete:
         assert Supplier.objects.filter(uuid=supplier.uuid).count() == 0
         assert Contract.objects.filter(uuid=contract.uuid).count() == 0
 
-    def test_delete_supplier_cross_tenant(self, user):
+    def test_delete_supplier_cross_tenant(self, user: Any) -> None:
         """Fornecedor de outro tenant não pode ser deletado."""
         other_user = UserFactory()
         other_supplier = SupplierFactory(company=other_user.company)
@@ -149,7 +181,7 @@ class TestSupplierServiceDelete:
 class TestSupplierServiceListAndGet:
     """Testes de listagem e obtenção de fornecedores."""
 
-    def test_list_suppliers_multitenancy(self):
+    def test_list_suppliers_multitenancy(self) -> None:
         """list() retorna apenas fornecedores do tenant."""
         user_a = UserFactory()
         user_b = UserFactory()
@@ -159,13 +191,17 @@ class TestSupplierServiceListAndGet:
 
         qs_a = SupplierService.list(user_a.company)
         assert qs_a.count() == 1
-        assert qs_a.first().name == "Fornecedor A"
+        first_a = qs_a.first()
+        assert first_a is not None
+        assert first_a.name == "Fornecedor A"
 
         qs_b = SupplierService.list(user_b.company)
         assert qs_b.count() == 1
-        assert qs_b.first().name == "Fornecedor B"
+        first_b = qs_b.first()
+        assert first_b is not None
+        assert first_b.name == "Fornecedor B"
 
-    def test_get_supplier_success(self, user):
+    def test_get_supplier_success(self, user: Any) -> None:
         """get() retorna fornecedor por UUID."""
         supplier = SupplierFactory(company=user.company, name="Decorações Ltda")
 
@@ -174,12 +210,12 @@ class TestSupplierServiceListAndGet:
         assert result.uuid == supplier.uuid
         assert result.name == "Decorações Ltda"
 
-    def test_get_supplier_not_found(self, user):
+    def test_get_supplier_not_found(self, user: Any) -> None:
         """UUID inexistente levanta ObjectNotFoundError."""
         with pytest.raises(ObjectNotFoundError):
             SupplierService.get(user.company, uuid4())
 
-    def test_get_supplier_multitenancy(self):
+    def test_get_supplier_multitenancy(self) -> None:
         """Usuário A não pode acessar fornecedor do Usuário B."""
         user_a = UserFactory()
         user_b = UserFactory()
@@ -188,7 +224,7 @@ class TestSupplierServiceListAndGet:
         with pytest.raises(ObjectNotFoundError):
             SupplierService.get(user_a.company, supplier_b.uuid)
 
-    def test_supplier_visible_across_weddings(self, user):
+    def test_supplier_visible_across_weddings(self, user: Any) -> None:
         """BR-L03: mesmo fornecedor é acessível em múltiplos casamentos."""
         supplier = SupplierFactory(company=user.company)
 
@@ -201,6 +237,7 @@ class TestSupplierServiceListAndGet:
         # Fornecedor deve aparecer apenas uma vez na listagem
         qs = SupplierService.list(user.company)
         assert qs.count() == 1
-        assert qs.first() == supplier
+        first = qs.first()
+        assert first == supplier
         # E ter 2 contratos associados
         assert supplier.contracts.count() == 2

--- a/backend/apps/logistics/tests/test_apis.py
+++ b/backend/apps/logistics/tests/test_apis.py
@@ -1,24 +1,40 @@
 import json
 from datetime import date
 from decimal import Decimal
+from typing import Any, cast
 
 import pytest
 
 from apps.finances.services.budget_service import BudgetService
 from apps.finances.tests.factories import BudgetCategoryFactory, BudgetFactory
+from apps.logistics.models import Supplier
 from apps.logistics.schemas import ContractIn, ItemIn, SupplierIn
 from apps.logistics.services.contract_service import ContractService
 from apps.logistics.services.item_service import ItemService
 from apps.logistics.services.supplier_service import SupplierService
-from apps.logistics.tests.factories import SupplierFactory
-from apps.users.tests.factories import UserFactory
+from apps.logistics.tests.factories import SupplierFactory as _SupplierFactory
+from apps.users.models import User
+from apps.users.tests.factories import UserFactory as _UserFactory
+from apps.weddings.models import Wedding
 from apps.weddings.schemas import WeddingIn
 from apps.weddings.services import WeddingService
-from apps.weddings.tests.factories import WeddingFactory
+from apps.weddings.tests.factories import WeddingFactory as _WeddingFactory
+
+
+def SupplierFactory(*args: Any, **kwargs: Any) -> Supplier:
+    return cast(Supplier, _SupplierFactory(*args, **kwargs))
+
+
+def UserFactory(*args: Any, **kwargs: Any) -> User:
+    return cast(User, _UserFactory(*args, **kwargs))
+
+
+def WeddingFactory(*args: Any, **kwargs: Any) -> Wedding:
+    return cast(Wedding, _WeddingFactory(*args, **kwargs))
 
 
 @pytest.fixture
-def seed_data(user, django_user_model):
+def seed_data(user: User, django_user_model: Any) -> dict[str, Any]:
     # Planner alvo
     my_wedding = WeddingService.create(
         user.company,
@@ -27,6 +43,7 @@ def seed_data(user, django_user_model):
             groom_name="Noz",
             location="Local",
             date=date(2026, 10, 10),
+            template=None,
         ),
     )
     my_supplier = SupplierService.create(
@@ -36,6 +53,8 @@ def seed_data(user, django_user_model):
             cnpj="00.000.000/0001-00",
             phone="0",
             email="a@email.com",
+            state="",
+            website="",
         ),
     )
     my_contract = ContractService.create(
@@ -60,8 +79,6 @@ def seed_data(user, django_user_model):
     )
 
     # Planner alheio
-    from apps.users.tests.factories import UserFactory
-
     other_user = UserFactory(email="a@a.com")
     other_user.set_password("123")
     other_user.save()
@@ -72,12 +89,18 @@ def seed_data(user, django_user_model):
             groom_name="Noz",
             location="Local",
             date=date(2026, 10, 10),
+            template=None,
         ),
     )
     other_supplier = SupplierService.create(
         other_user.company,
         SupplierIn(
-            name="Outro", cnpj="00.000.000/0001-01", phone="1", email="b@email.com"
+            name="Outro",
+            cnpj="00.000.000/0001-01",
+            phone="1",
+            email="b@email.com",
+            state="",
+            website="",
         ),
     )
     other_contract = ContractService.create(
@@ -118,21 +141,27 @@ def seed_data(user, django_user_model):
 
 @pytest.mark.django_db
 class TestLogisticsNinjaAPI:
-    def test_list_suppliers_isolation(self, auth_client, seed_data):
+    def test_list_suppliers_isolation(
+        self, auth_client: Any, seed_data: dict[str, Any]
+    ) -> None:
         response = auth_client.get("/api/v1/logistics/suppliers/")
         assert response.status_code == 200
         data = response.json()
         assert len(data["items"]) == 1
         assert data["items"][0]["name"] == "Fornecedor Meu"
 
-    def test_list_contracts_isolation(self, auth_client, seed_data):
+    def test_list_contracts_isolation(
+        self, auth_client: Any, seed_data: dict[str, Any]
+    ) -> None:
         response = auth_client.get("/api/v1/logistics/contracts/")
         assert response.status_code == 200
         data = response.json()
         assert len(data["items"]) == 1
         assert data["items"][0]["status"] == "DRAFT"
 
-    def test_list_contracts_filter_by_parent(self, auth_client, seed_data):
+    def test_list_contracts_filter_by_parent(
+        self, auth_client: Any, seed_data: dict[str, Any]
+    ) -> None:
         """GET /api/v1/logistics/contracts/?parent_id=X retorna só aditivos."""
         response = auth_client.get(
             f"/api/v1/logistics/contracts/?parent_id={seed_data['my_contract'].uuid}"
@@ -141,14 +170,16 @@ class TestLogisticsNinjaAPI:
         data = response.json()
         assert len(data["items"]) == 0  # seed_data não cria aditivos
 
-    def test_list_items_isolation(self, auth_client, seed_data):
+    def test_list_items_isolation(
+        self, auth_client: Any, seed_data: dict[str, Any]
+    ) -> None:
         response = auth_client.get("/api/v1/logistics/items/")
         assert response.status_code == 200
         data = response.json()
         assert len(data["items"]) == 1
         assert data["items"][0]["name"] == "Item Meu"
 
-    def test_create_supplier_success(self, auth_client):
+    def test_create_supplier_success(self, auth_client: Any) -> None:
         payload = {
             "name": "Banda Ninja",
             "cnpj": "99.999.999/0001-99",
@@ -176,7 +207,7 @@ class TestLogisticsNinjaAPI:
         assert data["website"] == "https://bandaninja.com.br"
         assert data["notes"] == "Banda de casamento"
 
-    def test_create_supplier_invalid_cnpj_returns_422(self, auth_client):
+    def test_create_supplier_invalid_cnpj_returns_422(self, auth_client: Any) -> None:
         payload = {
             "name": "CNPJ Inválido",
             "cnpj": "123",
@@ -190,7 +221,9 @@ class TestLogisticsNinjaAPI:
         )
         assert response.status_code == 422
 
-    def test_create_supplier_invalid_cnpj_shows_friendly_message(self, auth_client):
+    def test_create_supplier_invalid_cnpj_shows_friendly_message(
+        self, auth_client: Any
+    ) -> None:
         """CNPJ inválido deve retornar 422 com mensagem amigável, não regex cru."""
         payload = {
             "name": "CNPJ Inválido",
@@ -208,7 +241,9 @@ class TestLogisticsNinjaAPI:
         detail = str(body.get("detail", ""))
         assert "formato" in detail.lower() or "XX.XXX" in detail
 
-    def test_list_suppliers_filter_by_search(self, auth_client, user):
+    def test_list_suppliers_filter_by_search(
+        self, auth_client: Any, user: User
+    ) -> None:
         SupplierService.create(
             user.company,
             SupplierIn(
@@ -216,6 +251,8 @@ class TestLogisticsNinjaAPI:
                 cnpj="00.000.000/0001-00",
                 phone="1",
                 email="buffet@email.com",
+                state="",
+                website="",
             ),
         )
         SupplierService.create(
@@ -225,6 +262,8 @@ class TestLogisticsNinjaAPI:
                 cnpj="00.000.000/0001-00",
                 phone="2",
                 email="foto@email.com",
+                state="",
+                website="",
             ),
         )
         SupplierService.create(
@@ -234,6 +273,8 @@ class TestLogisticsNinjaAPI:
                 cnpj="00.000.000/0001-00",
                 phone="3",
                 email="outro@email.com",
+                state="",
+                website="",
             ),
         )
 
@@ -244,7 +285,9 @@ class TestLogisticsNinjaAPI:
         assert len(data["items"]) == 1
         assert data["items"][0]["name"] == "Buffet Estrela"
 
-    def test_list_suppliers_filter_by_is_active(self, auth_client, user):
+    def test_list_suppliers_filter_by_is_active(
+        self, auth_client: Any, user: User
+    ) -> None:
         SupplierService.create(
             user.company,
             SupplierIn(
@@ -252,6 +295,8 @@ class TestLogisticsNinjaAPI:
                 cnpj="00.000.000/0001-00",
                 phone="1",
                 email="a@email.com",
+                state="",
+                website="",
                 is_active=True,
             ),
         )
@@ -262,6 +307,8 @@ class TestLogisticsNinjaAPI:
                 cnpj="00.000.000/0001-00",
                 phone="2",
                 email="b@email.com",
+                state="",
+                website="",
                 is_active=False,
             ),
         )
@@ -272,7 +319,9 @@ class TestLogisticsNinjaAPI:
         assert data["count"] == 1
         assert data["items"][0]["name"] == "Inativo"
 
-    def test_list_suppliers_filter_by_search_and_status(self, auth_client, user):
+    def test_list_suppliers_filter_by_search_and_status(
+        self, auth_client: Any, user: User
+    ) -> None:
         SupplierService.create(
             user.company,
             SupplierIn(
@@ -280,6 +329,8 @@ class TestLogisticsNinjaAPI:
                 cnpj="00.000.000/0001-00",
                 phone="1",
                 email="a@email.com",
+                state="",
+                website="",
                 is_active=True,
             ),
         )
@@ -290,6 +341,8 @@ class TestLogisticsNinjaAPI:
                 cnpj="00.000.000/0001-00",
                 phone="2",
                 email="b@email.com",
+                state="",
+                website="",
                 is_active=False,
             ),
         )
@@ -302,7 +355,9 @@ class TestLogisticsNinjaAPI:
         assert data["count"] == 1
         assert data["items"][0]["name"] == "A Buffet"
 
-    def test_update_contract_success(self, auth_client, seed_data):
+    def test_update_contract_success(
+        self, auth_client: Any, seed_data: dict[str, Any]
+    ) -> None:
         """Testa atualização de contrato com PATCH."""
         contract = seed_data["my_contract"]
         payload = {"name": "Contrato Atualizado"}
@@ -315,8 +370,8 @@ class TestLogisticsNinjaAPI:
         assert response.json()["name"] == "Contrato Atualizado"
 
     def test_update_contract_wedding_field_is_ignored(
-        self, auth_client, seed_data, user
-    ):
+        self, auth_client: Any, seed_data: dict[str, Any], user: User
+    ) -> None:
         """
         Testa que enviar o campo wedding no PATCH do contrato é ignorado (200)
         e não altera o casamento.
@@ -334,13 +389,17 @@ class TestLogisticsNinjaAPI:
         assert contract.name == "Novo Nome"
         assert contract.wedding.uuid == seed_data["my_contract"].wedding.uuid
 
-    def test_delete_contract_success(self, auth_client, seed_data):
+    def test_delete_contract_success(
+        self, auth_client: Any, seed_data: dict[str, Any]
+    ) -> None:
         """Testa exclusão de contrato com DELETE."""
         contract = seed_data["my_contract"]
         response = auth_client.delete(f"/api/v1/logistics/contracts/{contract.uuid}/")
         assert response.status_code == 204
 
-    def test_update_item_success(self, auth_client, seed_data):
+    def test_update_item_success(
+        self, auth_client: Any, seed_data: dict[str, Any]
+    ) -> None:
         """Testa atualização de item com PATCH."""
         item = seed_data["my_item"]
         payload = {"name": "Item Atualizado"}
@@ -352,7 +411,9 @@ class TestLogisticsNinjaAPI:
         assert response.status_code == 200
         assert response.json()["name"] == "Item Atualizado"
 
-    def test_update_item_wedding_field_is_ignored(self, auth_client, seed_data, user):
+    def test_update_item_wedding_field_is_ignored(
+        self, auth_client: Any, seed_data: dict[str, Any], user: User
+    ) -> None:
         """
         Testa que enviar o campo wedding no PATCH do item é ignorado (200)
         e não altera o casamento.
@@ -370,13 +431,17 @@ class TestLogisticsNinjaAPI:
         assert item.name == "Novo Nome"
         assert item.wedding.uuid == seed_data["my_item"].wedding.uuid
 
-    def test_delete_item_success(self, auth_client, seed_data):
+    def test_delete_item_success(
+        self, auth_client: Any, seed_data: dict[str, Any]
+    ) -> None:
         """Testa exclusão de item com DELETE."""
         item = seed_data["my_item"]
         response = auth_client.delete(f"/api/v1/logistics/items/{item.uuid}/")
         assert response.status_code == 204
 
-    def test_update_supplier_success(self, auth_client, seed_data):
+    def test_update_supplier_success(
+        self, auth_client: Any, seed_data: dict[str, Any]
+    ) -> None:
         """Testa atualização de fornecedor com PATCH."""
         supplier = seed_data["my_supplier"]
         payload = {"name": "Fornecedor Atualizado"}
@@ -388,20 +453,26 @@ class TestLogisticsNinjaAPI:
         assert response.status_code == 200
         assert response.json()["name"] == "Fornecedor Atualizado"
 
-    def test_delete_supplier_success(self, auth_client, seed_data):
+    def test_delete_supplier_success(
+        self, auth_client: Any, seed_data: dict[str, Any]
+    ) -> None:
         """Testa exclusão de fornecedor com DELETE."""
         supplier = seed_data["my_supplier"]
         response = auth_client.delete(f"/api/v1/logistics/suppliers/{supplier.uuid}/")
         assert response.status_code == 204
 
-    def test_retrieve_contract(self, auth_client, seed_data):
+    def test_retrieve_contract(
+        self, auth_client: Any, seed_data: dict[str, Any]
+    ) -> None:
         response = auth_client.get(
             f"/api/v1/logistics/contracts/{seed_data['my_contract'].uuid}/"
         )
         assert response.status_code == 200
         assert response.json()["name"] == "Contrato Teste"
 
-    def test_create_contract_via_api(self, auth_client, seed_data):
+    def test_create_contract_via_api(
+        self, auth_client: Any, seed_data: dict[str, Any]
+    ) -> None:
         payload = {
             "wedding": str(seed_data["my_contract"].wedding.uuid),
             "supplier": str(seed_data["my_supplier"].uuid),
@@ -417,7 +488,9 @@ class TestLogisticsNinjaAPI:
         assert response.status_code == 201
         assert response.json()["name"] == "Contrato API"
 
-    def test_upload_contract_file(self, auth_client, seed_data):
+    def test_upload_contract_file(
+        self, auth_client: Any, seed_data: dict[str, Any]
+    ) -> None:
         response = auth_client.post(
             f"/api/v1/logistics/contracts/{seed_data['my_contract'].uuid}/upload/",
             data=json.dumps({"pdf_file_key": "contracts/test.pdf"}),
@@ -425,7 +498,9 @@ class TestLogisticsNinjaAPI:
         )
         assert response.status_code == 200
 
-    def test_delete_contract_file(self, auth_client, seed_data):
+    def test_delete_contract_file(
+        self, auth_client: Any, seed_data: dict[str, Any]
+    ) -> None:
         auth_client.post(
             f"/api/v1/logistics/contracts/{seed_data['my_contract'].uuid}/upload/",
             data=json.dumps({"pdf_file_key": "contracts/test.pdf"}),
@@ -436,7 +511,9 @@ class TestLogisticsNinjaAPI:
         )
         assert response.status_code == 204
 
-    def test_transition_contract_status(self, auth_client, seed_data):
+    def test_transition_contract_status(
+        self, auth_client: Any, seed_data: dict[str, Any]
+    ) -> None:
         """DRAFT → PENDING (transição válida)."""
         response = auth_client.post(
             f"/api/v1/logistics/contracts/{seed_data['my_contract'].uuid}"
@@ -447,14 +524,16 @@ class TestLogisticsNinjaAPI:
         assert response.status_code == 200
         assert response.json()["status"] == "PENDING"
 
-    def test_retrieve_item(self, auth_client, seed_data):
+    def test_retrieve_item(self, auth_client: Any, seed_data: dict[str, Any]) -> None:
         response = auth_client.get(
             f"/api/v1/logistics/items/{seed_data['my_item'].uuid}/"
         )
         assert response.status_code == 200
         assert response.json()["name"] == "Item Meu"
 
-    def test_create_item_via_api(self, auth_client, seed_data):
+    def test_create_item_via_api(
+        self, auth_client: Any, seed_data: dict[str, Any]
+    ) -> None:
         payload = {
             "wedding": str(seed_data["my_contract"].wedding.uuid),
             "contract": str(seed_data["my_contract"].uuid),
@@ -469,7 +548,9 @@ class TestLogisticsNinjaAPI:
         assert response.status_code == 201
         assert response.json()["name"] == "Item API"
 
-    def test_transition_item_status(self, auth_client, seed_data):
+    def test_transition_item_status(
+        self, auth_client: Any, seed_data: dict[str, Any]
+    ) -> None:
         """PENDING → IN_PROGRESS → DONE."""
         # Primeiro PENDING → IN_PROGRESS
         auth_client.post(
@@ -486,7 +567,9 @@ class TestLogisticsNinjaAPI:
         assert response.status_code == 200
         assert response.json()["acquisition_status"] == "DONE"
 
-    def test_retrieve_supplier(self, auth_client, seed_data):
+    def test_retrieve_supplier(
+        self, auth_client: Any, seed_data: dict[str, Any]
+    ) -> None:
         response = auth_client.get(
             f"/api/v1/logistics/suppliers/{seed_data['my_supplier'].uuid}/"
         )
@@ -505,18 +588,18 @@ class DummyStorageService:
 class TestContractCreateFullAPI:
     """Testes HTTP do endpoint contracts/full/ (criação atômica)."""
 
-    def _wedding_supplier(self, user):
+    def _wedding_supplier(self, user: User) -> tuple[Any, Supplier]:
         wedding = WeddingFactory(company=user.company)
         supplier = SupplierFactory(company=user.company)
         return wedding, supplier
 
-    def _category(self, user):
+    def _category(self, user: User) -> tuple[Any, Any]:
         wedding = WeddingFactory(company=user.company)
         budget = BudgetFactory(wedding=wedding)
         category = BudgetCategoryFactory(budget=budget)
         return wedding, category
 
-    def test_create_full_contract_only(self, auth_client, user):
+    def test_create_full_contract_only(self, auth_client: Any, user: User) -> None:
         """POST /full/ apenas com dados do contrato retorna 201."""
         wedding, supplier = self._wedding_supplier(user)
         response = auth_client.post(
@@ -536,7 +619,7 @@ class TestContractCreateFullAPI:
         assert data["name"] == "Contrato Full"
         assert "uuid" in data
 
-    def test_create_full_with_items(self, auth_client, user):
+    def test_create_full_with_items(self, auth_client: Any, user: User) -> None:
         """POST /full/ com items_data em JSON string retorna 201."""
         wedding, supplier = self._wedding_supplier(user)
         response = auth_client.post(
@@ -558,7 +641,7 @@ class TestContractCreateFullAPI:
         assert response.status_code == 201
         assert response.json()["name"] == "Contrato com Itens"
 
-    def test_create_full_with_file(self, auth_client, user):
+    def test_create_full_with_file(self, auth_client: Any, user: User) -> None:
         """POST /full/ com pdf_file_key retorna 201."""
         wedding, supplier = self._wedding_supplier(user)
         response = auth_client.post(
@@ -579,7 +662,7 @@ class TestContractCreateFullAPI:
         assert data["has_file"] is True
         assert data["file_name"] == "contrato.pdf"
 
-    def test_create_full_with_expense(self, auth_client, user):
+    def test_create_full_with_expense(self, auth_client: Any, user: User) -> None:
         """POST /full/ com create_expense=True cria despesa vinculada."""
         wedding, category = self._category(user)
         supplier = SupplierFactory(company=user.company)
@@ -603,7 +686,7 @@ class TestContractCreateFullAPI:
         data = response.json()
         assert data["expense_uuid"] is not None
 
-    def test_create_full_with_all(self, auth_client, user):
+    def test_create_full_with_all(self, auth_client: Any, user: User) -> None:
         """POST /full/ com file + items + expense — cenário completo."""
         wedding, category = self._category(user)
         supplier = SupplierFactory(company=user.company)
@@ -634,7 +717,7 @@ class TestContractCreateFullAPI:
         data = response.json()
         assert data["name"] == "Contrato Completo"
 
-    def test_create_full_invalid_items_json(self, auth_client, user):
+    def test_create_full_invalid_items_json(self, auth_client: Any, user: User) -> None:
         """POST /full/ com items_data inválido retorna 422."""
         wedding, supplier = self._wedding_supplier(user)
         response = auth_client.post(
@@ -655,7 +738,7 @@ class TestContractCreateFullAPI:
         detail = str(body.get("detail", ""))
         assert "json" in detail.lower()
 
-    def test_create_full_non_list_items_json(self, auth_client, user) -> None:
+    def test_create_full_non_list_items_json(self, auth_client: Any, user: Any) -> None:
         """POST /full/ com items_data não-lista retorna 422."""
         wedding, supplier = self._wedding_supplier(user)
         response = auth_client.post(
@@ -675,7 +758,9 @@ class TestContractCreateFullAPI:
         body = response.json()
         assert "items_data" in str(body).lower()
 
-    def test_create_full_expense_without_category(self, auth_client, user):
+    def test_create_full_expense_without_category(
+        self, auth_client: Any, user: User
+    ) -> None:
         """POST /full/ com create_expense=True sem categoria retorna 422."""
         wedding = WeddingFactory(company=user.company)
         supplier = SupplierFactory(company=user.company)
@@ -694,7 +779,7 @@ class TestContractCreateFullAPI:
         )
         assert response.status_code == 422
 
-    def test_create_full_multitenancy(self, auth_client, user):
+    def test_create_full_multitenancy(self, auth_client: Any, user: User) -> None:
         """Usuário não pode criar contrato com wedding de outro tenant."""
         other_user = UserFactory()
         other_wedding = WeddingFactory(company=other_user.company)
@@ -713,7 +798,9 @@ class TestContractCreateFullAPI:
         )
         assert response.status_code == 404
 
-    def test_generate_upload_url_api_success(self, auth_client, user, settings):
+    def test_generate_upload_url_api_success(
+        self, auth_client: Any, user: User, settings: Any
+    ) -> None:
         settings.AWS_STORAGE_BUCKET_NAME = "test-bucket"
         wedding = WeddingFactory(company=user.company)
 
@@ -742,22 +829,22 @@ class TestContractCreateFullAPI:
                 data["upload_url"] == f"https://r2.com/test-bucket/{data['object_key']}"
             )
         finally:
-            ContractService.set_storage_service(original_storage)
+            ContractService.set_storage_service(cast(Any, original_storage))
 
 
 @pytest.mark.django_db
 class TestLogisticsAPIAuth:
-    def test_contracts_requires_auth(self, client):
+    def test_contracts_requires_auth(self, client: Any) -> None:
         """Verifica que listar contratos sem autenticação retorna 401."""
         response = client.get("/api/v1/logistics/contracts/")
         assert response.status_code == 401
 
-    def test_items_requires_auth(self, client):
+    def test_items_requires_auth(self, client: Any) -> None:
         """Verifica que listar itens sem autenticação retorna 401."""
         response = client.get("/api/v1/logistics/items/")
         assert response.status_code == 401
 
-    def test_suppliers_requires_auth(self, client):
+    def test_suppliers_requires_auth(self, client: Any) -> None:
         """Verifica que listar fornecedores sem autenticação retorna 401."""
         response = client.get("/api/v1/logistics/suppliers/")
         assert response.status_code == 401

--- a/backend/apps/notifications/services.py
+++ b/backend/apps/notifications/services.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import Sequence
+from typing import TYPE_CHECKING, cast
 from uuid import UUID
 
 from django.db import transaction
@@ -15,6 +16,17 @@ from apps.users.models import User
 
 
 logger = logging.getLogger(__name__)
+
+
+if TYPE_CHECKING:
+
+    class AnnotatedNotification(Notification):
+        """Notificação com o nome do casamento calculado pela consulta."""
+
+        wedding_name: str | None
+
+else:
+    AnnotatedNotification = Notification
 
 
 def _get_wedding_name_subquery() -> Subquery:
@@ -158,7 +170,7 @@ class NotificationService:
         company: Company,
         user: User,
         is_read: bool | None = None,
-    ) -> QuerySet[Notification]:
+    ) -> QuerySet[AnnotatedNotification]:
         """Lista todas as notificações de um usuário vinculadas à sua empresa.
 
         Args:
@@ -178,7 +190,7 @@ class NotificationService:
         if is_read is not None:
             qs = qs.filter(is_read=is_read)
 
-        return qs
+        return cast(QuerySet[AnnotatedNotification], qs)
 
     @staticmethod
     def get_unread_count(company: Company, user: User) -> int:
@@ -203,7 +215,7 @@ class NotificationService:
         company: Company,
         user: User,
         notification_id: UUID | str,
-    ) -> Notification:
+    ) -> AnnotatedNotification:
         """Marca notificação como lida se ela pertencer ao usuário e empresa.
 
         Args:
@@ -237,7 +249,7 @@ class NotificationService:
                 user.id,
             )
 
-        return notification
+        return cast(AnnotatedNotification, notification)
 
     @staticmethod
     @transaction.atomic

--- a/backend/apps/notifications/tests/test_api.py
+++ b/backend/apps/notifications/tests/test_api.py
@@ -1,20 +1,33 @@
+from typing import Any, cast
 from uuid import uuid4
 
 import pytest
 
-from apps.notifications.tests.factories import NotificationFactory
-from apps.users.tests.factories import UserFactory
+from apps.notifications.models import Notification
+from apps.notifications.tests.factories import (
+    NotificationFactory as _NotificationFactory,
+)
+from apps.users.models import User
+from apps.users.tests.factories import UserFactory as _UserFactory
+
+
+def NotificationFactory(*args: Any, **kwargs: Any) -> Notification:
+    return cast(Notification, _NotificationFactory(*args, **kwargs))
+
+
+def UserFactory(*args: Any, **kwargs: Any) -> User:
+    return cast(User, _UserFactory(*args, **kwargs))
 
 
 @pytest.mark.django_db
 class TestNotificationsAPI:
     """Testes de integração para a API de Notificações In-App."""
 
-    def test_list_notifications_unauthorized(self, client):
+    def test_list_notifications_unauthorized(self, client: Any) -> None:
         response = client.get("/api/v1/notifications/")
         assert response.status_code == 401
 
-    def test_list_notifications_success(self, auth_client, user):
+    def test_list_notifications_success(self, auth_client: Any, user: Any) -> None:
         target_uuid = uuid4()
         wedding_uuid = uuid4()
         n1 = NotificationFactory(
@@ -43,7 +56,9 @@ class TestNotificationsAPI:
         assert n1_data["target_id"] == str(target_uuid)
         assert n1_data["wedding_id"] == str(wedding_uuid)
 
-    def test_list_notifications_filter_by_is_read(self, auth_client, user):
+    def test_list_notifications_filter_by_is_read(
+        self, auth_client: Any, user: Any
+    ) -> None:
         n1 = NotificationFactory(user=user, is_read=False)
         NotificationFactory(user=user, is_read=True)
 
@@ -54,7 +69,7 @@ class TestNotificationsAPI:
         assert len(items) == 1
         assert items[0]["uuid"] == str(n1.uuid)
 
-    def test_get_unread_count_success(self, auth_client, user):
+    def test_get_unread_count_success(self, auth_client: Any, user: Any) -> None:
         NotificationFactory(user=user, is_read=False)
         NotificationFactory(user=user, is_read=False)
         NotificationFactory(user=user, is_read=True)
@@ -64,7 +79,7 @@ class TestNotificationsAPI:
         data = response.json()
         assert data["count"] == 2
 
-    def test_mark_as_read_success(self, auth_client, user):
+    def test_mark_as_read_success(self, auth_client: Any, user: Any) -> None:
         notification = NotificationFactory(user=user, is_read=False)
 
         response = auth_client.patch(f"/api/v1/notifications/{notification.uuid}/read/")
@@ -73,18 +88,20 @@ class TestNotificationsAPI:
         assert data["is_read"] is True
         assert data["read_at"] is not None
 
-    def test_mark_as_read_not_found(self, auth_client):
+    def test_mark_as_read_not_found(self, auth_client: Any) -> None:
         response = auth_client.patch(f"/api/v1/notifications/{uuid4()}/read/")
         assert response.status_code == 404
 
-    def test_mark_as_read_other_user_notification(self, auth_client, user):
+    def test_mark_as_read_other_user_notification(
+        self, auth_client: Any, user: Any
+    ) -> None:
         other_user = UserFactory()
         other_note = NotificationFactory(user=other_user)
 
         response = auth_client.patch(f"/api/v1/notifications/{other_note.uuid}/read/")
         assert response.status_code == 404
 
-    def test_mark_all_as_read_success(self, auth_client, user):
+    def test_mark_all_as_read_success(self, auth_client: Any, user: Any) -> None:
         NotificationFactory(user=user, is_read=False)
         NotificationFactory(user=user, is_read=False)
         NotificationFactory(user=user, is_read=True)
@@ -97,12 +114,12 @@ class TestNotificationsAPI:
         count_response = auth_client.get("/api/v1/notifications/unread-count/")
         assert count_response.json()["count"] == 0
 
-    def test_delete_notification_api_success(self, auth_client, user):
+    def test_delete_notification_api_success(self, auth_client: Any, user: Any) -> None:
         n = NotificationFactory(user=user)
         response = auth_client.delete(f"/api/v1/notifications/{n.uuid}/")
         assert response.status_code == 204
 
-    def test_bulk_mark_as_read_api_success(self, auth_client, user):
+    def test_bulk_mark_as_read_api_success(self, auth_client: Any, user: Any) -> None:
         n1 = NotificationFactory(user=user, is_read=False)
         n2 = NotificationFactory(user=user, is_read=False)
         payload = {"notification_ids": [str(n1.uuid), str(n2.uuid)]}
@@ -115,7 +132,7 @@ class TestNotificationsAPI:
         assert response.status_code == 200
         assert response.json()["affected_count"] == 2
 
-    def test_bulk_delete_api_success(self, auth_client, user):
+    def test_bulk_delete_api_success(self, auth_client: Any, user: Any) -> None:
         n1 = NotificationFactory(user=user)
         n2 = NotificationFactory(user=user)
         payload = {"notification_ids": [str(n1.uuid), str(n2.uuid)]}
@@ -128,7 +145,7 @@ class TestNotificationsAPI:
         assert response.status_code == 200
         assert response.json()["affected_count"] == 2
 
-    def test_clear_all_api_success(self, auth_client, user):
+    def test_clear_all_api_success(self, auth_client: Any, user: Any) -> None:
         NotificationFactory(user=user)
         NotificationFactory(user=user)
 

--- a/backend/apps/notifications/tests/test_services.py
+++ b/backend/apps/notifications/tests/test_services.py
@@ -1,3 +1,4 @@
+from typing import Any, cast
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -6,20 +7,40 @@ from django.tasks import Task
 from django.utils import timezone
 
 from apps.core.exceptions import BusinessRuleViolation, ObjectNotFoundError
-from apps.notifications.models import NotificationType
+from apps.notifications.models import Notification, NotificationType
 from apps.notifications.services import NotificationService
-from apps.notifications.tests.factories import NotificationFactory
-from apps.tenants.tests.factories import CompanyFactory
+from apps.notifications.tests.factories import (
+    NotificationFactory as _NotificationFactory,
+)
+from apps.tenants.models import Company
+from apps.tenants.tests.factories import CompanyFactory as _CompanyFactory
 from apps.users.models import User
-from apps.users.tests.factories import UserFactory
-from apps.weddings.tests.factories import WeddingFactory
+from apps.users.tests.factories import UserFactory as _UserFactory
+from apps.weddings.models import Wedding
+from apps.weddings.tests.factories import WeddingFactory as _WeddingFactory
+
+
+def NotificationFactory(*args: Any, **kwargs: Any) -> Notification:
+    return cast(Notification, _NotificationFactory(*args, **kwargs))
+
+
+def CompanyFactory(*args: Any, **kwargs: Any) -> Company:
+    return cast(Company, _CompanyFactory(*args, **kwargs))
+
+
+def UserFactory(*args: Any, **kwargs: Any) -> User:
+    return cast(User, _UserFactory(*args, **kwargs))
+
+
+def WeddingFactory(*args: Any, **kwargs: Any) -> Wedding:
+    return cast(Wedding, _WeddingFactory(*args, **kwargs))
 
 
 @pytest.mark.django_db
 class TestNotificationServiceCreate:
     """Testes para o método create_notification."""
 
-    def test_create_notification_success(self, user):
+    def test_create_notification_success(self, user: Any) -> None:
         notification = NotificationService.create_notification(
             company=user.company,
             user=user,
@@ -39,7 +60,7 @@ class TestNotificationServiceCreate:
         assert notification.is_read is False
         assert notification.read_at is None
 
-    def test_create_notification_with_target_fields(self, user):
+    def test_create_notification_with_target_fields(self, user: Any) -> None:
         target_uuid = uuid4()
         wedding_uuid = uuid4()
 
@@ -59,7 +80,7 @@ class TestNotificationServiceCreate:
         assert notification.target_id == target_uuid
         assert notification.wedding_id == wedding_uuid
 
-    def test_create_notification_with_company_and_user_ids(self, user):
+    def test_create_notification_with_company_and_user_ids(self, user: Any) -> None:
         notification_by_id = NotificationService.create_notification(
             company=user.company.id,
             user=user.id,
@@ -78,7 +99,7 @@ class TestNotificationServiceCreate:
         assert notification_by_uuid.company == user.company
         assert notification_by_uuid.user == user
 
-    def test_create_notification_failure_invalid_user_id(self, user):
+    def test_create_notification_failure_invalid_user_id(self, user: Any) -> None:
         with pytest.raises(User.DoesNotExist):
             NotificationService.create_notification(
                 company=user.company,
@@ -87,7 +108,7 @@ class TestNotificationServiceCreate:
                 message="Mensagem",
             )
 
-    def test_create_notification_failure_user_company_mismatch(self, user):
+    def test_create_notification_failure_user_company_mismatch(self, user: Any) -> None:
         other_company = CompanyFactory()
         with pytest.raises(
             BusinessRuleViolation, match=r"Usuário não pertence à empresa informada\."
@@ -99,7 +120,7 @@ class TestNotificationServiceCreate:
                 message="Mensagem",
             )
 
-    def test_notification_str_representation(self, user):
+    def test_notification_str_representation(self, user: Any) -> None:
         notification = NotificationFactory(
             user=user, title="Novo Evento", type=NotificationType.GENERAL
         )
@@ -110,7 +131,7 @@ class TestNotificationServiceCreate:
 class TestNotificationServiceCreateAsync:
     """Testes para o método create_async_notification."""
 
-    def test_create_async_notification_success(self, user):
+    def test_create_async_notification_success(self, user: Any) -> None:
         with patch.object(Task, "enqueue") as mock_enqueue:
             NotificationService.create_async_notification(
                 company=user.company,
@@ -128,7 +149,7 @@ class TestNotificationServiceCreateAsync:
             assert kwargs["message"] == "Async Message"
             assert kwargs["notification_type"] == NotificationType.GENERAL
 
-    def test_create_async_notification_with_target_fields(self, user):
+    def test_create_async_notification_with_target_fields(self, user: Any) -> None:
         target_uuid = uuid4()
         wedding_uuid = uuid4()
 
@@ -155,7 +176,7 @@ class TestNotificationServiceCreateAsync:
 class TestNotificationServiceList:
     """Testes para o método list_notifications."""
 
-    def test_list_notifications_success(self, user):
+    def test_list_notifications_success(self, user: Any) -> None:
         n1 = NotificationFactory(user=user, is_read=False)
         NotificationFactory(user=user, is_read=True)
 
@@ -166,24 +187,30 @@ class TestNotificationServiceList:
             user.company, user, is_read=False
         )
         assert unread_notes.count() == 1
-        assert unread_notes.first().id == n1.id
+        first = unread_notes.first()
+        assert first is not None
+        assert first.id == n1.id
 
-    def test_list_notifications_multitenancy_isolation(self, user):
+    def test_list_notifications_multitenancy_isolation(self, user: Any) -> None:
         other_user = UserFactory()
         NotificationFactory(user=user)
         NotificationFactory(user=other_user)
 
         user_notes = NotificationService.list_notifications(user.company, user)
         assert user_notes.count() == 1
-        assert user_notes.first().user == user
+        first = user_notes.first()
+        assert first is not None
+        assert first.user == user
 
-    def test_list_notifications_with_wedding_name(self, user):
+    def test_list_notifications_with_wedding_name(self, user: Any) -> None:
         wedding = WeddingFactory(company=user.company)
         NotificationFactory(user=user, wedding_id=wedding.uuid)
 
         user_notes = NotificationService.list_notifications(user.company, user)
+        first = user_notes.first()
+        assert first is not None
         assert (
-            user_notes.first().wedding_name
+            first.wedding_name
             == f"Casamento de {wedding.bride_name} e {wedding.groom_name}"
         )
 
@@ -192,7 +219,7 @@ class TestNotificationServiceList:
 class TestNotificationServiceUnreadCount:
     """Testes para o método get_unread_count."""
 
-    def test_get_unread_count_success(self, user):
+    def test_get_unread_count_success(self, user: Any) -> None:
         NotificationFactory(user=user, is_read=False)
         NotificationFactory(user=user, is_read=False)
         NotificationFactory(user=user, is_read=True)
@@ -200,7 +227,7 @@ class TestNotificationServiceUnreadCount:
         count = NotificationService.get_unread_count(user.company, user)
         assert count == 2
 
-    def test_get_unread_count_multitenancy_isolated(self, user):
+    def test_get_unread_count_multitenancy_isolated(self, user: Any) -> None:
         other_user = UserFactory()
         NotificationFactory(user=other_user, is_read=False)
 
@@ -212,7 +239,7 @@ class TestNotificationServiceUnreadCount:
 class TestNotificationServiceMarkAsRead:
     """Testes para o método mark_as_read."""
 
-    def test_mark_as_read_success(self, user):
+    def test_mark_as_read_success(self, user: Any) -> None:
         notification = NotificationFactory(user=user, is_read=False)
 
         updated = NotificationService.mark_as_read(
@@ -221,14 +248,14 @@ class TestNotificationServiceMarkAsRead:
         assert updated.is_read is True
         assert updated.read_at is not None
 
-    def test_mark_as_read_failure_other_tenant(self, user):
+    def test_mark_as_read_failure_other_tenant(self, user: Any) -> None:
         other_company = CompanyFactory()
         notification = NotificationFactory(company=other_company, is_read=False)
 
         with pytest.raises(ObjectNotFoundError):
             NotificationService.mark_as_read(user.company, user, notification.uuid)
 
-    def test_mark_as_read_failure_other_user_same_company(self, user):
+    def test_mark_as_read_failure_other_user_same_company(self, user: Any) -> None:
         user2 = UserFactory(company=user.company)
         notification = NotificationFactory(
             company=user.company, user=user2, is_read=False
@@ -237,7 +264,7 @@ class TestNotificationServiceMarkAsRead:
         with pytest.raises(ObjectNotFoundError):
             NotificationService.mark_as_read(user.company, user, notification.uuid)
 
-    def test_mark_as_read_already_read_idempotent(self, user):
+    def test_mark_as_read_already_read_idempotent(self, user: Any) -> None:
         notification = NotificationFactory(
             user=user, is_read=True, read_at=timezone.now()
         )
@@ -249,7 +276,7 @@ class TestNotificationServiceMarkAsRead:
         assert updated.is_read is True
         assert updated.read_at == read_at_before
 
-    def test_mark_as_read_populates_wedding_name(self, user):
+    def test_mark_as_read_populates_wedding_name(self, user: Any) -> None:
         wedding = WeddingFactory(company=user.company)
         notification = NotificationFactory(
             user=user, wedding_id=wedding.uuid, is_read=False
@@ -263,7 +290,7 @@ class TestNotificationServiceMarkAsRead:
             == f"Casamento de {wedding.bride_name} e {wedding.groom_name}"
         )
 
-    def test_mark_as_read_with_nonexistent_wedding_id(self, user):
+    def test_mark_as_read_with_nonexistent_wedding_id(self, user: Any) -> None:
         notification = NotificationFactory(user=user, wedding_id=uuid4(), is_read=False)
         updated = NotificationService.mark_as_read(
             user.company, user, notification.uuid
@@ -275,7 +302,7 @@ class TestNotificationServiceMarkAsRead:
 class TestNotificationServiceMarkAllAsRead:
     """Testes para o método mark_all_as_read."""
 
-    def test_mark_all_as_read_success(self, user):
+    def test_mark_all_as_read_success(self, user: Any) -> None:
         NotificationFactory(user=user, is_read=False)
         NotificationFactory(user=user, is_read=False)
         NotificationFactory(user=user, is_read=True)
@@ -284,7 +311,7 @@ class TestNotificationServiceMarkAllAsRead:
         assert marked_count == 2
         assert NotificationService.get_unread_count(user.company, user) == 0
 
-    def test_mark_all_as_read_multitenancy_isolated(self, user):
+    def test_mark_all_as_read_multitenancy_isolated(self, user: Any) -> None:
         other_user = UserFactory()
         other_note = NotificationFactory(user=other_user, is_read=False)
 
@@ -299,12 +326,12 @@ class TestNotificationServiceMarkAllAsRead:
 class TestNotificationServiceDelete:
     """Testes para o método delete_notification."""
 
-    def test_delete_notification_success(self, user):
+    def test_delete_notification_success(self, user: Any) -> None:
         n = NotificationFactory(user=user)
         NotificationService.delete_notification(user.company, user, n.uuid)
         assert NotificationService.list_notifications(user.company, user).count() == 0
 
-    def test_delete_notification_other_user_failure(self, user):
+    def test_delete_notification_other_user_failure(self, user: Any) -> None:
         other_user = UserFactory(company=user.company)
         n = NotificationFactory(user=other_user)
         with pytest.raises(ObjectNotFoundError):
@@ -315,7 +342,7 @@ class TestNotificationServiceDelete:
 class TestNotificationServiceBulkOperations:
     """Testes para os métodos de operações em lote (bulk)."""
 
-    def test_bulk_mark_as_read_success(self, user):
+    def test_bulk_mark_as_read_success(self, user: Any) -> None:
         n1 = NotificationFactory(user=user, is_read=False)
         n2 = NotificationFactory(user=user, is_read=False)
         NotificationFactory(user=user, is_read=False)
@@ -326,7 +353,7 @@ class TestNotificationServiceBulkOperations:
         assert count == 2
         assert NotificationService.get_unread_count(user.company, user) == 1
 
-    def test_bulk_delete_success(self, user):
+    def test_bulk_delete_success(self, user: Any) -> None:
         n1 = NotificationFactory(user=user)
         n2 = NotificationFactory(user=user)
         NotificationFactory(user=user)
@@ -335,7 +362,7 @@ class TestNotificationServiceBulkOperations:
         assert count == 2
         assert NotificationService.list_notifications(user.company, user).count() == 1
 
-    def test_clear_all_success(self, user):
+    def test_clear_all_success(self, user: Any) -> None:
         NotificationFactory(user=user)
         NotificationFactory(user=user)
         other_user = UserFactory()

--- a/backend/apps/notifications/tests/test_tasks.py
+++ b/backend/apps/notifications/tests/test_tasks.py
@@ -1,3 +1,4 @@
+from typing import Any
 from uuid import uuid4
 
 import pytest
@@ -10,7 +11,7 @@ from apps.notifications.tasks import dispatch_async_notification_task
 class TestNotificationTasks:
     """Testes de integração para as tarefas assíncronas de notificação."""
 
-    def test_dispatch_async_notification_task_with_pk_ids(self, user):
+    def test_dispatch_async_notification_task_with_pk_ids(self, user: Any) -> None:
         dispatch_async_notification_task.func(
             company_id=user.company.id,
             user_id=user.id,
@@ -23,7 +24,7 @@ class TestNotificationTasks:
         assert notification.message == "Async Task Message"
         assert notification.company == user.company
 
-    def test_dispatch_async_notification_task_with_uuids(self, user):
+    def test_dispatch_async_notification_task_with_uuids(self, user: Any) -> None:
         target_uuid = str(uuid4())
         wedding_uuid = str(uuid4())
 

--- a/backend/apps/scheduler/admin.py
+++ b/backend/apps/scheduler/admin.py
@@ -5,7 +5,7 @@ from .models import Event
 
 # Configuração do modelo Event no painel administrativo do Django
 @admin.register(Event)
-class EventAdmin(admin.ModelAdmin):
+class EventAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
     """Define como o modelo Event será exibido e filtrado no admin."""
 
     # Campos exibidos na listagem

--- a/backend/apps/scheduler/tests/appointments/test_models.py
+++ b/backend/apps/scheduler/tests/appointments/test_models.py
@@ -1,24 +1,34 @@
 from datetime import timedelta
+from typing import Any, cast
 
 import pytest
 from django.utils import timezone
 
 from apps.scheduler.models import Event
-from apps.scheduler.tests.factories import EventFactory
-from apps.weddings.tests.factories import WeddingFactory
+from apps.scheduler.tests.factories import EventFactory as _EventFactory
+from apps.weddings.models import Wedding
+from apps.weddings.tests.factories import WeddingFactory as _WeddingFactory
+
+
+def EventFactory(*args: Any, **kwargs: Any) -> Event:
+    return cast(Event, _EventFactory(*args, **kwargs))
+
+
+def WeddingFactory(*args: Any, **kwargs: Any) -> Wedding:
+    return cast(Wedding, _WeddingFactory(*args, **kwargs))
 
 
 @pytest.mark.django_db
 class TestEventModelMetadata:
     """Testes de representação e metadados do modelo Event."""
 
-    def test_event_str_is_title(self, user):
+    def test_event_str_is_title(self, user: Any) -> None:
         """__str__ deve retornar o título do evento."""
         wedding = WeddingFactory(user_context=user)
         event = EventFactory(wedding=wedding, title="Prova de Vestido")
         assert str(event) == "Prova de Vestido"
 
-    def test_event_ordering_by_start_time(self, user):
+    def test_event_ordering_by_start_time(self, user: Any) -> None:
         """Ordenação padrão deve ser por start_time ascendente."""
         wedding = WeddingFactory(user_context=user)
         now = timezone.now()
@@ -31,7 +41,7 @@ class TestEventModelMetadata:
         assert events[1] == e_mid
         assert events[2] == e_late
 
-    def test_event_end_time_defaults_hour_after_start(self, user):
+    def test_event_end_time_defaults_hour_after_start(self, user: Any) -> None:
         """End_time padrão via factory é 1h após start_time."""
         wedding = WeddingFactory(user_context=user)
         now = timezone.now()
@@ -50,31 +60,31 @@ class TestEventModelMetadata:
 class TestEventTypeChoices:
     """Testes dos tipos de evento disponíveis."""
 
-    def test_event_type_meeting(self, user):
+    def test_event_type_meeting(self, user: Any) -> None:
         """Evento do tipo MEETING é válido."""
         wedding = WeddingFactory(user_context=user)
         event = EventFactory(wedding=wedding, event_type=Event.TypeChoices.MEETING)
         event.full_clean()
 
-    def test_event_type_payment(self, user):
+    def test_event_type_payment(self, user: Any) -> None:
         """Evento do tipo PAYMENT é válido."""
         wedding = WeddingFactory(user_context=user)
         event = EventFactory(wedding=wedding, event_type=Event.TypeChoices.PAYMENT)
         event.full_clean()
 
-    def test_event_type_visit(self, user):
+    def test_event_type_visit(self, user: Any) -> None:
         """Evento do tipo VISIT é válido."""
         wedding = WeddingFactory(user_context=user)
         event = EventFactory(wedding=wedding, event_type=Event.TypeChoices.VISIT)
         event.full_clean()
 
-    def test_event_type_tasting(self, user):
+    def test_event_type_tasting(self, user: Any) -> None:
         """Evento do tipo TASTING é válido."""
         wedding = WeddingFactory(user_context=user)
         event = EventFactory(wedding=wedding, event_type=Event.TypeChoices.TASTING)
         event.full_clean()
 
-    def test_event_type_default_is_other(self, user):
+    def test_event_type_default_is_other(self, user: Any) -> None:
         """Tipo padrão deve ser OTHER."""
         wedding = WeddingFactory(user_context=user)
         event = Event(
@@ -90,7 +100,7 @@ class TestEventTypeChoices:
 class TestEventReminder:
     """Testes das configurações de lembrete do Event."""
 
-    def test_event_reminder_default_disabled(self, user):
+    def test_event_reminder_default_disabled(self, user: Any) -> None:
         """reminder_enabled deve ser False por padrão."""
         wedding = WeddingFactory(user_context=user)
         event = Event(
@@ -101,7 +111,7 @@ class TestEventReminder:
         )
         assert event.reminder_enabled is False
 
-    def test_event_reminder_minutes_default(self, user):
+    def test_event_reminder_minutes_default(self, user: Any) -> None:
         """reminder_minutes_before deve ser 60 por padrão."""
         wedding = WeddingFactory(user_context=user)
         event = Event(
@@ -112,7 +122,7 @@ class TestEventReminder:
         )
         assert event.reminder_minutes_before == 60
 
-    def test_event_recurrence_rule_choices(self, user):
+    def test_event_recurrence_rule_choices(self, user: Any) -> None:
         """RecurrenceChoices contém os valores em português."""
         expected = {"none", "semanal", "quinzenal", "mensal"}
         assert set(Event.RecurrenceChoices.values) == expected

--- a/backend/apps/scheduler/tests/appointments/test_services.py
+++ b/backend/apps/scheduler/tests/appointments/test_services.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import no_type_check
+from typing import Any, cast, no_type_check
 from uuid import uuid4
 
 import pytest
@@ -9,9 +9,23 @@ from apps.core.exceptions import BusinessRuleViolation, ObjectNotFoundError
 from apps.scheduler.models import Event
 from apps.scheduler.schemas import EventIn, EventPatchIn
 from apps.scheduler.services.events import EventService
-from apps.scheduler.tests.factories import EventFactory
-from apps.users.tests.factories import UserFactory
-from apps.weddings.tests.factories import WeddingFactory
+from apps.scheduler.tests.factories import EventFactory as _EventFactory
+from apps.users.models import User
+from apps.users.tests.factories import UserFactory as _UserFactory
+from apps.weddings.models import Wedding
+from apps.weddings.tests.factories import WeddingFactory as _WeddingFactory
+
+
+def EventFactory(*args: Any, **kwargs: Any) -> Event:
+    return cast(Event, _EventFactory(*args, **kwargs))
+
+
+def UserFactory(*args: Any, **kwargs: Any) -> User:
+    return cast(User, _UserFactory(*args, **kwargs))
+
+
+def WeddingFactory(*args: Any, **kwargs: Any) -> Wedding:
+    return cast(Wedding, _WeddingFactory(*args, **kwargs))
 
 
 @pytest.mark.django_db
@@ -19,10 +33,12 @@ class TestEventServiceCreate:
     """Testes de criação de eventos via EventService."""
 
     @pytest.mark.parametrize("use_dict", [False, True])
-    def test_create_event_rejects_past_start_time(self, user, use_dict):
+    def test_create_event_rejects_past_start_time(
+        self, user: Any, use_dict: bool
+    ) -> None:
         """BR-VAL02: criação rejeita início no passado em ambos os payloads."""
         wedding = WeddingFactory(user_context=user)
-        data = {
+        data: dict[str, Any] = {
             "wedding": wedding.uuid,
             "title": "Evento no passado",
             "event_type": Event.TypeChoices.MEETING,
@@ -37,12 +53,12 @@ class TestEventServiceCreate:
         assert "não pode estar no passado" in exc_info.value.detail
         assert Event.objects.count() == 0
 
-    def test_create_event_success(self, user):
+    def test_create_event_success(self, user: Any) -> None:
         """Criação de evento vinculado ao casamento."""
         wedding = WeddingFactory(user_context=user)
         now = timezone.now()
 
-        data = {
+        data: dict[str, Any] = {
             "wedding": wedding.uuid,
             "title": "Prova de Vestido",
             "event_type": Event.TypeChoices.MEETING,
@@ -55,11 +71,11 @@ class TestEventServiceCreate:
         assert event.title == "Prova de Vestido"
         assert event.company == user.company
 
-    def test_create_event_with_wedding_instance(self, user):
+    def test_create_event_with_wedding_instance(self, user: Any) -> None:
         """create() aceita instância de Wedding, não só UUID."""
         wedding = WeddingFactory(user_context=user)
 
-        data = {
+        data: dict[str, Any] = {
             "wedding": wedding,
             "title": "Reunião com Buffet",
             "event_type": Event.TypeChoices.VISIT,
@@ -69,9 +85,9 @@ class TestEventServiceCreate:
         event = EventService.create(user.company, data)
         assert event.wedding == wedding
 
-    def test_create_event_wedding_not_found(self, user):
+    def test_create_event_wedding_not_found(self, user: Any) -> None:
         """UUID de wedding inexistente levanta ObjectNotFoundError."""
-        data = {
+        data: dict[str, Any] = {
             "wedding": uuid4(),
             "title": "Evento Fantasma",
             "event_type": Event.TypeChoices.OTHER,
@@ -83,13 +99,13 @@ class TestEventServiceCreate:
 
         assert "wedding_not_found_or_denied" in str(exc_info.value.code)
 
-    def test_create_event_multitenancy(self):
+    def test_create_event_multitenancy(self) -> None:
         """Usuário A não pode criar evento com wedding do Usuário B."""
         user_a = UserFactory()
         user_b = UserFactory()
         wedding_b = WeddingFactory(user_context=user_b)
 
-        data = {
+        data: dict[str, Any] = {
             "wedding": wedding_b.uuid,
             "title": "Invasão",
             "event_type": Event.TypeChoices.OTHER,
@@ -107,7 +123,7 @@ class TestEventServiceCreate:
         user_a = UserFactory()
         user_b = UserFactory()
         wedding_b = WeddingFactory(user_context=user_b)
-        data = {
+        data: dict[str, Any] = {
             "wedding": wedding_b,
             "title": "Invasão por instância",
             "event_type": Event.TypeChoices.OTHER,
@@ -119,11 +135,11 @@ class TestEventServiceCreate:
 
         assert exc_info.value.code == "wedding_not_found_or_denied"
 
-    def test_create_payment_event_blocked(self, user):
+    def test_create_payment_event_blocked(self, user: Any) -> None:
         """BR-S01: Eventos PAYMENT não podem ser criados manualmente."""
         wedding = WeddingFactory(user_context=user)
 
-        data = {
+        data: dict[str, Any] = {
             "wedding": wedding.uuid,
             "title": "Pagamento Manual",
             "event_type": Event.TypeChoices.PAYMENT,
@@ -136,7 +152,7 @@ class TestEventServiceCreate:
         assert exc_info.value.code == "payment_event_readonly"
         assert Event.objects.count() == 0
 
-    def test_create_payment_event_internal_allowed(self, user):
+    def test_create_payment_event_internal_allowed(self, user: Any) -> None:
         """BR-S01: Chamadas internas (_caller_internal=True) podem criar PAYMENT."""
         wedding = WeddingFactory(user_context=user)
         start_time_today = timezone.localtime().replace(
@@ -146,7 +162,7 @@ class TestEventServiceCreate:
             microsecond=0,
         )
 
-        data = {
+        data: dict[str, Any] = {
             "wedding": wedding.uuid,
             "title": "Pagamento: Buffet - Parcela 1/3",
             "event_type": Event.TypeChoices.PAYMENT,
@@ -158,10 +174,10 @@ class TestEventServiceCreate:
         assert event.event_type == Event.TypeChoices.PAYMENT
         assert event.title == "Pagamento: Buffet - Parcela 1/3"
 
-    def test_create_past_payment_event_internal_rejected(self, user):
+    def test_create_past_payment_event_internal_rejected(self, user: Any) -> None:
         """BR-VAL02: Eventos financeiros internos também rejeitam data passada."""
         wedding = WeddingFactory(user_context=user)
-        data = {
+        data: dict[str, Any] = {
             "wedding": wedding.uuid,
             "title": "Pagamento vencido",
             "event_type": Event.TypeChoices.PAYMENT,
@@ -173,7 +189,7 @@ class TestEventServiceCreate:
 
         assert exc_info.value.code == "event_start_time_in_past"
 
-    def test_create_historical_template_event_allowed(self, user):
+    def test_create_historical_template_event_allowed(self, user: Any) -> None:
         """Templates podem gerar marcos históricos anteriores à data atual."""
         wedding = WeddingFactory(user_context=user)
         data = {
@@ -196,53 +212,55 @@ class TestEventServiceCreate:
 class TestEventServiceUpdate:
     """Testes de atualização de eventos via EventService."""
 
-    def test_update_event_allows_past_start_time(self, user):
+    def test_update_event_allows_past_start_time(self, user: Any) -> None:
         """BR-VAL02: edição permite data passada para correção histórica."""
         wedding = WeddingFactory(user_context=user)
         event = EventFactory(wedding=wedding)
         past_start_time = timezone.now() - timedelta(days=1)
 
         updated = EventService.update(
-            user.company, event, EventPatchIn(start_time=past_start_time)
+            user.company,
+            event,
+            EventPatchIn.model_construct(start_time=past_start_time),
         )
 
         assert updated.start_time == past_start_time
 
-    def test_update_event_title(self, user):
+    def test_update_event_title(self, user: Any) -> None:
         """Atualização de título é permitida."""
         wedding = WeddingFactory(user_context=user)
         event = EventFactory(wedding=wedding, title="Título Antigo")
 
         updated = EventService.update(
-            user.company, event, EventPatchIn(title="Título Novo")
+            user.company, event, EventPatchIn.model_construct(title="Título Novo")
         )
 
         assert updated.title == "Título Novo"
 
-    def test_update_event_cannot_change_wedding(self, user):
+    def test_update_event_cannot_change_wedding(self, user: Any) -> None:
         """Wedding é bloqueado no update."""
         wedding1 = WeddingFactory(user_context=user)
         wedding2 = WeddingFactory(user_context=user)
         event = EventFactory(wedding=wedding1)
 
         updated = EventService.update(
-            user.company, event, EventPatchIn(wedding=wedding2.uuid)
+            user.company, event, EventPatchIn.model_construct(wedding=wedding2.uuid)
         )
 
         assert updated.wedding == wedding1
 
-    def test_update_event_toggle_reminder(self, user):
+    def test_update_event_toggle_reminder(self, user: Any) -> None:
         """Habilitar/desabilitar lembrete é permitido."""
         wedding = WeddingFactory(user_context=user)
         event = EventFactory(wedding=wedding, reminder_enabled=False)
 
         updated = EventService.update(
-            user.company, event, EventPatchIn(reminder_enabled=True)
+            user.company, event, EventPatchIn.model_construct(reminder_enabled=True)
         )
 
         assert updated.reminder_enabled is True
 
-    def test_update_cannot_change_event_type_to_payment(self, user):
+    def test_update_cannot_change_event_type_to_payment(self, user: Any) -> None:
         """BR-S01: Não pode alterar event_type de um evento para PAYMENT."""
         wedding = WeddingFactory(user_context=user)
         event = EventFactory(
@@ -253,12 +271,14 @@ class TestEventServiceUpdate:
 
         with pytest.raises(BusinessRuleViolation) as exc_info:
             EventService.update(
-                user.company, event, EventPatchIn(event_type=Event.TypeChoices.PAYMENT)
+                user.company,
+                event,
+                EventPatchIn.model_construct(event_type=Event.TypeChoices.PAYMENT),
             )
 
         assert exc_info.value.code == "payment_event_readonly"
 
-    def test_update_payment_event_blocked(self, user):
+    def test_update_payment_event_blocked(self, user: Any) -> None:
         """BR-S01: Eventos PAYMENT não podem ser editados manualmente."""
         wedding = WeddingFactory(user_context=user)
         event = EventFactory(
@@ -268,11 +288,15 @@ class TestEventServiceUpdate:
         )
 
         with pytest.raises(BusinessRuleViolation) as exc_info:
-            EventService.update(user.company, event, EventPatchIn(title="Novo título"))
+            EventService.update(
+                user.company,
+                event,
+                EventPatchIn.model_construct(title="Novo título"),
+            )
 
         assert exc_info.value.code == "payment_event_readonly"
 
-    def test_update_payment_event_all_fields_blocked(self, user):
+    def test_update_payment_event_all_fields_blocked(self, user: Any) -> None:
         """BR-S01: Nenhum campo de evento PAYMENT pode ser alterado."""
         wedding = WeddingFactory(user_context=user)
         event = EventFactory(
@@ -285,10 +309,12 @@ class TestEventServiceUpdate:
             EventService.update(
                 user.company,
                 event,
-                EventPatchIn(start_time=timezone.now() + timedelta(days=10)),
+                EventPatchIn.model_construct(
+                    start_time=timezone.now() + timedelta(days=10)
+                ),
             )
 
-    def test_update_non_payment_event_allowed(self, user):
+    def test_update_non_payment_event_allowed(self, user: Any) -> None:
         """Eventos não-PAYMENT podem ser editados normalmente."""
         wedding = WeddingFactory(user_context=user)
         event = EventFactory(
@@ -298,26 +324,32 @@ class TestEventServiceUpdate:
         )
 
         updated = EventService.update(
-            user.company, event, EventPatchIn(title="Reunião com Buffet Atualizada")
+            user.company,
+            event,
+            EventPatchIn.model_construct(title="Reunião com Buffet Atualizada"),
         )
 
         assert updated.title == "Reunião com Buffet Atualizada"
 
-    def test_update_event_cross_tenant(self, user):
+    def test_update_event_cross_tenant(self, user: Any) -> None:
         """Evento de outro tenant não pode ser atualizado."""
         other_user = UserFactory()
         other_wedding = WeddingFactory(user_context=other_user)
         other_event = EventFactory(wedding=other_wedding)
 
         with pytest.raises(ObjectNotFoundError):
-            EventService.update(user.company, other_event, EventPatchIn(title="Hack"))
+            EventService.update(
+                user.company,
+                other_event,
+                EventPatchIn.model_construct(title="Hack"),
+            )
 
 
 @pytest.mark.django_db
 class TestEventServiceDelete:
     """Testes de deleção de eventos via EventService."""
 
-    def test_delete_event_success(self, user):
+    def test_delete_event_success(self, user: Any) -> None:
         """Deleção de evento sem dependências é permitida."""
         wedding = WeddingFactory(user_context=user)
         event = EventFactory(wedding=wedding)
@@ -326,7 +358,7 @@ class TestEventServiceDelete:
 
         assert Event.objects.filter(uuid=event.uuid).count() == 0
 
-    def test_delete_payment_event_blocked(self, user):
+    def test_delete_payment_event_blocked(self, user: Any) -> None:
         """BR-S01: Eventos PAYMENT não podem ser deletados manualmente."""
         wedding = WeddingFactory(user_context=user)
         event = EventFactory(
@@ -341,7 +373,7 @@ class TestEventServiceDelete:
         assert exc_info.value.code == "payment_event_readonly"
         assert Event.objects.filter(uuid=event.uuid).exists()
 
-    def test_delete_non_payment_event_allowed(self, user):
+    def test_delete_non_payment_event_allowed(self, user: Any) -> None:
         """Eventos não-PAYMENT podem ser deletados normalmente."""
         wedding = WeddingFactory(user_context=user)
         event = EventFactory(
@@ -353,7 +385,7 @@ class TestEventServiceDelete:
 
         assert Event.objects.filter(uuid=event.uuid).count() == 0
 
-    def test_delete_event_cross_tenant(self, user):
+    def test_delete_event_cross_tenant(self, user: Any) -> None:
         """Evento de outro tenant não pode ser deletado."""
         other_user = UserFactory()
         other_wedding = WeddingFactory(user_context=other_user)
@@ -367,7 +399,7 @@ class TestEventServiceDelete:
 class TestEventServiceListAndGet:
     """Testes de listagem e obtenção de eventos."""
 
-    def test_list_events_multitenancy(self):
+    def test_list_events_multitenancy(self) -> None:
         """list() retorna apenas eventos do tenant."""
         user_a = UserFactory()
         user_b = UserFactory()
@@ -379,13 +411,17 @@ class TestEventServiceListAndGet:
 
         qs_a = EventService.list(user_a.company)
         assert qs_a.count() == 1
-        assert qs_a.first().title == "Evento A"
+        first_a = qs_a.first()
+        assert first_a is not None
+        assert first_a.title == "Evento A"
 
         qs_b = EventService.list(user_b.company)
         assert qs_b.count() == 1
-        assert qs_b.first().title == "Evento B"
+        first_b = qs_b.first()
+        assert first_b is not None
+        assert first_b.title == "Evento B"
 
-    def test_list_events_filter_by_wedding(self, user):
+    def test_list_events_filter_by_wedding(self, user: Any) -> None:
         """list() com wedding_id filtra por casamento."""
         wedding1 = WeddingFactory(user_context=user)
         wedding2 = WeddingFactory(user_context=user)
@@ -395,9 +431,11 @@ class TestEventServiceListAndGet:
 
         qs = EventService.list(user.company, wedding_id=wedding1.uuid)
         assert qs.count() == 1
-        assert qs.first().title == "Evento W1"
+        first = qs.first()
+        assert first is not None
+        assert first.title == "Evento W1"
 
-    def test_get_event_success(self, user):
+    def test_get_event_success(self, user: Any) -> None:
         """get() retorna evento por UUID."""
         wedding = WeddingFactory(user_context=user)
         event = EventFactory(wedding=wedding, title="Degustação")
@@ -406,12 +444,12 @@ class TestEventServiceListAndGet:
         assert result.uuid == event.uuid
         assert result.title == "Degustação"
 
-    def test_get_event_not_found(self, user):
+    def test_get_event_not_found(self, user: Any) -> None:
         """UUID inexistente levanta ObjectNotFoundError."""
         with pytest.raises(ObjectNotFoundError):
             EventService.get(user.company, uuid4())
 
-    def test_get_event_multitenancy(self):
+    def test_get_event_multitenancy(self) -> None:
         """Usuário A não pode acessar evento do Usuário B."""
         user_a = UserFactory()
         user_b = UserFactory()
@@ -421,7 +459,7 @@ class TestEventServiceListAndGet:
         with pytest.raises(ObjectNotFoundError):
             EventService.get(user_a.company, event_b.uuid)
 
-    def test_list_events_empty_company(self, user):
+    def test_list_events_empty_company(self, user: Any) -> None:
         """list() sem eventos retorna QuerySet vazio."""
         qs = EventService.list(user.company)
         assert qs.count() == 0

--- a/backend/apps/scheduler/tests/appointments/test_templates.py
+++ b/backend/apps/scheduler/tests/appointments/test_templates.py
@@ -12,7 +12,7 @@ from apps.scheduler.services.templates import (
 class TestGetTemplateEvents:
     """Testes para a função de obtenção de templates de cronograma."""
 
-    def test_get_religious_12m_template(self):
+    def test_get_religious_12m_template(self) -> None:
         """Retorna eventos do template religious_12m com estrutura correta."""
         events = get_template_events("religious_12m")
 
@@ -23,20 +23,20 @@ class TestGetTemplateEvents:
             assert "offset_days" in event
             assert isinstance(event["offset_days"], int)
 
-    def test_get_beach_6m_template(self):
+    def test_get_beach_6m_template(self) -> None:
         """Retorna eventos do template beach_6m."""
         events = get_template_events("beach_6m")
 
         assert len(events) == 8
         assert events[0]["title"] == "Definir local na praia"
 
-    def test_get_civil_buffet_3m_template(self):
+    def test_get_civil_buffet_3m_template(self) -> None:
         """Retorna eventos do template civil_buffet_3m."""
         events = get_template_events("civil_buffet_3m")
 
         assert len(events) == 7
 
-    def test_invalid_template_raises_business_rule_violation(self):
+    def test_invalid_template_raises_business_rule_violation(self) -> None:
         """Template inexistente levanta BusinessRuleViolation."""
         with pytest.raises(BusinessRuleViolation) as exc_info:
             get_template_events("invalid_template_name")
@@ -44,14 +44,14 @@ class TestGetTemplateEvents:
         assert exc_info.value.code == "template_not_found"
         assert "invalid_template_name" in str(exc_info.value.detail)
 
-    def test_all_template_names_are_valid(self):
+    def test_all_template_names_are_valid(self) -> None:
         """Todos os nomes em TEMPLATE_CHOICES são válidos."""
         for name in TEMPLATE_CHOICES:
             events = get_template_events(name)
             assert isinstance(events, list)
             assert len(events) > 0
 
-    def test_templates_are_not_mutated_on_access(self):
+    def test_templates_are_not_mutated_on_access(self) -> None:
         """get_template_events não modifica a estrutura original do template."""
         events = get_template_events("religious_12m")
 
@@ -63,7 +63,7 @@ class TestGetTemplateEvents:
         original = TEMPLATES["religious_12m"]
         assert "offset_days" in original[0]
 
-    def test_empty_template_name_raises(self):
+    def test_empty_template_name_raises(self) -> None:
         """Nome vazio ou nulo levanta erro apropriado."""
         with pytest.raises(BusinessRuleViolation):
             get_template_events("")

--- a/backend/apps/scheduler/tests/tasks/test_models.py
+++ b/backend/apps/scheduler/tests/tasks/test_models.py
@@ -1,17 +1,27 @@
 from datetime import date, timedelta
+from typing import Any, cast
 
 import pytest
 
 from apps.scheduler.models import Task
-from apps.scheduler.tests.factories import TaskFactory
-from apps.weddings.tests.factories import WeddingFactory
+from apps.scheduler.tests.factories import TaskFactory as _TaskFactory
+from apps.weddings.models import Wedding
+from apps.weddings.tests.factories import WeddingFactory as _WeddingFactory
+
+
+def TaskFactory(*args: Any, **kwargs: Any) -> Task:
+    return cast(Task, _TaskFactory(*args, **kwargs))
+
+
+def WeddingFactory(*args: Any, **kwargs: Any) -> Wedding:
+    return cast(Wedding, _WeddingFactory(*args, **kwargs))
 
 
 @pytest.mark.django_db
 class TestTaskModelMetadata:
     """Testes de representação e metadados do modelo Task."""
 
-    def test_task_str_shows_checkbox_and_title(self, user):
+    def test_task_str_shows_checkbox_and_title(self, user: Any) -> None:
         """__str__ deve conter [ ] ou [x] e o título."""
         wedding = WeddingFactory(user_context=user)
         task_pending = Task(
@@ -30,7 +40,7 @@ class TestTaskModelMetadata:
         )
         assert str(task_done) == "[x] Enviar Convites"
 
-    def test_task_ordering_pending_first(self, user):
+    def test_task_ordering_pending_first(self, user: Any) -> None:
         """Ordenação: is_completed (False primeiro), due_date, created_at."""
         wedding = WeddingFactory(user_context=user)
         today = date.today()
@@ -55,13 +65,13 @@ class TestTaskModelMetadata:
         assert tasks[1] == t_pending_late
         assert tasks[2] == t_completed
 
-    def test_task_is_completed_default_false(self, user):
+    def test_task_is_completed_default_false(self, user: Any) -> None:
         """is_completed padrão deve ser False."""
         wedding = WeddingFactory(user_context=user)
         task = Task(company=user.company, wedding=wedding, title="Teste")
         assert task.is_completed is False
 
-    def test_task_due_date_nullable(self, user):
+    def test_task_due_date_nullable(self, user: Any) -> None:
         """due_date pode ser nulo (tarefa sem prazo)."""
         wedding = WeddingFactory(user_context=user)
         task = TaskFactory(wedding=wedding, due_date=None)

--- a/backend/apps/scheduler/tests/tasks/test_services.py
+++ b/backend/apps/scheduler/tests/tasks/test_services.py
@@ -1,4 +1,4 @@
-from typing import no_type_check
+from typing import Any, cast, no_type_check
 from uuid import uuid4
 
 import pytest
@@ -7,20 +7,34 @@ from apps.core.exceptions import ObjectNotFoundError
 from apps.scheduler.models import Task
 from apps.scheduler.schemas import TaskIn, TaskPatchIn
 from apps.scheduler.services.tasks import TaskService
-from apps.scheduler.tests.factories import TaskFactory
-from apps.users.tests.factories import UserFactory
-from apps.weddings.tests.factories import WeddingFactory
+from apps.scheduler.tests.factories import TaskFactory as _TaskFactory
+from apps.users.models import User
+from apps.users.tests.factories import UserFactory as _UserFactory
+from apps.weddings.models import Wedding
+from apps.weddings.tests.factories import WeddingFactory as _WeddingFactory
+
+
+def TaskFactory(*args: Any, **kwargs: Any) -> Task:
+    return cast(Task, _TaskFactory(*args, **kwargs))
+
+
+def UserFactory(*args: Any, **kwargs: Any) -> User:
+    return cast(User, _UserFactory(*args, **kwargs))
+
+
+def WeddingFactory(*args: Any, **kwargs: Any) -> Wedding:
+    return cast(Wedding, _WeddingFactory(*args, **kwargs))
 
 
 @pytest.mark.django_db
 class TestTaskServiceCreate:
     """Testes de criação de tarefas via TaskService."""
 
-    def test_create_task_success(self, user):
+    def test_create_task_success(self, user: Any) -> None:
         """Criação de tarefa vinculada ao casamento."""
         wedding = WeddingFactory(user_context=user)
 
-        data = {
+        data: dict[str, Any] = {
             "wedding": wedding.uuid,
             "title": "Contratar Buffet",
             "description": "Fazer orçamento com 3 fornecedores",
@@ -32,11 +46,11 @@ class TestTaskServiceCreate:
         assert task.title == "Contratar Buffet"
         assert task.is_completed is False
 
-    def test_create_task_with_wedding_instance(self, user):
+    def test_create_task_with_wedding_instance(self, user: Any) -> None:
         """create() aceita UUID do Wedding."""
         wedding = WeddingFactory(user_context=user)
 
-        data = {
+        data: dict[str, Any] = {
             "wedding": wedding.uuid,
             "title": "Enviar Convites",
         }
@@ -44,9 +58,9 @@ class TestTaskServiceCreate:
         task = TaskService.create(user.company, TaskIn(**data))
         assert task.wedding == wedding
 
-    def test_create_task_wedding_not_found(self, user):
+    def test_create_task_wedding_not_found(self, user: Any) -> None:
         """UUID de wedding inexistente levanta ObjectNotFoundError."""
-        data = {
+        data: dict[str, Any] = {
             "wedding": uuid4(),
             "title": "Tarefa Fantasma",
         }
@@ -56,13 +70,13 @@ class TestTaskServiceCreate:
 
         assert "wedding_not_found_or_denied" in str(exc_info.value.code)
 
-    def test_create_task_multitenancy(self):
+    def test_create_task_multitenancy(self) -> None:
         """Usuário A não pode criar tarefa com wedding do Usuário B."""
         user_a = UserFactory()
         user_b = UserFactory()
         wedding_b = WeddingFactory(user_context=user_b)
 
-        data = {
+        data: dict[str, Any] = {
             "wedding": wedding_b.uuid,
             "title": "Invasão",
         }
@@ -96,53 +110,59 @@ class TestTaskServiceCreate:
 class TestTaskServiceUpdate:
     """Testes de atualização de tarefas via TaskService."""
 
-    def test_update_task_title(self, user):
+    def test_update_task_title(self, user: Any) -> None:
         """Atualização de título é permitida."""
         wedding = WeddingFactory(user_context=user)
         task = TaskFactory(wedding=wedding, title="Título Antigo")
 
         updated = TaskService.update(
-            user.company, task, TaskPatchIn(title="Título Novo")
+            user.company, task, TaskPatchIn.model_construct(title="Título Novo")
         )
 
         assert updated.title == "Título Novo"
 
-    def test_update_task_toggle_completed(self, user):
+    def test_update_task_toggle_completed(self, user: Any) -> None:
         """Toggle de is_completed é permitido (ação principal do checklist)."""
         wedding = WeddingFactory(user_context=user)
         task = TaskFactory(wedding=wedding, is_completed=False)
 
-        updated = TaskService.update(user.company, task, TaskPatchIn(is_completed=True))
+        updated = TaskService.update(
+            user.company, task, TaskPatchIn.model_construct(is_completed=True)
+        )
 
         assert updated.is_completed is True
 
-    def test_update_task_cannot_change_wedding(self, user):
+    def test_update_task_cannot_change_wedding(self, user: Any) -> None:
         """Wedding é bloqueado no update."""
         wedding1 = WeddingFactory(user_context=user)
         wedding2 = WeddingFactory(user_context=user)
         task = TaskFactory(wedding=wedding1)
 
         updated = TaskService.update(
-            user.company, task, TaskPatchIn(wedding=wedding2.uuid)
+            user.company, task, TaskPatchIn.model_construct(wedding=wedding2.uuid)
         )
 
         assert updated.wedding == wedding1
 
-    def test_update_task_cross_tenant(self, user):
+    def test_update_task_cross_tenant(self, user: Any) -> None:
         """Tarefa de outro tenant não pode ser atualizada."""
         other_user = UserFactory()
         other_wedding = WeddingFactory(user_context=other_user)
         other_task = TaskFactory(wedding=other_wedding)
 
         with pytest.raises(ObjectNotFoundError):
-            TaskService.update(user.company, other_task, TaskPatchIn(title="Hack"))
+            TaskService.update(
+                user.company,
+                other_task,
+                TaskPatchIn.model_construct(title="Hack"),
+            )
 
 
 @pytest.mark.django_db
 class TestTaskServiceDelete:
     """Testes de deleção de tarefas via TaskService."""
 
-    def test_delete_task_success(self, user):
+    def test_delete_task_success(self, user: Any) -> None:
         """Deleção de tarefa é permitida."""
         wedding = WeddingFactory(user_context=user)
         task = TaskFactory(wedding=wedding)
@@ -151,7 +171,7 @@ class TestTaskServiceDelete:
 
         assert Task.objects.filter(uuid=task.uuid).count() == 0
 
-    def test_delete_task_cross_tenant(self, user):
+    def test_delete_task_cross_tenant(self, user: Any) -> None:
         """Tarefa de outro tenant não pode ser deletada."""
         other_user = UserFactory()
         other_wedding = WeddingFactory(user_context=other_user)
@@ -165,7 +185,7 @@ class TestTaskServiceDelete:
 class TestTaskServiceListAndGet:
     """Testes de listagem e obtenção de tarefas."""
 
-    def test_list_tasks_multitenancy(self):
+    def test_list_tasks_multitenancy(self) -> None:
         """list() retorna apenas tarefas do tenant."""
         user_a = UserFactory()
         user_b = UserFactory()
@@ -177,13 +197,17 @@ class TestTaskServiceListAndGet:
 
         qs_a = TaskService.list(user_a.company)
         assert qs_a.count() == 1
-        assert qs_a.first().title == "Tarefa A"
+        first_a = qs_a.first()
+        assert first_a is not None
+        assert first_a.title == "Tarefa A"
 
         qs_b = TaskService.list(user_b.company)
         assert qs_b.count() == 1
-        assert qs_b.first().title == "Tarefa B"
+        first_b = qs_b.first()
+        assert first_b is not None
+        assert first_b.title == "Tarefa B"
 
-    def test_list_tasks_filter_by_wedding(self, user):
+    def test_list_tasks_filter_by_wedding(self, user: Any) -> None:
         """list() com wedding_id filtra por casamento."""
         wedding1 = WeddingFactory(user_context=user)
         wedding2 = WeddingFactory(user_context=user)
@@ -193,9 +217,11 @@ class TestTaskServiceListAndGet:
 
         qs = TaskService.list(user.company, wedding_id=wedding1.uuid)
         assert qs.count() == 1
-        assert qs.first().title == "Tarefa W1"
+        first = qs.first()
+        assert first is not None
+        assert first.title == "Tarefa W1"
 
-    def test_get_task_success(self, user):
+    def test_get_task_success(self, user: Any) -> None:
         """get() retorna tarefa por UUID."""
         wedding = WeddingFactory(user_context=user)
         task = TaskFactory(wedding=wedding, title="Confirmar Convidados")
@@ -204,12 +230,12 @@ class TestTaskServiceListAndGet:
         assert result.uuid == task.uuid
         assert result.title == "Confirmar Convidados"
 
-    def test_get_task_not_found(self, user):
+    def test_get_task_not_found(self, user: Any) -> None:
         """UUID inexistente levanta ObjectNotFoundError."""
         with pytest.raises(ObjectNotFoundError):
             TaskService.get(user.company, uuid4())
 
-    def test_get_task_multitenancy(self):
+    def test_get_task_multitenancy(self) -> None:
         """Usuário A não pode acessar tarefa do Usuário B."""
         user_a = UserFactory()
         user_b = UserFactory()
@@ -219,7 +245,7 @@ class TestTaskServiceListAndGet:
         with pytest.raises(ObjectNotFoundError):
             TaskService.get(user_a.company, task_b.uuid)
 
-    def test_list_tasks_empty_company(self, user):
+    def test_list_tasks_empty_company(self, user: Any) -> None:
         """list() sem tarefas retorna QuerySet vazio."""
         qs = TaskService.list(user.company)
         assert qs.count() == 0

--- a/backend/apps/scheduler/tests/test_apis.py
+++ b/backend/apps/scheduler/tests/test_apis.py
@@ -1,16 +1,33 @@
+from datetime import timedelta
+from typing import Any, cast
+
 import pytest
 from django.utils import timezone
 
-from apps.scheduler.models import Event
-from apps.scheduler.tests.factories import EventFactory, TaskFactory
-from apps.weddings.tests.factories import WeddingFactory
+from apps.scheduler.models import Event, Task
+from apps.scheduler.tests.factories import EventFactory as _EventFactory
+from apps.scheduler.tests.factories import TaskFactory as _TaskFactory
+from apps.weddings.models import Wedding
+from apps.weddings.tests.factories import WeddingFactory as _WeddingFactory
+
+
+def EventFactory(*args: Any, **kwargs: Any) -> Event:
+    return cast(Event, _EventFactory(*args, **kwargs))
+
+
+def TaskFactory(*args: Any, **kwargs: Any) -> Task:
+    return cast(Task, _TaskFactory(*args, **kwargs))
+
+
+def WeddingFactory(*args: Any, **kwargs: Any) -> Wedding:
+    return cast(Wedding, _WeddingFactory(*args, **kwargs))
 
 
 @pytest.mark.django_db
 class TestSchedulerEventsAPI:
     """Testes dos endpoints de Eventos do Scheduler."""
 
-    def test_list_events_isolation(self, auth_client, user):
+    def test_list_events_isolation(self, auth_client: Any, user: Any) -> None:
         wedding = WeddingFactory(company=user.company)
         EventFactory(wedding=wedding, title="Reunião A")
         EventFactory(title="Reunião B")
@@ -21,11 +38,11 @@ class TestSchedulerEventsAPI:
         assert len(data["items"]) == 1
         assert data["items"][0]["title"] == "Reunião A"
 
-    def test_list_events_unauthorized(self, client):
+    def test_list_events_unauthorized(self, client: Any) -> None:
         response = client.get("/api/v1/scheduler/events/")
         assert response.status_code == 401
 
-    def test_create_event_success(self, auth_client, user):
+    def test_create_event_success(self, auth_client: Any, user: Any) -> None:
         wedding = WeddingFactory(company=user.company)
         now = timezone.now()
 
@@ -37,8 +54,8 @@ class TestSchedulerEventsAPI:
                 "event_type": "degustacao",
                 "location": "",
                 "description": "",
-                "start_time": (now + timezone.timedelta(days=10)).isoformat(),
-                "end_time": (now + timezone.timedelta(days=10, hours=1)).isoformat(),
+                "start_time": (now + timedelta(days=10)).isoformat(),
+                "end_time": (now + timedelta(days=10, hours=1)).isoformat(),
             },
             content_type="application/json",
         )
@@ -46,13 +63,13 @@ class TestSchedulerEventsAPI:
         data = response.json()
         assert data["title"] == "Prova de Buffet"
 
-    def test_create_event_unauthorized(self, client):
+    def test_create_event_unauthorized(self, client: Any) -> None:
         response = client.post(
             "/api/v1/scheduler/events/", {}, content_type="application/json"
         )
         assert response.status_code == 401
 
-    def test_create_event_invalid_end_time(self, auth_client, user):
+    def test_create_event_invalid_end_time(self, auth_client: Any, user: Any) -> None:
         """end_time < start_time deve retornar 422."""
         wedding = WeddingFactory(company=user.company)
         now = timezone.now()
@@ -65,14 +82,14 @@ class TestSchedulerEventsAPI:
                 "event_type": "outro",
                 "location": "",
                 "description": "",
-                "start_time": (now + timezone.timedelta(days=1, hours=12)).isoformat(),
-                "end_time": (now + timezone.timedelta(days=1, hours=10)).isoformat(),
+                "start_time": (now + timedelta(days=1, hours=12)).isoformat(),
+                "end_time": (now + timedelta(days=1, hours=10)).isoformat(),
             },
             content_type="application/json",
         )
         assert response.status_code == 422
 
-    def test_create_event_negative_reminder(self, auth_client, user):
+    def test_create_event_negative_reminder(self, auth_client: Any, user: Any) -> None:
         """reminder_minutes_before < 0 deve retornar 422."""
         wedding = WeddingFactory(company=user.company)
         now = timezone.now()
@@ -85,15 +102,17 @@ class TestSchedulerEventsAPI:
                 "event_type": "outro",
                 "location": "",
                 "description": "",
-                "start_time": (now + timezone.timedelta(days=1, hours=12)).isoformat(),
-                "end_time": (now + timezone.timedelta(days=1, hours=14)).isoformat(),
+                "start_time": (now + timedelta(days=1, hours=12)).isoformat(),
+                "end_time": (now + timedelta(days=1, hours=14)).isoformat(),
                 "reminder_minutes_before": -10,
             },
             content_type="application/json",
         )
         assert response.status_code == 422
 
-    def test_create_payment_event_manual_returns_422(self, auth_client, user):
+    def test_create_payment_event_manual_returns_422(
+        self, auth_client: Any, user: Any
+    ) -> None:
         """BR-S01: eventos de pagamento não podem ser criados manualmente."""
         wedding = WeddingFactory(company=user.company)
         now = timezone.now()
@@ -106,13 +125,13 @@ class TestSchedulerEventsAPI:
                 "event_type": "pagamento",
                 "location": "",
                 "description": "",
-                "start_time": (now + timezone.timedelta(days=1)).isoformat(),
+                "start_time": (now + timedelta(days=1)).isoformat(),
             },
             content_type="application/json",
         )
         assert response.status_code == 422
 
-    def test_retrieve_event_success(self, auth_client, user):
+    def test_retrieve_event_success(self, auth_client: Any, user: Any) -> None:
         wedding = WeddingFactory(company=user.company)
         event = EventFactory(wedding=wedding, title="Prova de Vestido")
 
@@ -120,13 +139,13 @@ class TestSchedulerEventsAPI:
         assert response.status_code == 200
         assert response.json()["title"] == "Prova de Vestido"
 
-    def test_retrieve_event_isolation_404(self, auth_client):
+    def test_retrieve_event_isolation_404(self, auth_client: Any) -> None:
         other_event = EventFactory(title="Evento Alheio")
 
         response = auth_client.get(f"/api/v1/scheduler/events/{other_event.uuid}/")
         assert response.status_code == 404
 
-    def test_update_event_success(self, auth_client, user):
+    def test_update_event_success(self, auth_client: Any, user: Any) -> None:
         wedding = WeddingFactory(company=user.company)
         event = EventFactory(wedding=wedding, title="Antigo")
 
@@ -138,7 +157,7 @@ class TestSchedulerEventsAPI:
         assert response.status_code == 200
         assert response.json()["title"] == "Novo Título"
 
-    def test_update_event_unauthorized(self, client):
+    def test_update_event_unauthorized(self, client: Any) -> None:
         response = client.patch(
             "/api/v1/scheduler/events/00000000-0000-0000-0000-000000000001/",
             {},
@@ -146,7 +165,7 @@ class TestSchedulerEventsAPI:
         )
         assert response.status_code == 401
 
-    def test_update_event_isolation_404(self, auth_client):
+    def test_update_event_isolation_404(self, auth_client: Any) -> None:
         other_event = EventFactory()
 
         response = auth_client.patch(
@@ -156,7 +175,9 @@ class TestSchedulerEventsAPI:
         )
         assert response.status_code == 404
 
-    def test_update_event_does_not_overwrite_recurrence_rule(self, auth_client, user):
+    def test_update_event_does_not_overwrite_recurrence_rule(
+        self, auth_client: Any, user: Any
+    ) -> None:
         """PATCH de evento sem recurrence_rule não deve alterar a regra existente."""
         wedding = WeddingFactory(company=user.company)
         event = EventFactory(
@@ -176,8 +197,8 @@ class TestSchedulerEventsAPI:
         assert event.recurrence_rule == Event.RecurrenceChoices.WEEKLY
 
     def test_update_event_clear_recurrence_rule_explicitly_success(
-        self, auth_client, user
-    ):
+        self, auth_client: Any, user: Any
+    ) -> None:
         """PATCH de evento enviando "none" limpa a recorrência."""
         wedding = WeddingFactory(company=user.company)
         event = EventFactory(
@@ -196,7 +217,9 @@ class TestSchedulerEventsAPI:
         event.refresh_from_db()
         assert event.recurrence_rule == Event.RecurrenceChoices.NONE
 
-    def test_update_event_recurrence_rule_null_returns_400(self, auth_client, user):
+    def test_update_event_recurrence_rule_null_returns_400(
+        self, auth_client: Any, user: Any
+    ) -> None:
         """PATCH de evento enviando null retorna 400."""
         wedding = WeddingFactory(company=user.company)
         event = EventFactory(
@@ -212,20 +235,20 @@ class TestSchedulerEventsAPI:
         )
         assert response.status_code == 400
 
-    def test_delete_event_success(self, auth_client, user):
+    def test_delete_event_success(self, auth_client: Any, user: Any) -> None:
         wedding = WeddingFactory(company=user.company)
         event = EventFactory(wedding=wedding)
 
         response = auth_client.delete(f"/api/v1/scheduler/events/{event.uuid}/")
         assert response.status_code == 204
 
-    def test_delete_event_unauthorized(self, client):
+    def test_delete_event_unauthorized(self, client: Any) -> None:
         response = client.delete(
             "/api/v1/scheduler/events/00000000-0000-0000-0000-000000000001/"
         )
         assert response.status_code == 401
 
-    def test_delete_event_isolation_404(self, auth_client):
+    def test_delete_event_isolation_404(self, auth_client: Any) -> None:
         other_event = EventFactory()
 
         response = auth_client.delete(f"/api/v1/scheduler/events/{other_event.uuid}/")
@@ -236,7 +259,7 @@ class TestSchedulerEventsAPI:
 class TestSchedulerTasksAPI:
     """Testes dos endpoints de Tarefas do Scheduler."""
 
-    def test_list_tasks_isolation(self, auth_client, user):
+    def test_list_tasks_isolation(self, auth_client: Any, user: Any) -> None:
         wedding = WeddingFactory(company=user.company)
         TaskFactory(wedding=wedding, title="Minha Tarefa")
         TaskFactory(title="Tarefa Alheia")
@@ -247,11 +270,11 @@ class TestSchedulerTasksAPI:
         assert len(data["items"]) == 1
         assert data["items"][0]["title"] == "Minha Tarefa"
 
-    def test_list_tasks_unauthorized(self, client):
+    def test_list_tasks_unauthorized(self, client: Any) -> None:
         response = client.get("/api/v1/scheduler/tasks/")
         assert response.status_code == 401
 
-    def test_create_task_success(self, auth_client, user):
+    def test_create_task_success(self, auth_client: Any, user: Any) -> None:
         wedding = WeddingFactory(company=user.company)
 
         response = auth_client.post(
@@ -267,13 +290,13 @@ class TestSchedulerTasksAPI:
         data = response.json()
         assert data["title"] == "Contratar Buffet"
 
-    def test_create_task_unauthorized(self, client):
+    def test_create_task_unauthorized(self, client: Any) -> None:
         response = client.post(
             "/api/v1/scheduler/tasks/", {}, content_type="application/json"
         )
         assert response.status_code == 401
 
-    def test_update_task_success(self, auth_client, user):
+    def test_update_task_success(self, auth_client: Any, user: Any) -> None:
         wedding = WeddingFactory(company=user.company)
         task = TaskFactory(wedding=wedding, title="Antigo", is_completed=False)
 
@@ -287,7 +310,7 @@ class TestSchedulerTasksAPI:
         assert data["title"] == "Novo"
         assert data["is_completed"] is True
 
-    def test_update_task_unauthorized(self, client):
+    def test_update_task_unauthorized(self, client: Any) -> None:
         response = client.patch(
             "/api/v1/scheduler/tasks/00000000-0000-0000-0000-000000000001/",
             {},
@@ -295,20 +318,20 @@ class TestSchedulerTasksAPI:
         )
         assert response.status_code == 401
 
-    def test_delete_task_success(self, auth_client, user):
+    def test_delete_task_success(self, auth_client: Any, user: Any) -> None:
         wedding = WeddingFactory(company=user.company)
         task = TaskFactory(wedding=wedding)
 
         response = auth_client.delete(f"/api/v1/scheduler/tasks/{task.uuid}/")
         assert response.status_code == 204
 
-    def test_delete_task_unauthorized(self, client):
+    def test_delete_task_unauthorized(self, client: Any) -> None:
         response = client.delete(
             "/api/v1/scheduler/tasks/00000000-0000-0000-0000-000000000001/"
         )
         assert response.status_code == 401
 
-    def test_delete_task_isolation_404(self, auth_client):
+    def test_delete_task_isolation_404(self, auth_client: Any) -> None:
         other_task = TaskFactory()
 
         response = auth_client.delete(f"/api/v1/scheduler/tasks/{other_task.uuid}/")

--- a/backend/apps/tenants/admin.py
+++ b/backend/apps/tenants/admin.py
@@ -4,7 +4,7 @@ from apps.tenants.models import Company
 
 
 @admin.register(Company)
-class CompanyAdmin(admin.ModelAdmin):
+class CompanyAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
     list_display = ("name", "slug", "is_active", "created_at")
     search_fields = ("name", "slug")
     list_filter = ("is_active",)

--- a/backend/apps/tenants/tests/test_managers.py
+++ b/backend/apps/tenants/tests/test_managers.py
@@ -5,6 +5,8 @@ O for_tenant() é a espinha dorsal de todo o sistema.
 Cada serviço depende dele para filtrar registros pela empresa correta.
 """
 
+from typing import Any, cast
+
 import pytest
 
 from apps.tenants.managers import TenantManager, TenantQuerySet
@@ -17,33 +19,33 @@ from .factories import CompanyFactory
 
 @pytest.mark.django_db
 class TestTenantQuerySet:
-    def test_for_tenant_filters_by_company(self):
-        company_a = CompanyFactory()
-        company_b = CompanyFactory()
+    def test_for_tenant_filters_by_company(self) -> None:
+        company_a = cast(Any, CompanyFactory())
+        company_b = cast(Any, CompanyFactory())
 
-        w1 = WeddingFactory(company=company_a)
+        w1 = cast(Any, WeddingFactory(company=company_a))
         WeddingFactory(company=company_b)
-        w3 = WeddingFactory(company=company_a)
+        w3 = cast(Any, WeddingFactory(company=company_a))
 
         qs = Wedding.objects.for_tenant(company_a)
 
         assert qs.count() == 2
         assert set(qs.values_list("id", flat=True)) == {w1.id, w3.id}
 
-    def test_for_tenant_returns_empty_when_no_records(self):
-        company = CompanyFactory()
+    def test_for_tenant_returns_empty_when_no_records(self) -> None:
+        company = cast(Any, CompanyFactory())
 
         qs = Wedding.objects.for_tenant(company)
 
         assert qs.count() == 0
         assert not qs.exists()
 
-    def test_for_tenant_excludes_other_company_records(self):
-        company_a = CompanyFactory()
-        company_b = CompanyFactory()
+    def test_for_tenant_excludes_other_company_records(self) -> None:
+        company_a = cast(Any, CompanyFactory())
+        company_b = cast(Any, CompanyFactory())
 
-        w_a = WeddingFactory(company=company_a)
-        w_b = WeddingFactory(company=company_b)
+        w_a = cast(Any, WeddingFactory(company=company_a))
+        w_b = cast(Any, WeddingFactory(company=company_b))
 
         qs = Wedding.objects.for_tenant(company_a)
         ids = set(qs.values_list("id", flat=True))
@@ -51,9 +53,9 @@ class TestTenantQuerySet:
         assert w_a.id in ids
         assert w_b.id not in ids
 
-    def test_for_tenant_with_multiple_models_isolated(self):
-        company_a = CompanyFactory()
-        company_b = CompanyFactory()
+    def test_for_tenant_with_multiple_models_isolated(self) -> None:
+        company_a = cast(Any, CompanyFactory())
+        company_b = cast(Any, CompanyFactory())
 
         WeddingFactory(company=company_a)
         WeddingFactory(company=company_b)
@@ -64,13 +66,13 @@ class TestTenantQuerySet:
 
 @pytest.mark.django_db
 class TestTenantManager:
-    def test_get_queryset_returns_tenant_queryset(self):
+    def test_get_queryset_returns_tenant_queryset(self) -> None:
         qs = Wedding.objects.get_queryset()
 
         assert isinstance(qs, TenantQuerySet)
 
-    def test_for_tenant_delegates_to_queryset(self):
-        company = CompanyFactory()
+    def test_for_tenant_delegates_to_queryset(self) -> None:
+        company = cast(Any, CompanyFactory())
         WeddingFactory(company=company)
 
         result = Wedding.objects.for_tenant(company)
@@ -78,7 +80,7 @@ class TestTenantManager:
         assert isinstance(result, TenantQuerySet)
         assert result.count() == 1
 
-    def test_all_models_with_tenant_manager_return_same_type(self):
+    def test_all_models_with_tenant_manager_return_same_type(self) -> None:
         """Garante consistência: todo TenantModel expõe TenantManager.
 
         NOTA: Ao adicionar novos modelos TenantModel, inclua-os nesta lista
@@ -110,13 +112,13 @@ class TestTenantManager:
         ]
 
         for model_class in models_with_tenant:
-            assert isinstance(model_class.objects, TenantManager), (
+            assert isinstance(cast(Any, model_class).objects, TenantManager), (
                 f"{model_class.__name__}.objects não é TenantManager"
             )
 
-    def test_tenant_model_is_abstract(self):
+    def test_tenant_model_is_abstract(self) -> None:
         assert TenantModel._meta.abstract is True
 
-    def test_tenant_manager_cannot_be_accessed_on_abstract(self):
+    def test_tenant_manager_cannot_be_accessed_on_abstract(self) -> None:
         with pytest.raises(AttributeError):
             _ = TenantModel.objects

--- a/backend/apps/tenants/tests/test_models.py
+++ b/backend/apps/tenants/tests/test_models.py
@@ -5,6 +5,8 @@ Verifica configuração de FK, índices, validação de fábricas e
 representação textual dos modelos.
 """
 
+from typing import cast
+
 import pytest
 from django.db import models
 
@@ -12,33 +14,37 @@ from apps.tenants.managers import TenantManager
 from apps.tenants.models import Company, TenantModel
 from apps.weddings.models import Wedding
 
-from .factories import CompanyFactory
+from .factories import CompanyFactory as _CompanyFactory
+
+
+def CompanyFactory(**kwargs: object) -> Company:
+    return cast(Company, _CompanyFactory(**kwargs))
 
 
 @pytest.mark.django_db
 class TestTenantModelStructure:
-    def test_has_company_foreign_key(self):
+    def test_has_company_foreign_key(self) -> None:
         field = TenantModel._meta.get_field("company")
         assert isinstance(field, models.ForeignKey)
         assert field.remote_field.model == Company
         assert field.remote_field.on_delete == models.CASCADE
 
-    def test_has_composite_index_on_company_and_uuid(self):
+    def test_has_composite_index_on_company_and_uuid(self) -> None:
         indexes = TenantModel._meta.indexes
         index_fields = [tuple(idx.fields) for idx in indexes]
 
         assert ("company", "uuid") in index_fields
 
-    def test_concrete_model_inherits_tenant_manager(self):
+    def test_concrete_model_inherits_tenant_manager(self) -> None:
         assert isinstance(Wedding.objects, TenantManager)
 
 
 class TestCompanyModel:
-    def test_str_returns_name(self):
+    def test_str_returns_name(self) -> None:
         company = Company(name="Empresa Teste", slug="empresa-teste")
         assert str(company) == "Empresa Teste"
 
-    def test_fields_configuration(self):
+    def test_fields_configuration(self) -> None:
         name_field = Company._meta.get_field("name")
         assert name_field.max_length == 255
 
@@ -48,14 +54,14 @@ class TestCompanyModel:
         active_field = Company._meta.get_field("is_active")
         assert active_field.default is True
 
-    def test_meta_configuration(self):
+    def test_meta_configuration(self) -> None:
         assert Company._meta.db_table == "companies"
         assert Company._meta.ordering == ["name"]
         assert Company._meta.verbose_name == "Empresa"
         assert Company._meta.verbose_name_plural == "Empresas"
 
     @pytest.mark.django_db
-    def test_company_inherits_from_base_model(self):
+    def test_company_inherits_from_base_model(self) -> None:
         company = CompanyFactory()
         assert company.uuid is not None
         assert company.created_at is not None
@@ -64,18 +70,18 @@ class TestCompanyModel:
 
 @pytest.mark.django_db
 class TestCompanyFactory:
-    def test_creates_valid_company(self):
+    def test_creates_valid_company(self) -> None:
         company = CompanyFactory()
         assert company.pk is not None
         assert company.name
         assert company.slug
         assert company.is_active is True
 
-    def test_name_can_be_overridden(self):
+    def test_name_can_be_overridden(self) -> None:
         company = CompanyFactory(name="Minha Empresa")
         assert company.name == "Minha Empresa"
 
-    def test_slug_is_unique_across_instances(self):
+    def test_slug_is_unique_across_instances(self) -> None:
         c1 = CompanyFactory()
         c2 = CompanyFactory()
         assert c1.slug != c2.slug

--- a/backend/apps/tenants/tests/test_services.py
+++ b/backend/apps/tenants/tests/test_services.py
@@ -9,7 +9,7 @@ from apps.tenants.services.tenant_service import TenantService
 class TestTenantService:
     """Testes para o TenantService."""
 
-    def test_create_company_success(self):
+    def test_create_company_success(self) -> None:
         """Garante que a empresa é criada corretamente com um slug único."""
         display_name = "Rafael Araujo"
         company = TenantService.create_company(display_name)
@@ -19,7 +19,7 @@ class TestTenantService:
         assert display_name.lower().split()[0] in company.slug
         assert company.is_active is True
 
-    def test_create_company_slug_uniqueness(self):
+    def test_create_company_slug_uniqueness(self) -> None:
         """Garante que duas empresas com o mesmo nome ganham slugs diferentes."""
         display_name = "Mesmo Nome"
         company1 = TenantService.create_company(display_name)
@@ -28,7 +28,7 @@ class TestTenantService:
         assert company1.slug != company2.slug
         assert company1.id != company2.id
 
-    def test_get_or_create_admin_workspace(self):
+    def test_get_or_create_admin_workspace(self) -> None:
         """Garante que o workspace administrativo é único e persistente."""
         admin_company1 = TenantService.get_or_create_admin_workspace()
         admin_company2 = TenantService.get_or_create_admin_workspace()
@@ -37,7 +37,7 @@ class TestTenantService:
         assert admin_company1.id == admin_company2.id
         assert Company.objects.filter(slug="admin-workspace").count() == 1
 
-    def test_create_company_with_custom_name(self):
+    def test_create_company_with_custom_name(self) -> None:
         """company_name explícito substitui o nome padrão 'Workspace de ...'."""
         company = TenantService.create_company(
             display_name="Rafael", company_name="Cerimonial XPTO"
@@ -45,26 +45,26 @@ class TestTenantService:
         assert company.name == "Cerimonial XPTO"
         assert "Workspace de" not in company.name
 
-    def test_create_company_special_chars_in_display_name(self):
+    def test_create_company_special_chars_in_display_name(self) -> None:
         """Caracteres especiais e acentos são normalizados no slug."""
         company = TenantService.create_company(display_name="João & Maria")
         assert "joao" in company.slug
         assert "&" not in company.slug
 
-    def test_create_company_whitespace_only_display_name(self):
+    def test_create_company_whitespace_only_display_name(self) -> None:
         """Display name apenas com espaços gera slug mínimo com UUID."""
         company = TenantService.create_company(display_name="   ")
         assert company.name == "Workspace de    "
         assert company.slug  # slug não-vazio (contém UUID)
 
-    def test_create_company_display_name_too_long_raises(self):
+    def test_create_company_display_name_too_long_raises(self) -> None:
         """Display name >255 chars faz name exceder max_length → ValidationError."""
         long_name = "A" * 300
 
         with pytest.raises(ValidationError):
             TenantService.create_company(display_name=long_name)
 
-    def test_create_company_custom_name_too_long_raises(self):
+    def test_create_company_custom_name_too_long_raises(self) -> None:
         """company_name >255 chars excede max_length → ValidationError."""
         long_name = "B" * 300
 

--- a/backend/apps/users/admin.py
+++ b/backend/apps/users/admin.py
@@ -13,7 +13,7 @@ from .models import User
 
 
 @admin.register(User)
-class CustomUserAdmin(BaseUserAdmin):
+class CustomUserAdmin(BaseUserAdmin):  # type: ignore[type-arg]
     """Admin customizado para o modelo User.
 
     Adapta o UserAdmin padrão do Django para trabalhar com o modelo User

--- a/backend/apps/users/forms.py
+++ b/backend/apps/users/forms.py
@@ -9,7 +9,7 @@ from django.contrib.auth.forms import UserChangeForm, UserCreationForm
 from .models import User
 
 
-class CustomUserChangeForm(UserChangeForm):
+class CustomUserChangeForm(UserChangeForm):  # type: ignore[type-arg]
     """Formulário de edição de usuário existente.
 
     Herda de UserChangeForm do Django e adapta para o modelo User customizado.
@@ -21,7 +21,7 @@ class CustomUserChangeForm(UserChangeForm):
         fields = "__all__"
 
 
-class CustomUserCreationForm(UserCreationForm):
+class CustomUserCreationForm(UserCreationForm[User]):
     """Formulário de criação de novo usuário.
 
     Herda de UserCreationForm do Django e adapta para o modelo User customizado.

--- a/backend/apps/users/models.py
+++ b/backend/apps/users/models.py
@@ -5,7 +5,7 @@ e o CustomUserManager para gerenciar a criação de usuários e superusuários.
 """
 
 import uuid
-from typing import Any, cast
+from typing import Any
 
 from django.contrib.auth.models import (
     AbstractBaseUser,
@@ -16,7 +16,7 @@ from django.db import models
 from django.utils import timezone
 
 
-class CustomUserManager(BaseUserManager):
+class CustomUserManager(BaseUserManager["User"]):
     """Manager customizado para o modelo User.
 
     Gerencia a criação de usuários regulares e superusuários,
@@ -57,7 +57,7 @@ class CustomUserManager(BaseUserManager):
             company = TenantService.create_company(display_name)
             extra_fields["company"] = company
 
-        user = cast("User", self.model(email=email, **extra_fields))
+        user = self.model(email=email, **extra_fields)
         user.set_password(password)
         user.save(using=self._db)
         return user

--- a/backend/apps/users/schemas.py
+++ b/backend/apps/users/schemas.py
@@ -1,6 +1,8 @@
 from ninja import Schema
 from pydantic import UUID4, EmailStr, Field
 
+from apps.users.models import User
+
 
 class TokenPayloadIn(Schema):
     """Credenciais para autenticação (obtain token)."""
@@ -60,7 +62,7 @@ class UserOut(Schema):
     is_email_verified: bool = False
 
     @staticmethod
-    def resolve_company_slug(obj):
+    def resolve_company_slug(obj: "User") -> str | None:
         return obj.company.slug if obj.company else None
 
 

--- a/backend/apps/users/services/token_service.py
+++ b/backend/apps/users/services/token_service.py
@@ -1,5 +1,6 @@
 import hashlib
 import logging
+from typing import cast
 
 from django.contrib.auth import authenticate
 from ninja_jwt.schema import (
@@ -102,9 +103,9 @@ class TokenService:
         token_fp = hashlib.sha256(refresh_token.encode()).hexdigest()[:12]
         logger.info(f"Tentativa de refresh de token (fp={token_fp})")
         schema = TokenRefreshInputSchema(refresh=refresh_token)
-        result = schema.to_response_schema()
+        result = schema.to_response_schema()  # type: ignore[no-untyped-call]
         logger.info(f"Token refresh bem-sucedido (fp={token_fp})")
-        return result
+        return cast(TokenRefreshOutputSchema, result)
 
     @staticmethod
     def verify(token: str) -> VerifyTokenOut:
@@ -124,6 +125,6 @@ class TokenService:
         logger.info(f"Tentativa de verificação de token (fp={token_fp})")
         schema = TokenVerifyInputSchema(token=token)
         # O método levanta HttpError(401) caso o token seja inválido.
-        schema.to_response_schema()
+        schema.to_response_schema()  # type: ignore[no-untyped-call]
         logger.info(f"Token verificado com sucesso (fp={token_fp})")
         return VerifyTokenOut()

--- a/backend/apps/users/tests/test_apis.py
+++ b/backend/apps/users/tests/test_apis.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from apps.users.models import User
@@ -7,7 +9,7 @@ from apps.users.models import User
 class TestAuthAPI:
     """Testes de integração para a API de autenticação e registro."""
 
-    def test_register_user_success(self, client):
+    def test_register_user_success(self, client: Any) -> None:
         """Garante que o registro de usuário com senha válida tem sucesso."""
         payload = {
             "email": "novo_user@exemplo.com",
@@ -26,7 +28,7 @@ class TestAuthAPI:
         assert data["email"] == "novo_user@exemplo.com"
         assert User.objects.filter(email="novo_user@exemplo.com").exists()
 
-    def test_register_user_short_password_fails(self, client):
+    def test_register_user_short_password_fails(self, client: Any) -> None:
         """Garante que a API rejeita registro com senha menor de 8 caracteres."""
         payload = {
             "email": "invalid_pwd@exemplo.com",
@@ -47,7 +49,7 @@ class TestAuthAPI:
         assert "password" in error["loc"]
         assert "string_too_short" in error["type"]
 
-    def test_register_user_duplicate_email_fails(self, client, user):
+    def test_register_user_duplicate_email_fails(self, client: Any, user: Any) -> None:
         """
         Garante que a API rejeita registro de e-mail
         já existente com 409 Conflict.

--- a/backend/apps/users/tests/test_auth_api.py
+++ b/backend/apps/users/tests/test_auth_api.py
@@ -11,13 +11,15 @@ Cobre:
 - Verificação de token inválido (401)
 """
 
+from typing import Any
+
 import pytest
 
 
 pytestmark = pytest.mark.django_db
 
 
-def test_obtain_token_success(auth_client, user):
+def test_obtain_token_success(auth_client: Any, user: Any) -> None:
     """POST /api/v1/auth/token/ com credenciais válidas retorna 200 com tokens."""
     response = auth_client.post(
         "/api/v1/auth/token/",
@@ -32,7 +34,7 @@ def test_obtain_token_success(auth_client, user):
     assert data["user"]["email"] == user.email
 
 
-def test_obtain_token_invalid_password(auth_client, user):
+def test_obtain_token_invalid_password(auth_client: Any, user: Any) -> None:
     """POST /api/v1/auth/token/ com senha errada retorna 401."""
     response = auth_client.post(
         "/api/v1/auth/token/",
@@ -42,7 +44,7 @@ def test_obtain_token_invalid_password(auth_client, user):
     assert response.status_code == 401
 
 
-def test_obtain_token_inactive_user(auth_client, inactive_planner):
+def test_obtain_token_inactive_user(auth_client: Any, inactive_planner: Any) -> None:
     """POST /api/v1/auth/token/ com usuário inativo retorna 401."""
     response = auth_client.post(
         "/api/v1/auth/token/",
@@ -52,7 +54,7 @@ def test_obtain_token_inactive_user(auth_client, inactive_planner):
     assert response.status_code == 401
 
 
-def test_refresh_token_success(auth_client, user):
+def test_refresh_token_success(auth_client: Any, user: Any) -> None:
     """POST /api/v1/auth/refresh/ com refresh válido retorna 200 com novos tokens."""
     obtain_resp = auth_client.post(
         "/api/v1/auth/token/",
@@ -74,7 +76,7 @@ def test_refresh_token_success(auth_client, user):
     assert data["refresh"] != tokens["refresh"]
 
 
-def test_refresh_token_reuse_after_rotation(auth_client, user):
+def test_refresh_token_reuse_after_rotation(auth_client: Any, user: Any) -> None:
     """Usar o mesmo refresh token duas vezes deve falhar na segunda (blacklist)."""
     obtain_resp = auth_client.post(
         "/api/v1/auth/token/",
@@ -100,7 +102,7 @@ def test_refresh_token_reuse_after_rotation(auth_client, user):
     assert second.status_code == 401
 
 
-def test_verify_token_success(auth_client, user):
+def test_verify_token_success(auth_client: Any, user: Any) -> None:
     """POST /api/v1/auth/verify/ com access token válido retorna 200."""
     obtain_resp = auth_client.post(
         "/api/v1/auth/token/",
@@ -117,7 +119,7 @@ def test_verify_token_success(auth_client, user):
     assert response.status_code == 200
 
 
-def test_verify_token_invalid(auth_client):
+def test_verify_token_invalid(auth_client: Any) -> None:
     """POST /api/v1/auth/verify/ com token inválido retorna 401."""
     response = auth_client.post(
         "/api/v1/auth/verify/",

--- a/backend/apps/users/tests/test_auth_throttling.py
+++ b/backend/apps/users/tests/test_auth_throttling.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 
@@ -23,7 +25,9 @@ import pytest
         ("/api/v1/auth/verify/", {"token": "invalid-token-value"}),
     ],
 )
-def test_auth_endpoint_exceeds_rate_limit_returns_429(client, url, payload):
+def test_auth_endpoint_exceeds_rate_limit_returns_429(
+    client: Any, url: str, payload: dict[str, str]
+) -> None:
     """
     Garante que os endpoints de autenticação retornam 429
     após exceder o limite de 5 req/min.
@@ -39,7 +43,7 @@ def test_auth_endpoint_exceeds_rate_limit_returns_429(client, url, payload):
 
 
 @pytest.mark.django_db
-def test_auth_throttling_scopes_are_isolated_and_independent(client):
+def test_auth_throttling_scopes_are_isolated_and_independent(client: Any) -> None:
     """
     Garante que requisições em um endpoint de autenticação
     não interferem no limite do outro.

--- a/backend/apps/users/tests/test_email_verification_api.py
+++ b/backend/apps/users/tests/test_email_verification_api.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 from django.contrib.auth.tokens import default_token_generator
 from django.utils.encoding import force_bytes
@@ -6,7 +8,7 @@ from django.utils.http import urlsafe_base64_encode
 
 @pytest.mark.django_db
 class TestEmailVerificationAPI:
-    def test_verify_email_success(self, client, user_factory):
+    def test_verify_email_success(self, client: Any, user_factory: Any) -> None:
         user = user_factory.create(is_active=False, is_email_verified=False)
         uid = urlsafe_base64_encode(force_bytes(str(user.uuid)))
         token = default_token_generator.make_token(user)
@@ -24,7 +26,7 @@ class TestEmailVerificationAPI:
         assert user.is_email_verified is True
         assert user.is_active is True
 
-    def test_verify_email_invalid_token(self, client, user_factory):
+    def test_verify_email_invalid_token(self, client: Any, user_factory: Any) -> None:
         user = user_factory.create(is_active=False, is_email_verified=False)
         uid = urlsafe_base64_encode(force_bytes(str(user.uuid)))
 
@@ -37,7 +39,7 @@ class TestEmailVerificationAPI:
         assert response.status_code == 400
         assert response.json()["code"] == "invalid_token"
 
-    def test_resend_verification_email(self, client, user_factory):
+    def test_resend_verification_email(self, client: Any, user_factory: Any) -> None:
         user = user_factory.create(is_active=False, is_email_verified=False)
 
         response = client.post(

--- a/backend/apps/users/tests/test_email_verification_service.py
+++ b/backend/apps/users/tests/test_email_verification_service.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 from django.contrib.auth.tokens import default_token_generator
 from django.core import mail
@@ -10,7 +12,7 @@ from apps.users.services.email_verification_service import EmailVerificationServ
 
 @pytest.mark.django_db
 class TestEmailVerificationService:
-    def test_send_verification_email(self, user_factory):
+    def test_send_verification_email(self, user_factory: Any) -> None:
         user = user_factory.create(is_active=False, is_email_verified=False)
         EmailVerificationService.send_verification_email(user)
 
@@ -18,7 +20,7 @@ class TestEmailVerificationService:
         assert mail.outbox[0].subject == "Confirme seu e-mail"
         assert user.email in mail.outbox[0].to
 
-    def test_verify_email_success(self, user_factory):
+    def test_verify_email_success(self, user_factory: Any) -> None:
         user = user_factory.create(is_active=False, is_email_verified=False)
         uid = urlsafe_base64_encode(force_bytes(str(user.uuid)))
         token = default_token_generator.make_token(user)
@@ -29,7 +31,7 @@ class TestEmailVerificationService:
         assert verified_user.is_active is True
         assert verified_user.email_verified_at is not None
 
-    def test_verify_email_invalid_token(self, user_factory):
+    def test_verify_email_invalid_token(self, user_factory: Any) -> None:
         user = user_factory.create(is_active=False, is_email_verified=False)
         uid = urlsafe_base64_encode(force_bytes(str(user.uuid)))
 
@@ -38,20 +40,22 @@ class TestEmailVerificationService:
 
         assert exc_info.value.code == "invalid_token"
 
-    def test_resend_verification_email_success(self, user_factory):
+    def test_resend_verification_email_success(self, user_factory: Any) -> None:
         user = user_factory.create(is_active=False, is_email_verified=False)
         EmailVerificationService.resend_verification_email(user.email)
 
         assert len(mail.outbox) == 1
         assert mail.outbox[0].subject == "Confirme seu e-mail"
 
-    def test_resend_verification_email_already_verified(self, user_factory):
+    def test_resend_verification_email_already_verified(
+        self, user_factory: Any
+    ) -> None:
         user = user_factory.create(is_active=True, is_email_verified=True)
         EmailVerificationService.resend_verification_email(user.email)
 
         assert len(mail.outbox) == 0
 
-    def test_resend_verification_email_non_existent(self, user_factory):
+    def test_resend_verification_email_non_existent(self, user_factory: Any) -> None:
         EmailVerificationService.resend_verification_email("nonexistent@example.com")
 
         assert len(mail.outbox) == 0

--- a/backend/apps/users/tests/test_models.py
+++ b/backend/apps/users/tests/test_models.py
@@ -1,21 +1,34 @@
 """Testes do modelo User."""
 
+from typing import Any, cast
+
 import pytest
 from django.contrib.auth import get_user_model
 from django.db import IntegrityError
 from django.db import models as db_models
 
-from .factories import AdminFactory, UserFactory
+from apps.users.models import User as UserModel
+
+from .factories import AdminFactory as _AdminFactory
+from .factories import UserFactory as _UserFactory
 
 
 User = get_user_model()
+
+
+def UserFactory(*args: Any, **kwargs: Any) -> UserModel:
+    return cast(UserModel, _UserFactory(*args, **kwargs))
+
+
+def AdminFactory(*args: Any, **kwargs: Any) -> UserModel:
+    return cast(UserModel, _AdminFactory(*args, **kwargs))
 
 
 @pytest.mark.django_db
 class TestUserModel:
     """Testes do modelo customizado User com campos explícitos e Factories."""
 
-    def test_create_user_via_manager(self):
+    def test_create_user_via_manager(self) -> None:
         """Testa se o Manager cria o usuário com os campos separados corretamente."""
         user = User.objects.create_user(
             email="manager_test@example.com",
@@ -29,7 +42,7 @@ class TestUserModel:
         assert user.check_password("password123")
         assert not user.is_active  # Valida regra de negócio: inativo por padrão
 
-    def test_create_superuser_via_manager(self):
+    def test_create_superuser_via_manager(self) -> None:
         """Testa se o Manager cria o superusuário com as permissões corretas."""
         admin = User.objects.create_superuser(
             email="admin_manager@example.com",
@@ -41,47 +54,47 @@ class TestUserModel:
         assert admin.is_superuser
         assert admin.is_active
 
-    def test_user_factory_creation(self):
+    def test_user_factory_creation(self) -> None:
         """Valida que a UserFactory gera usuários ativos e válidos para testes."""
         user = UserFactory()
         assert user.is_active is True
         assert "@" in user.email
         assert len(user.first_name) > 0
 
-    def test_admin_factory_creation(self):
+    def test_admin_factory_creation(self) -> None:
         """Valida que a AdminFactory gera superusuários corretamente."""
         admin = AdminFactory()
         assert admin.is_superuser is True
         assert admin.is_staff is True
 
-    def test_user_email_required(self):
+    def test_user_email_required(self) -> None:
         """Testa a obrigatoriedade do email no nível do Manager."""
         with pytest.raises(ValueError, match="O e-mail é obrigatório"):
             User.objects.create_user(email="", first_name="User", last_name="Test")
 
-    def test_user_email_unique(self):
+    def test_user_email_unique(self) -> None:
         """Testa a restrição de unicidade do email no banco de dados."""
         UserFactory(email="unique@example.com")
         with pytest.raises(IntegrityError):
             # Tentativa de criar outro usuário com o mesmo email via Factory
             UserFactory(email="unique@example.com")
 
-    def test_user_str_representation(self):
+    def test_user_str_representation(self) -> None:
         """Testa o dunder method __str__ usando dados da Factory."""
         user = UserFactory(first_name="Dunder", last_name="Method", email="test@ex.com")
         assert str(user) == "Dunder Method (test@ex.com)"
 
-    def test_get_full_name(self):
+    def test_get_full_name(self) -> None:
         """Testa se a união do nome e sobrenome está correta."""
         user = UserFactory(first_name="Full", last_name="Name")
         assert user.get_full_name() == "Full Name"
 
-    def test_get_short_name(self):
+    def test_get_short_name(self) -> None:
         """Testa se o nome curto retorna apenas o first_name."""
         user = UserFactory(first_name="Short", last_name="LongName")
         assert user.get_short_name() == "Short"
 
-    def test_email_normalization(self):
+    def test_email_normalization(self) -> None:
         """Testa se o Manager normaliza o domínio do email para minúsculo."""
         email_mixed = "USER@DOMAIN.COM"
         user = User.objects.create_user(
@@ -97,7 +110,7 @@ class TestUserModel:
 class TestUserCompanyProtect:
     """Testes da constraint on_delete=PROTECT no FK company."""
 
-    def test_delete_company_with_users_raises_protected_error(self):
+    def test_delete_company_with_users_raises_protected_error(self) -> None:
         """Não é possível deletar Company que possui Users vinculados."""
         user = UserFactory()
         company = user.company

--- a/backend/apps/users/tests/test_password_reset_api.py
+++ b/backend/apps/users/tests/test_password_reset_api.py
@@ -1,3 +1,5 @@
+from typing import Any, cast
+
 import pytest
 from django.contrib.auth.tokens import default_token_generator
 from django.core import mail
@@ -5,17 +7,22 @@ from django.test import Client
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
 
-from apps.users.tests.factories import UserFactory
+from apps.users.models import User
+from apps.users.tests.factories import UserFactory as _UserFactory
+
+
+def UserFactory(*args: Any, **kwargs: Any) -> User:
+    return cast(User, _UserFactory(*args, **kwargs))
 
 
 @pytest.fixture
-def unauth_client():
+def unauth_client() -> Client:
     return Client()
 
 
 @pytest.mark.django_db
 class TestPasswordResetAPI:
-    def test_request_password_reset(self, unauth_client):
+    def test_request_password_reset(self, unauth_client: Client) -> None:
         UserFactory(email="test_api@example.com")
 
         response = unauth_client.post(
@@ -31,7 +38,9 @@ class TestPasswordResetAPI:
         )
         assert len(mail.outbox) == 1
 
-    def test_request_password_reset_non_existent_user(self, unauth_client):
+    def test_request_password_reset_non_existent_user(
+        self, unauth_client: Client
+    ) -> None:
         response = unauth_client.post(
             "/api/v1/auth/password-reset/request/",
             {"email": "notfound@example.com"},
@@ -45,7 +54,7 @@ class TestPasswordResetAPI:
         )
         assert len(mail.outbox) == 0
 
-    def test_confirm_password_reset(self, unauth_client):
+    def test_confirm_password_reset(self, unauth_client: Client) -> None:
 
         user = UserFactory()
         uid = urlsafe_base64_encode(force_bytes(str(user.uuid)))
@@ -65,7 +74,7 @@ class TestPasswordResetAPI:
         user.refresh_from_db()
         assert user.check_password("NewStrongPass123!")
 
-    def test_confirm_password_reset_invalid(self, unauth_client):
+    def test_confirm_password_reset_invalid(self, unauth_client: Client) -> None:
         payload = {
             "uid": "invalid",
             "token": "invalid",

--- a/backend/apps/users/tests/test_password_reset_service.py
+++ b/backend/apps/users/tests/test_password_reset_service.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 import pytest
 from django.contrib.auth.tokens import default_token_generator
 from django.core import mail
@@ -5,14 +7,15 @@ from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
 
 from apps.core.exceptions import ApplicationError
+from apps.users.models import User
 from apps.users.services.password_reset_service import PasswordResetService
 from apps.users.tests.factories import UserFactory
 
 
 @pytest.mark.django_db
 class TestPasswordResetService:
-    def test_request_password_reset_success(self):
-        user = UserFactory(email="test@example.com")
+    def test_request_password_reset_success(self) -> None:
+        user = cast(User, UserFactory(email="test@example.com"))
         PasswordResetService.request_password_reset(email="test@example.com")
 
         assert len(mail.outbox) == 1
@@ -20,12 +23,12 @@ class TestPasswordResetService:
         assert mail.outbox[0].to == [user.email]
         assert "reset-password?uid=" in mail.outbox[0].body
 
-    def test_request_password_reset_non_existent_user(self):
+    def test_request_password_reset_non_existent_user(self) -> None:
         PasswordResetService.request_password_reset(email="notfound@example.com")
         assert len(mail.outbox) == 0
 
-    def test_confirm_password_reset_success(self):
-        user = UserFactory(email="test2@example.com")
+    def test_confirm_password_reset_success(self) -> None:
+        user = cast(User, UserFactory(email="test2@example.com"))
         uid = urlsafe_base64_encode(force_bytes(str(user.uuid)))
         token = default_token_generator.make_token(user)
 
@@ -33,8 +36,8 @@ class TestPasswordResetService:
         user.refresh_from_db()
         assert user.check_password("NewStrongPass123!")
 
-    def test_confirm_password_reset_invalid_token(self):
-        user = UserFactory()
+    def test_confirm_password_reset_invalid_token(self) -> None:
+        user = cast(User, UserFactory())
         uid = urlsafe_base64_encode(force_bytes(str(user.uuid)))
 
         with pytest.raises(ApplicationError) as exc_info:
@@ -45,8 +48,8 @@ class TestPasswordResetService:
         assert exc_info.value.code == "invalid_token"
         assert exc_info.value.status_code == 400
 
-    def test_confirm_password_reset_invalid_uid(self):
-        user = UserFactory()
+    def test_confirm_password_reset_invalid_uid(self) -> None:
+        user = cast(User, UserFactory())
         token = default_token_generator.make_token(user)
 
         with pytest.raises(ApplicationError) as exc_info:
@@ -56,8 +59,8 @@ class TestPasswordResetService:
 
         assert exc_info.value.code == "invalid_token"
 
-    def test_confirm_password_reset_weak_password(self):
-        user = UserFactory(email="weak@example.com")
+    def test_confirm_password_reset_weak_password(self) -> None:
+        user = cast(User, UserFactory(email="weak@example.com"))
         uid = urlsafe_base64_encode(force_bytes(str(user.uuid)))
         token = default_token_generator.make_token(user)
 

--- a/backend/apps/users/tests/test_password_security.py
+++ b/backend/apps/users/tests/test_password_security.py
@@ -8,7 +8,7 @@ from apps.users.services.registration_service import RegistrationService
 class TestRegistrationPasswordSecurity:
     """Testes de segurança para validação de senha no registro."""
 
-    def test_register_new_owner_with_weak_password_fails(self):
+    def test_register_new_owner_with_weak_password_fails(self) -> None:
         """
         Garante que senhas fracas (comuns) são rejeitadas durante o registro.
         """

--- a/backend/apps/users/tests/test_register_api_security.py
+++ b/backend/apps/users/tests/test_register_api_security.py
@@ -1,8 +1,10 @@
+from typing import Any
+
 import pytest
 
 
 @pytest.mark.django_db
-def test_register_user_weak_password_api_response(auth_client):
+def test_register_user_weak_password_api_response(auth_client: Any) -> None:
     """
     Testa se o endpoint de registro retorna uma mensagem de erro amigável (400)
     quando a validação de senha falha.

--- a/backend/apps/users/tests/test_services.py
+++ b/backend/apps/users/tests/test_services.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 from django.core.exceptions import ValidationError
 from django.db import DataError
@@ -12,7 +14,7 @@ from apps.users.services.registration_service import RegistrationService
 class TestRegistrationService:
     """Testes unitários para o RegistrationService."""
 
-    def test_register_new_owner_success(self):
+    def test_register_new_owner_success(self) -> None:
         """Garante que um novo usuário e empresa são criados corretamente."""
         email = "novo@exemplo.com"
         password = "SecurePassword123!"
@@ -35,7 +37,7 @@ class TestRegistrationService:
         assert isinstance(user.company, Company)
         assert user.company.name == f"Workspace de {first_name} {last_name}"
 
-    def test_register_new_owner_duplicate_email_fails(self, user):
+    def test_register_new_owner_duplicate_email_fails(self, user: Any) -> None:
         """Garante que não é possível registrar dois usuários com o mesmo e-mail."""
         email = user.email
         password = "another_password"
@@ -46,7 +48,7 @@ class TestRegistrationService:
         assert exc_info.value.code == "email_already_exists"
         assert "e-mail já está cadastrado" in str(exc_info.value.detail)
 
-    def test_register_new_owner_transaction_rollback(self, db):
+    def test_register_new_owner_transaction_rollback(self, db: Any) -> None:
         """Garante que a empresa não é criada se o usuário falhar (Rollback)."""
         email = "falha@exemplo.com"
 
@@ -61,7 +63,7 @@ class TestRegistrationService:
         # Verifica que a empresa não foi criada ou foi revertida
         assert not Company.objects.filter(name__icontains=email).exists()
 
-    def test_register_new_owner_with_company_name(self):
+    def test_register_new_owner_with_company_name(self) -> None:
         """Garante que o nome da empresa é usado quando fornecido."""
         email = "agencia@exemplo.com"
         password = "SecurePassword123!"

--- a/backend/apps/weddings/admin.py
+++ b/backend/apps/weddings/admin.py
@@ -4,7 +4,7 @@ from .models import Wedding
 
 
 @admin.register(Wedding)
-class WeddingAdmin(admin.ModelAdmin):
+class WeddingAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
     list_display = [
         "id",
         "groom_name",

--- a/backend/apps/weddings/api/dashboard.py
+++ b/backend/apps/weddings/api/dashboard.py
@@ -15,7 +15,7 @@ dashboard_router = Router(tags=["Dashboard"])
     response={200: DashboardSummaryOut, **READ_ERROR_RESPONSES},
     operation_id="dashboard_summary",
 )
-def dashboard_summary(request: AuthRequest) -> dict:
+def dashboard_summary(request: AuthRequest) -> dict[str, object]:
     """Aggregated dashboard KPIs for the authenticated company.
 
     Returns a ``DashboardSummaryOut`` with pending installments, urgent tasks,
@@ -30,7 +30,7 @@ def dashboard_summary(request: AuthRequest) -> dict:
     response={200: WeddingDashboardOut, **READ_ERROR_RESPONSES},
     operation_id="dashboard_wedding",
 )
-def wedding_dashboard(request: AuthRequest, uuid: UUID4) -> dict:
+def wedding_dashboard(request: AuthRequest, uuid: UUID4) -> dict[str, object]:
     """Per-wedding dashboard view.
 
     Returns a ``WeddingDashboardOut`` with days until the event, budget usage,

--- a/backend/apps/weddings/api/weddings.py
+++ b/backend/apps/weddings/api/weddings.py
@@ -48,7 +48,7 @@ def list_weddings(
 def list_weddings_by_month(
     request: AuthRequest,
     year: int,
-) -> Sequence[dict]:
+) -> Sequence[dict[str, int]]:
     """Retorna a quantidade de casamentos por mês no ano informado."""
     user = request.user
     return WeddingService.count_by_month(company=user.company, year=year)

--- a/backend/apps/weddings/services/summaries/financial.py
+++ b/backend/apps/weddings/services/summaries/financial.py
@@ -1,7 +1,8 @@
 import logging
 from datetime import date, timedelta
 from decimal import Decimal
-from typing import Any, cast
+from typing import TypedDict
+from uuid import UUID
 
 from django.db.models import Q, Sum
 from django.utils import timezone
@@ -12,6 +13,21 @@ from apps.weddings.models import Wedding
 
 
 logger = logging.getLogger(__name__)
+
+
+class _UpcomingInstallment(TypedDict):
+    uuid: UUID
+    installment_number: int
+    amount: str
+    due_date: date
+    status: str
+
+
+class _CategorySummary(TypedDict):
+    name: str
+    allocated: str
+    spent: str
+    percentage: int
 
 
 class FinancialSummaryService:
@@ -88,10 +104,8 @@ class FinancialSummaryService:
             Percentual utilizado (float) arredondado para uma casa decimal.
         """
         try:
-            from apps.finances.managers import BudgetQuerySet
-
             budget = (
-                cast(BudgetQuerySet, Budget.objects.for_tenant(company))
+                Budget.objects.for_tenant(company)
                 .with_total_spent()
                 .get(wedding=wedding)
             )
@@ -107,7 +121,7 @@ class FinancialSummaryService:
     @staticmethod
     def upcoming_installments(
         *, company: Company, wedding: Wedding, today: date | None = None
-    ) -> list[dict[str, Any]]:
+    ) -> list[_UpcomingInstallment]:
         """
         Retorna até 5 parcelas a vencer nos próximos 30 dias de um casamento.
 
@@ -150,7 +164,7 @@ class FinancialSummaryService:
     @staticmethod
     def categories_summary(
         *, company: Company, wedding: Wedding
-    ) -> list[dict[str, Any]]:
+    ) -> list[_CategorySummary]:
         """
         Gera um resumo de categorias de orçamento com alocação e gastos.
 
@@ -166,9 +180,9 @@ class FinancialSummaryService:
             BudgetCategory.objects.for_tenant(company)
             .filter(wedding=wedding)
             .select_related("budget")
-            .with_total_spent()  # type: ignore[attr-defined]
+            .with_total_spent()
         )
-        result = []
+        result: list[_CategorySummary] = []
         for cat in categories:
             spent = cat.total_spent
             alloc = cat.allocated_budget

--- a/backend/apps/weddings/services/wedding_service.py
+++ b/backend/apps/weddings/services/wedding_service.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from datetime import datetime, time, timedelta
 from decimal import Decimal
-from typing import cast
+from typing import Protocol, cast
 from uuid import UUID
 
 from django.core.exceptions import ValidationError as DjangoValidationError
@@ -37,6 +37,14 @@ from ..schemas import (
 
 
 logger = logging.getLogger(__name__)
+
+
+class _BudgetCategorySummary(Protocol):
+    """Linha de categoria anotada por ``BudgetCategoryQuerySet.with_total_spent()``."""
+
+    name: str
+    allocated_budget: Decimal
+    _total_spent: Decimal
 
 
 class WeddingService:
@@ -146,7 +154,7 @@ class WeddingService:
         )
 
     @staticmethod
-    def count_by_month(company: Company, year: int) -> Sequence[dict]:
+    def count_by_month(company: Company, year: int) -> Sequence[dict[str, int]]:
         """
         Agrupa e conta os casamentos por mês para um determinado ano.
 
@@ -345,6 +353,34 @@ class WeddingService:
             ) from e
 
     @staticmethod
+    def _list_categories_with_total_spent(
+        company: Company, budget: Budget | None
+    ) -> Iterable[_BudgetCategorySummary]:
+        """Categorias do orçamento com ``_total_spent`` anotado
+        (invisível ao django-stubs).
+
+        Args:
+            company: O tenant atual para isolamento de dados.
+            budget: Orçamento do casamento; ``None`` retorna iterável vazio.
+
+        Returns:
+            Iterável das categorias com os campos anotados pelo queryset.
+        """
+        from apps.finances.models import BudgetCategory
+
+        if not budget:
+            return cast(
+                Iterable[_BudgetCategorySummary],
+                BudgetCategory.objects.none(),
+            )
+        return cast(
+            Iterable[_BudgetCategorySummary],
+            BudgetCategory.objects.for_tenant(company)
+            .with_total_spent()
+            .filter(budget=budget),
+        )
+
+    @staticmethod
     def overview(company: Company, uuid: UUID | str) -> WeddingOverviewOut:
         """
         Retorna visão geral do casamento com métricas agregadas.
@@ -375,13 +411,12 @@ class WeddingService:
         today = date_type.today()
         days_until = max(0, (wedding.date - today).days) if wedding.date else 0
 
-        from apps.finances.managers import BudgetCategoryQuerySet, BudgetQuerySet
-        from apps.finances.models import Budget, BudgetCategory, Installment
+        from apps.finances.models import Budget, Installment
         from apps.logistics.models import Contract
         from apps.scheduler.models import Task
 
         budget = (
-            cast(BudgetQuerySet, Budget.objects.for_tenant(company))
+            Budget.objects.for_tenant(company)
             .with_total_spent()
             .filter(wedding=wedding)
             .first()
@@ -394,12 +429,8 @@ class WeddingService:
             else 0.0
         )
 
-        categories_list = (
-            cast(BudgetCategoryQuerySet, BudgetCategory.objects.for_tenant(company))
-            .with_total_spent()
-            .filter(budget=budget)
-            if budget
-            else []
+        categories_list = WeddingService._list_categories_with_total_spent(
+            company, budget
         )
         categories_summary = [
             WeddingDashboardCategoryOut(

--- a/backend/apps/weddings/tests/test_models.py
+++ b/backend/apps/weddings/tests/test_models.py
@@ -1,4 +1,5 @@
 from datetime import date, timedelta
+from typing import Any, cast
 
 import pytest
 from django.core.exceptions import ValidationError
@@ -14,7 +15,7 @@ class TestWeddingModelMetadata:
     Testes de representação e metadados do modelo Wedding.
     """
 
-    def test_wedding_str_representation(self):
+    def test_wedding_str_representation(self) -> None:
         """
         RF: O método __str__ deve retornar 'Groom & Bride'.
         """
@@ -24,7 +25,7 @@ class TestWeddingModelMetadata:
         # 2. Asserção do método mágico __str__
         assert str(wedding) == "Diogo & Laura"
 
-    def test_wedding_ordering_by_date_descending(self, user):
+    def test_wedding_ordering_by_date_descending(self, user: Any) -> None:
         """
         RF: A ordenação padrão deve ser pela data mais futura primeiro (-date).
         """
@@ -45,7 +46,11 @@ class TestWeddingModelMetadata:
         queryset = list(Wedding.objects.all())
 
         # 3. Asserção da ordem lógica
-        assert queryset == [w_future, w_mid, w_soon]
+        assert queryset == [
+            cast(Wedding, w_future),
+            cast(Wedding, w_mid),
+            cast(Wedding, w_soon),
+        ]
 
         # Verificação matemática da ordem: date_i >= date_{i+1}
         for i in range(len(queryset) - 1):
@@ -59,7 +64,7 @@ class TestWeddingDateValidator:
     Usamos .build() + .full_clean() para isolar o validador do banco de dados.
     """
 
-    def test_wedding_date_future_passes(self, user):
+    def test_wedding_date_future_passes(self, user: Any) -> None:
         """Garante que data no futuro passa."""
         future_date = timezone.now().date() + timedelta(days=30)
         wedding = Wedding(
@@ -71,13 +76,13 @@ class TestWeddingDateValidator:
         )
         wedding.full_clean()  # Se não levantar erro, passou!
 
-    def test_wedding_date_today_passes(self, user):
+    def test_wedding_date_today_passes(self, user: Any) -> None:
         """Garante que data de hoje passa."""
         today = timezone.now().date()
         wedding = WeddingFactory.build(company=user.company, date=today)
         wedding.full_clean()
 
-    def test_wedding_date_past_fails(self, user):
+    def test_wedding_date_past_fails(self, user: Any) -> None:
         """
         Garante que datas passadas disparam ValidationError.
         Este é o teste que estava falhando.
@@ -101,7 +106,7 @@ class TestWeddingBusinessRules:
     Focamos apenas na lógica do status vs data.
     """
 
-    def test_status_completed_valid_past_date(self, user):
+    def test_status_completed_valid_past_date(self, user: Any) -> None:
         """
         Garante que um casamento que já aconteceu pode ser marcado como CONCLUÍDO.
         """
@@ -117,7 +122,7 @@ class TestWeddingBusinessRules:
         # Não deve lançar erro
         wedding.clean()
 
-    def test_status_completed_invalid_future_date(self, user):
+    def test_status_completed_invalid_future_date(self, user: Any) -> None:
         """
         Garante que NÃO se pode concluir um casamento que ainda não aconteceu (Precoce).
         """
@@ -139,7 +144,7 @@ class TestWeddingBusinessRules:
             excinfo.value
         )
 
-    def test_other_statuses_work_with_future_dates(self, user):
+    def test_other_statuses_work_with_future_dates(self, user: Any) -> None:
         """
         Garante que as travas do status COMPLETED não afetam outros status.
         """
@@ -168,21 +173,21 @@ class TestWeddingTemplateField:
     Testes de validação para o campo 'template' do modelo Wedding.
     """
 
-    def test_template_null_passes(self, user):
+    def test_template_null_passes(self, user: Any) -> None:
         """
         Garante que o campo template pode ser nulo.
         """
         wedding = WeddingFactory.build(company=user.company, template=None)
         wedding.full_clean()
 
-    def test_template_blank_passes(self, user):
+    def test_template_blank_passes(self, user: Any) -> None:
         """
         Garante que o campo template pode ser em branco (vazio).
         """
         wedding = WeddingFactory.build(company=user.company, template="")
         wedding.full_clean()
 
-    def test_template_max_length_exceeded_fails(self, user):
+    def test_template_max_length_exceeded_fails(self, user: Any) -> None:
         """
         Garante que o campo template falha na validação se exceder 50 caracteres.
         """

--- a/backend/config/api.py
+++ b/backend/config/api.py
@@ -135,7 +135,7 @@ def general_exception_handler(request: HttpRequest, exc: Exception) -> HttpRespo
 
 
 @api.get("/health", auth=None, operation_id="core_health_check")
-def health_check(request: HttpRequest):
+def health_check(request: HttpRequest):  # type: ignore[no-untyped-def]
     """
     Verifica a saúde do serviço e a conectividade com o banco de dados.
     Pode ser pingado por serviços externos de monitoramento.

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -2,12 +2,16 @@
 Configuração Global de Testes (Pytest).
 """
 
+from typing import Any, cast
+
 import factory
 import pytest
+from django.http import HttpResponseBase
 from django.test import Client
 from ninja_jwt.tokens import RefreshToken
 from pytest_factoryboy import register
 
+from apps.users.models import User
 from apps.users.tests.factories import AdminFactory, UserFactory
 
 
@@ -16,28 +20,30 @@ register(UserFactory)
 register(AdminFactory)
 
 # 2. Configuração do Faker para dados brasileiros reais
-factory.Faker._DEFAULT_LOCALE = "pt_BR"
+factory.Faker._DEFAULT_LOCALE = "pt_BR"  # type: ignore[attr-defined]
 
 
 class JWTClient(Client):
     """Django test client that injects a Bearer JWT on every request."""
 
-    def __init__(self, user=None, **kwargs):
+    user: User | None
+
+    def __init__(self, user: User | None = None, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self._jwt_headers = {}
         if user is not None:
-            refresh = RefreshToken.for_user(user)
+            refresh = RefreshToken.for_user(user)  # type: ignore[misc]
             self._jwt_headers = {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}
 
-    def generic(
+    def generic(  # type: ignore[override]
         self,
-        method,
-        path,
-        data="",
-        content_type="application/octet-stream",
-        secure=False,
-        **extra,
-    ):
+        method: str,
+        path: str,
+        data: Any = "",
+        content_type: str = "application/octet-stream",
+        secure: bool = False,
+        **extra: Any,
+    ) -> HttpResponseBase:
         extra = {**self._jwt_headers, **extra}
         return super().generic(
             method, path, data=data, content_type=content_type, secure=secure, **extra
@@ -45,13 +51,13 @@ class JWTClient(Client):
 
 
 @pytest.fixture
-def user(user_factory):
+def user(user_factory: Any) -> User:
     """Cria e retorna um usuário ativo (Planner) para uso nos testes."""
-    return user_factory.create(is_active=True)
+    return cast(User, user_factory.create(is_active=True))
 
 
 @pytest.fixture
-def auth_client(user):
+def auth_client(user: User) -> JWTClient:
     """
     Django test Client pré-configurado com JWT Bearer do usuário `user`.
     """

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -5,7 +5,7 @@ import os
 import sys
 
 
-def main():
+def main() -> None:
     """Run administrative tasks."""
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.development")
     try:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -218,9 +218,10 @@ module = [
     "apps.logistics.tests.contracts.test_services",
     "apps.logistics.tests.test_apis",
 ]
-# Exige assinatura completa e checagem de corpo. disallow_untyped_calls permanece false
-# herdado de apps.*.tests.* para suportar métodos dinâmicos de factories (factory_boy).
+# Exige assinatura completa e checagem de corpo. disallow_untyped_calls é explicitamente false
+# para suportar métodos dinâmicos de factories (factory_boy).
 disallow_untyped_defs = true
+disallow_untyped_calls = false
 check_untyped_defs = true
 
 # 3. Management commands e scripts utilitários CLI

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -206,8 +206,6 @@ module = [
     "apps.core.tests.test_commands",
     "apps.core.tests.test_concurrency_locks",
     "apps.core.tests.test_api_performance",
-    "apps.core.tests.test_api_architecture",
-    "apps.core.tests.test_cron_api",
     "apps.scheduler.tests.test_apis",
     "apps.finances.tests.test_apis",
     "apps.users.tests.test_email_verification_api",
@@ -219,7 +217,9 @@ module = [
     "apps.logistics.tests.contracts.test_performance",
     "apps.logistics.tests.contracts.test_services",
     "apps.logistics.tests.test_apis",
-  ]
+]
+# Exige assinatura completa e checagem de corpo. disallow_untyped_calls permanece false
+# herdado de apps.*.tests.* para suportar métodos dinâmicos de factories (factory_boy).
 disallow_untyped_defs = true
 check_untyped_defs = true
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -115,9 +115,14 @@ line-ending = "lf"
 plugins = ["mypy_django_plugin.main"]
 python_version = "3.12"
 exclude = ["migrations"]
+strict = true
 warn_unused_ignores = true
 warn_redundant_casts = true
 
+[tool.django-stubs]
+django_settings_module = "config.settings.development"
+
+# 1. Módulos terceiros sem stubs/tipagem
 [[tool.mypy.overrides]]
 module = [
     "environ",
@@ -127,41 +132,106 @@ module = [
 ]
 ignore_missing_imports = true
 
-
-[tool.django-stubs]
-django_settings_module = "config.settings.development"
-
+# 2. Testes ainda não migrados e pontos de integração dinâmicos
+# A verificação dos corpos é ativada por camadas no override específico abaixo.
 [[tool.mypy.overrides]]
 module = [
     "apps.*.admin",
-    "apps.*.tests.factories",
+    "apps.*.tests.*",
 ]
-ignore_errors = true
+disallow_untyped_defs = false
+disallow_untyped_calls = false
+check_untyped_defs = false
 
 [[tool.mypy.overrides]]
 module = [
-    "apps.weddings.services",
-    "apps.scheduler.services",
-    "apps.finances.services.*",
-    "apps.logistics.services.*",
-    "apps.users.api",
-    "apps.weddings.api",
-    "apps.scheduler.api",
-    "apps.logistics.api",
-    "apps.finances.api",
-    "apps.weddings.deps",
-    "apps.core.exceptions",
-    "apps.core.mixins",
-    "apps.core.models",
-    "apps.users.models",
-    "apps.weddings.models",
-    "apps.scheduler.models",
-    "apps.finances.models.*",
-    "apps.logistics.models.*",
+    "apps.*.tests.factories",
+    "apps.*.tests.factories.*",
 ]
+ignore_errors = true
+
+# Primeira camada migrada: testes unitários sem dependências dinâmicas.
+[[tool.mypy.overrides]]
+module = [
+    "apps.core.tests.test_validators",
+    "apps.core.tests.test_health",
+    "apps.core.tests.test_exceptions",
+    "apps.core.tests.test_oidc_verifier",
+    "apps.core.tests.test_shortcuts",
+    "apps.core.tests.test_transactions",
+    "apps.core.tests.test_write_performance",
+    "apps.core.tests.test_cascade_delete_safety",
+    "apps.tenants.tests.test_services",
+    "apps.tenants.tests.test_managers",
+    "apps.finances.tests.test_managers",
+    "apps.core.tests.test_storage_service",
+    "apps.core.tests.test_cache_fallback",
+    "apps.core.tests.test_api_architecture",
+    "apps.core.tests.test_cron_api",
+    "apps.core.tests.test_error_envelope_consistency",
+    "apps.core.tests.test_schema_integrity",
+    "apps.core.tests.test_security_audit",
+    "apps.core.tests.test_sensitive_data_leak",
+    "apps.scheduler.tests.appointments.test_templates",
+    "apps.users.tests.test_email_verification_service",
+    "apps.users.tests.test_password_security",
+    "apps.users.tests.test_password_reset_service",
+    "apps.finances.tests.budgets.test_services",
+    "apps.finances.tests.categories.test_services",
+    "apps.tenants.tests.test_models",
+    "apps.scheduler.tests.tasks.test_models",
+    "apps.scheduler.tests.appointments.test_models",
+    "apps.scheduler.tests.appointments.test_services",
+    "apps.scheduler.tests.tasks.test_services",
+    "apps.notifications.tests.test_services",
+    "apps.users.tests.test_services",
+    "apps.logistics.tests.suppliers.test_services",
+    "apps.users.tests.test_models",
+    "apps.logistics.tests.items.test_services",
+    "apps.finances.tests.expenses.test_services",
+    "apps.finances.tests.expenses.test_models",
+    "apps.finances.tests.categories.test_models",
+    "apps.finances.tests.installments.test_models",
+    "apps.finances.tests.installments.test_services",
+    "apps.finances.tests.budgets.test_models",
+    "apps.logistics.tests.contracts.test_models",
+    "apps.logistics.tests.suppliers.test_models",
+    "apps.logistics.tests.items.test_models",
+    "apps.weddings.tests.test_models",
+    "apps.core.tests.test_base_model",
+    "apps.core.tests.test_middleware",
+    "apps.core.tests.test_mixins",
+    "apps.notifications.tests.test_tasks",
+    "apps.notifications.tests.test_api",
+    "apps.core.tests.test_commands",
+    "apps.core.tests.test_concurrency_locks",
+    "apps.core.tests.test_api_performance",
+    "apps.core.tests.test_api_architecture",
+    "apps.core.tests.test_cron_api",
+    "apps.scheduler.tests.test_apis",
+    "apps.finances.tests.test_apis",
+    "apps.users.tests.test_email_verification_api",
+    "apps.users.tests.test_password_reset_api",
+    "apps.users.tests.test_register_api_security",
+    "apps.users.tests.test_auth_throttling",
+    "apps.users.tests.test_apis",
+    "apps.users.tests.test_auth_api",
+    "apps.logistics.tests.contracts.test_performance",
+    "apps.logistics.tests.contracts.test_services",
+    "apps.logistics.tests.test_apis",
+  ]
 disallow_untyped_defs = true
 check_untyped_defs = true
 
+# 3. Management commands e scripts utilitários CLI
+# Permite rodar sem obrigar anotação estrita no handle(*args, **options)
+[[tool.mypy.overrides]]
+module = [
+    "apps.*.management.*",
+    "manage",
+]
+disallow_untyped_defs = false
+check_untyped_defs = true
 
 # ==============================================================================
 # TESTING: PYTEST CONFIGURATION

--- a/docs/3-reference/testing/backend-testing-spec.md
+++ b/docs/3-reference/testing/backend-testing-spec.md
@@ -64,6 +64,10 @@ Todo teste de API ou serviço deve assegurar que requisições acessando recurso
 ### 2.4 Parâmetro `company` Obrigatório
 Funções públicas de serviço devem declarar `company` (ou `company: Company | None = None` para rotas de cron/sistema), auditado automaticamente por `test_security_audit.py`.
 
+### 2.5 Tipagem Estática em Testes (`mypy`)
+- Toda função e método de teste deve declarar anotação explícita de retorno `-> None` e tipagem em parâmetros e fixtures.
+- O projeto mantém `disallow_untyped_calls = false` na suíte de testes devido à natureza dinâmica das factories do `factory_boy`, garantindo checagem estrita de definições (`disallow_untyped_defs = true`) e de corpo (`check_untyped_defs = true`) sem exigir anotações artificiais nas instanciações de factories.
+
 ---
 
 ## 3. Estrutura de Arquivos e Nomenclatura

--- a/docs/3-reference/testing/backend-testing-spec.md
+++ b/docs/3-reference/testing/backend-testing-spec.md
@@ -66,7 +66,7 @@ Funções públicas de serviço devem declarar `company` (ou `company: Company |
 
 ### 2.5 Tipagem Estática em Testes (`mypy`)
 - Toda função e método de teste deve declarar anotação explícita de retorno `-> None` e tipagem em parâmetros e fixtures.
-- O projeto mantém `disallow_untyped_calls = false` na suíte de testes devido à natureza dinâmica das factories do `factory_boy`, garantindo checagem estrita de definições (`disallow_untyped_defs = true`) e de corpo (`check_untyped_defs = true`) sem exigir anotações artificiais nas instanciações de factories.
+- O projeto configura explicitamente `disallow_untyped_calls = false` nos overrides da suíte de testes devido à natureza dinâmica das factories do `factory_boy`, garantindo checagem estrita de definições (`disallow_untyped_defs = true`) e de corpo (`check_untyped_defs = true`) sem exigir anotações artificiais nas instanciações de factories.
 
 ---
 


### PR DESCRIPTION
## Summary

- enforce strict mypy typing across the backend
- replace unsafe inferred types with explicit annotations and narrowings
- align tests, services, schemas, and integrations with stricter type checks

## Validation

- `uv run --no-cache mypy .`
- `uv run --no-cache ruff check .`
- `uv run --no-cache ruff format --check .`
- `uv run --no-cache pytest -q` — 914 passed

The branch is based on the already-merged `develop` state and excludes the previously merged authentication feature.